### PR TITLE
Truncate AMI description to 255 characters

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -95,10 +95,9 @@ TAG_ENCRYPTOR_AMI = 'BrktEncryptorAMI'
 TAG_DESCRIPTION = 'Description'
 
 NAME_ENCRYPTED_IMAGE = '%(original_image_name)s %(encrypted_suffix)s'
-NAME_ENCRYPTED_IMAGE_SUFFIX = '(encrypted %(nonce)s)'
-DESCRIPTION_ENCRYPTED_IMAGE = (
-    '%(original_image_description)s - based on %(image_id)s, '
-    'encrypted by Bracket Computing'
+NAME_ENCRYPTED_IMAGE_SUFFIX = ' (encrypted %(nonce)s)'
+SUFFIX_ENCRYPTED_IMAGE = (
+    ' - based on %(image_id)s, encrypted by Bracket Computing'
 )
 DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE = \
     'Based on %(image_id)s, encrypted by Bracket Computing'
@@ -252,14 +251,21 @@ def _get_encrypted_suffix():
     The suffix is in the format "(encrypted 787ace7a)".  The nonce portion of
     the suffix is necessary because Amazon requires image names to be unique.
     """
-    nonce = make_nonce()
-    return NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': nonce}
+    return NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': make_nonce()}
 
 
-def _get_encrypted_image_name(original_name, suffix=None):
-    suffix = ' ' + (suffix or _get_encrypted_suffix())
-    max_length = 128 - len(suffix)
-    return original_name[:max_length] + suffix
+def _append_suffix(name, suffix, max_length=None):
+    """ Append the suffix to the given name.  If the appended length exceeds
+    max_length, truncate the name to make room for the suffix.
+
+    :return: The possibly truncated name with the suffix appended
+    """
+    if not suffix:
+        return name
+    if max_length:
+        original_length = max_length - len(suffix)
+        name = name[:original_length]
+    return name + suffix
 
 
 def _get_encryptor_ami(region):
@@ -580,12 +586,12 @@ def run(aws_svc, enc_svc_cls, image_id, encryptor_ami):
             raise Exception("Can't find image %s" % encryptor_ami)
 
         # Register the new AMI.
-        name = _get_encrypted_image_name(image.name)
+        name = _append_suffix(
+            image.name, _get_encrypted_suffix(), 128)
         if image.description:
-            description = DESCRIPTION_ENCRYPTED_IMAGE % {
-                'original_image_description': image.description,
-                'image_id': image_id
-            }
+            suffix = SUFFIX_ENCRYPTED_IMAGE % {'image_id': image_id}
+            description = _append_suffix(
+                image.description, suffix, max_length=255)
         else:
             description = DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE % {
                 'image_id': image_id

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -263,8 +263,8 @@ def _append_suffix(name, suffix, max_length=None):
     if not suffix:
         return name
     if max_length:
-        original_length = max_length - len(suffix)
-        name = name[:original_length]
+        truncated_length = max_length - len(suffix)
+        name = name[:truncated_length]
     return name + suffix
 
 
@@ -587,7 +587,7 @@ def run(aws_svc, enc_svc_cls, image_id, encryptor_ami):
 
         # Register the new AMI.
         name = _append_suffix(
-            image.name, _get_encrypted_suffix(), 128)
+            image.name, _get_encrypted_suffix(), max_length=128)
         if image.description:
             suffix = SUFFIX_ENCRYPTED_IMAGE % {'image_id': image_id}
             description = _append_suffix(

--- a/test.py
+++ b/test.py
@@ -238,27 +238,24 @@ class TestSnapshotProgress(unittest.TestCase):
 class TestEncryptedImageName(unittest.TestCase):
 
     def test_encrypted_image_suffix(self):
+        """ Test that generated suffixes are unique.
+        """
         s1 = brkt_cli._get_encrypted_suffix()
-        regexp = r'\(encrypted .+\)'
-        m = re.match(regexp, s1)
-        self.assertIsNotNone(m)
-
         s2 = brkt_cli._get_encrypted_suffix()
-        m = re.match(regexp, s2)
-        self.assertIsNotNone(m)
         self.assertNotEqual(s1, s2)
 
-    def test_encrypted_image_name(self):
+    def test_append_suffix(self):
+        """ Test that we append the suffix and truncate the original name.
+        """
         name = 'Boogie nights are always the best in town'
-        suffix = brkt_cli._get_encrypted_suffix()
-        encrypted_name = brkt_cli._get_encrypted_image_name(
-            name, suffix=suffix)
+        suffix = ' (except Tuesday)'
+        encrypted_name = brkt_cli._append_suffix(name, suffix, max_length=128)
         self.assertTrue(encrypted_name.startswith(name))
         self.assertTrue(encrypted_name.endswith(suffix))
 
         # Make sure we truncate the original name when it's too long.
         name += ('X' * 100)
-        encrypted_name = brkt_cli._get_encrypted_image_name(name)
+        encrypted_name = brkt_cli._append_suffix(name, suffix, max_length=128)
         self.assertEqual(128, len(encrypted_name))
         self.assertTrue(encrypted_name.startswith('Boogie nights'))
 


### PR DESCRIPTION
Truncate the AMI description, so that it doesn't exceed 255 characters.
Convert _get_encrypted_image_name() to a new _append_suffix() function
that's called when generating both the AMI name and suffix.

Remove brittle tests that make assumptions about the format of the AMI
name suffix.

Change-Id: I64b63236bc6f6cd30c8ceac8000386bbf78e0039