### PR TITLE
Handle unsupported guest failure code

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -210,6 +210,10 @@ class EncryptionError(BracketError):
         self.console_output_file = None
 
 
+class UnsupportedGuestError(BracketError):
+    pass
+
+
 def _wait_for_encryption(enc_svc):
     err_count = 0
     max_errs = 10
@@ -242,6 +246,11 @@ def _wait_for_encryption(enc_svc):
             log.info('Encrypted root drive created.')
             return
         elif state == service.ENCRYPT_FAILED:
+            failure_code = status.get('failure_code')
+            log.debug('failure_code=%s', failure_code)
+            if failure_code == service.FAILURE_CODE_UNSUPPORTED_GUEST:
+                raise UnsupportedGuestError(
+                    'The specified AMI uses an unsupported operating system')
             raise EncryptionError('Encryption failed')
 
         _sleep(10)

--- a/brkt_cli/service.py
+++ b/brkt_cli/service.py
@@ -26,6 +26,7 @@ import time
 ENCRYPT_SUCCESSFUL = 'finished'
 ENCRYPT_FAILED = 'failed'
 ENCRYPTOR_STATUS_PORT = 8000
+FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
 
 PLATFORM_WINDOWS = 'windows'
 

--- a/test.py
+++ b/test.py
@@ -446,6 +446,24 @@ class TestEncryptionService(unittest.TestCase):
                 encrypt_ami.EncryptionError, 'Encryption failed'):
             encrypt_ami._wait_for_encryption(svc)
 
+    def test_unsupported_guest(self):
+        class UnsupportedGuestService(service.BaseEncryptorService):
+            def __init__(self):
+                super(UnsupportedGuestService, self).__init__('localhost', 80)
+
+            def is_encryptor_up(self):
+                return True
+
+            def get_status(self):
+                return {
+                    'state': service.ENCRYPT_FAILED,
+                    'failure_code': service.FAILURE_CODE_UNSUPPORTED_GUEST,
+                    'percent_complete': 0
+                }
+
+        with self.assertRaises(encrypt_ami.UnsupportedGuestError):
+            encrypt_ami._wait_for_encryption(UnsupportedGuestService())
+
 
 class TestProgress(unittest.TestCase):
 


### PR DESCRIPTION
Handle the server returning an "unsupported_guest" failure code.  Sample
output:

    ...
    14:38:11 Waiting for encryption service on i-82ebd859 at
52.27.165.218
    14:38:50 Creating encrypted root drive.
    14:39:00 Terminating encryptor instance i-82ebd859
    14:39:00 Waiting for instances to terminate.
    14:39:57 Deleting orphaned volume vol-1b32e2fd
    14:39:58 Deleting orphaned volume vol-1832e2fe
    14:39:58 Deleting orphaned volume vol-f333e315
    14:39:58 Deleting orphaned volume vol-8833e36e
    14:39:58 Deleting temporary security group sg-8fccb9eb
    14:39:58 Deleting snapshot copy of original root volume snap-
ec370fae
    14:39:58 The specified AMI uses an unsupported operating system