### PR TITLE
Console output needs to be more specific about console log being avai…

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -575,7 +575,10 @@ def run(aws_svc, enc_svc_cls, image_id, encryptor_ami):
                 )
             else:
                 log.error(
-                    'Console output for instance %s is not available.',
+                    'Encryptor console output is not currently available.  '
+                    'Wait a minute and check the console output for '
+                    'instance %s in the EC2 Management '
+                    'Console.',
                     encryptor_instance.id
                 )
             raise e


### PR DESCRIPTION
…lable later

New log message when the AWS API does not return a console log for the
encryptor instance:

"Encryptor console output is not currently available.  Wait a minute and
check the console output for instance i-ebe542 in the EC2 Management
Console."

Add a unit test that verifies that we handle the case when console
output is not available.

Change-Id: Id3b679550a1683816a658292f4c5cf5773123c4b