### PR TITLE
Image encryptor fails without sufficient details

### DIFF
--- a/brkt_cli/service.py
+++ b/brkt_cli/service.py
@@ -120,6 +120,10 @@ class BaseAWSService(object):
     def get_key_pair(self, keyname):
         pass
 
+    @abc.abstractmethod
+    def get_console_output(self, instance_id):
+        pass
+
 
 class AWSService(BaseAWSService):
 
@@ -282,6 +286,9 @@ class AWSService(BaseAWSService):
 
     def get_key_pair(self, keyname):
         return self.conn.get_all_key_pairs(keynames=[keyname])[0]
+
+    def get_console_output(self, instance_id):
+        return self.conn.get_console_output(instance_id)
 
 
 class BaseEncryptorService(object):

--- a/iam.json
+++ b/iam.json
@@ -19,6 +19,7 @@
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSnapshots",
                 "ec2:DescribeVolumes",
+                "ec2:GetConsoleOutput",
                 "ec2:RegisterImage",
                 "ec2:RunInstances",
                 "ec2:StopInstances",

--- a/test.py
+++ b/test.py
@@ -15,14 +15,13 @@ from boto.ec2.keypair import KeyPair
 from boto.ec2.securitygroup import SecurityGroup
 import brkt_cli
 import logging
-import re
 import time
 import unittest
 import uuid
 
 from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from boto.ec2.image import Image
-from boto.ec2.instance import Instance
+from boto.ec2.instance import Instance, ConsoleOutput
 from boto.ec2.snapshot import Snapshot
 from boto.ec2.volume import Volume
 from brkt_cli import service, util
@@ -210,6 +209,11 @@ class DummyAWSService(service.BaseAWSService):
         kp = KeyPair()
         kp.name = keyname
         return kp
+
+    def get_console_output(self, instance_id):
+        console_output = ConsoleOutput()
+        console_output.output = 'Starting up.\nAll systems go!\n'
+        return console_output
 
 
 class TestSnapshotProgress(unittest.TestCase):


### PR DESCRIPTION
When image encryption fails, point the user to the instance console log.
Write the console log to a temporary file, if possible.

Change-Id: I0a573506e96cc323f4d67cf14bc7246776f5d418