### PR TITLE
Validate AMI name

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -845,14 +845,12 @@ def main():
     log.setLevel(log_level)
     service.log.setLevel(log_level)
 
-    if (values.encrypted_ami_name and
-            len(values.encrypted_ami_name) > AMI_NAME_MAX_LENGTH):
-        print(
-            'The encrypted AMI name cannot be longer than '
-            '%d characters' % AMI_NAME_MAX_LENGTH,
-            file=sys.stderr
-        )
-        return 1
+    if values.encrypted_ami_name:
+        try:
+            service.validate_image_name(values.encrypted_ami_name)
+        except service.ImageNameError as e:
+            print(e.message, file=sys.stderr)
+            return 1
 
     # Validate the region.
     regions = [str(r.name) for r in boto.vpc.regions()]

--- a/brkt_cli/service.py
+++ b/brkt_cli/service.py
@@ -394,3 +394,26 @@ class EncryptorService(BaseEncryptorService):
             ratio = float(info['bytes_written']) / info['bytes_total']
             info['percent_complete'] = int(100 * ratio)
         return info
+
+
+class ImageNameError(Exception):
+    pass
+
+
+def validate_image_name(name):
+    """ Verify that the name is a valid EC2 image name.  Return the name
+        if it's valid.
+
+    :raises ImageNameError
+    """
+    if not (name and 3 <= len(name) <= 128):
+        raise ImageNameError(
+            'Image name must be between 3 and 128 characters long')
+
+    m = re.match(r'[A-Za-z0-9()\[\] ./\-\'@_]+$', name)
+    if not m:
+        raise ImageNameError(
+            "Image name may only contain letters, numbers, spaces, "
+            "and the following characters: ()[]./-'@_"
+        )
+    return name

--- a/test.py
+++ b/test.py
@@ -277,6 +277,19 @@ class TestEncryptedImageName(unittest.TestCase):
         self.assertEqual(128, len(encrypted_name))
         self.assertTrue(encrypted_name.startswith('Boogie nights'))
 
+    def test_name_validation(self):
+        name = 'Test123 ()[]./-\'@_'
+        self.assertEquals(name, service.validate_image_name(name))
+        with self.assertRaises(service.ImageNameError):
+            service.validate_image_name(None)
+        with self.assertRaises(service.ImageNameError):
+            service.validate_image_name('ab')
+        with self.assertRaises(service.ImageNameError):
+            service.validate_image_name('a' * 129)
+        for c in '?!#$%^&*~`{}\|"<>':
+            with self.assertRaises(service.ImageNameError):
+                service.validate_image_name('test' + c)
+
 
 def _build_aws_service():
     aws_svc = DummyAWSService()


### PR DESCRIPTION
When --encrypted-ami-name is specified, verify that the name follows the
EC2 image naming rules.

Change-Id: I10ab6d6c864411ae284ae7579dab5cc8a19f3b97