### PR TITLE
Vague error when encryptor does not come up

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -189,7 +189,8 @@ def _wait_for_encryptor_up(enc_svc, deadline):
             )
             return
         _sleep(5)
-    raise BracketError('Unable to contact %s' % enc_svc.hostname)
+    raise BracketError(
+        'Unable to contact encryptor instance at %s' % enc_svc.hostname)
 
 
 def _get_encryption_progress_message(start_time, percent_complete, now=None):


### PR DESCRIPTION
Tell the user that we couldn't contact the encryptor instance, instead
of just logging the IP address.

Change-Id: I9df055cb941392fcb0986d67835152b96829da44