### PR TITLE
Don't log a traceback on keyboard interrupt

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -923,6 +923,11 @@ def main():
             log.exception(e.message)
         else:
             log.error(e.message)
+    except KeyboardInterrupt:
+        if values.verbose:
+            log.exception('Interrupted by user')
+        else:
+            log.error('Interrupted by user')
     return 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
Catch KeyboardInterrupt.  Only log the traceback if -v was specified.

Change-Id: Ice68d0054b83381496bddf8557c5e837e1d896e3