### PR TITLE
Don't require key pair name

### DIFF
--- a/brkt_cli/service.py
+++ b/brkt_cli/service.py
@@ -189,9 +189,9 @@ class AWSService(BaseAWSService):
         self.region = None
         self.conn = None
 
-    def connect(self, key_name, region):
-        self.key_name = key_name
+    def connect(self, region, key_name=None):
         self.region = region
+        self.key_name = key_name
         self.conn = boto.vpc.connect_to_region(region)
 
     def run_instance(self,


### PR DESCRIPTION
Make --key a hidden option.  It's no longer required to launch the
encryptor node, and is only used for development.

Change-Id: I834c9c1d4a8be0547820acb4177514f9902faa30