### PR TITLE
Make EncryptionError a subclass of BracketError

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -201,7 +201,7 @@ def _get_encryption_progress_message(start_time, percent_complete, now=None):
     return msg
 
 
-class EncryptionError(Exception):
+class EncryptionError(BracketError):
     def __init__(self, message):
         super(EncryptionError, self).__init__(message)
         self.console_output_file = None


### PR DESCRIPTION
Make EncryptionError a subclass of BracketError, so that we don't log a
traceback unless the user specifies -v.

Change-Id: I0bc4b35b7520a19d2b8bf0d22c425f317fec79ca