### PR TITLE
Distribute ca_cert.pem with setup.py

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -281,10 +281,12 @@ def _get_encryptor_ami(region):
         raise Exception('No API URL found')
     # This suppresses warnings about no `subjectAltName` for cert.
     # TODO: remove when the cert has subjectAltName
+    cert = os.path.join(os.path.dirname(__file__), '../ca_cert.pem')
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         r = requests.get("%s/api/v1/encryptor_ami/%s" %
-                         (api_url, region), verify="ca_cert.pem")
+                         (api_url, region),
+                         verify=cert)
     if r.status_code not in (200, 201):
         raise Exception('Getting encryptor ami gave response: %s', r.text)
     ami = r.json()['ami_id']

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
             'brkt = brkt_cli:main',
         ]
     },
+    data_files=[('', ['ca_cert.pem',]),],
     test_suite='test'
 )


### PR DESCRIPTION
Added ca_cert file to be distributed with python package and
read file from the relative package location.

Testing done:

- Tested encryption from root of repo
- Tested in virtualenv with python setup.py install and ran
script