### PR TITLE
Allow specifying the encrypted AMI name as a command option

### DIFF
--- a/test.py
+++ b/test.py
@@ -384,6 +384,23 @@ class TestRun(unittest.TestCase):
         # Verify that the volume was deleted.
         self.assertIsNone(aws_svc.get_volume(volume.id))
 
+    def test_encrypted_ami_name(self):
+        """ Test that the name is set on the encrypted AMI when specified.
+        """
+        aws_svc, encryptor_image, guest_image = _build_aws_service()
+        brkt_cli.SLEEP_ENABLED = False
+
+        name = 'Am I an AMI?'
+        image_id = brkt_cli.run(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id,
+            encrypted_ami_name=name
+        )
+        ami = aws_svc.get_image(image_id)
+        self.assertEqual(name, ami.name)
+
 
 class ExpiredDeadline(object):
     def is_expired(self):


### PR DESCRIPTION
Add an --encrypted-ami-name option.  When the name is specified, pass it
through to the register_image() call.  Break out the maximum name length
into a constant.

Change-Id: I3cf20075137552ecdeb3edc12ab5d599386e7795