### PR TITLE
Remove encryption time estimate

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -34,7 +34,6 @@ AWS_SECRET_ACCESS_KEY environment variables, like you would when
 running the AWS command line utility.
 """
 
-import datetime
 import os
 import logging
 import re
@@ -54,7 +53,6 @@ from brkt_cli import service
 from brkt_cli.util import (
     BracketError,
     Deadline,
-    estimate_seconds_remaining,
     make_nonce,
 )
 
@@ -193,17 +191,6 @@ def _wait_for_encryptor_up(enc_svc, deadline):
     raise BracketError('Unable to contact %s' % enc_svc.hostname)
 
 
-def _get_encryption_progress_message(start_time, percent_complete, now=None):
-    msg = 'Encryption is %d%% complete' % percent_complete
-    if percent_complete > 0:
-        remaining = estimate_seconds_remaining(
-            start_time, percent_complete, now=now)
-        msg += (
-            ', %s remaining' % datetime.timedelta(seconds=int(remaining))
-        )
-    return msg
-
-
 class EncryptionError(BracketError):
     def __init__(self, message):
         super(EncryptionError, self).__init__(message)
@@ -237,9 +224,7 @@ def _wait_for_encryption(enc_svc):
         # Log progress once a minute.
         now = time.time()
         if now - last_progress_log >= 60:
-            msg = _get_encryption_progress_message(
-                start_time, percent_complete)
-            log.info(msg)
+            log.info('Encryption is %d%% complete', percent_complete)
             last_progress_log = now
 
         if state == service.ENCRYPT_SUCCESSFUL:

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -38,12 +38,3 @@ class Deadline(object):
             True if the deadline has passed. False otherwise.
         """
         return self.clock.time() >= self.deadline
-
-
-def estimate_seconds_remaining(start_time, percent_complete, now=None):
-    if percent_complete == 0:
-        return 0
-    now = now or time.time()
-    elapsed = now - start_time
-    total = elapsed / (float(percent_complete) / 100)
-    return total - elapsed

--- a/test.py
+++ b/test.py
@@ -17,7 +17,6 @@ from boto.exception import EC2ResponseError
 import brkt_cli
 import logging
 import os
-import time
 import unittest
 import uuid
 
@@ -26,7 +25,7 @@ from boto.ec2.image import Image
 from boto.ec2.instance import Instance, ConsoleOutput
 from boto.ec2.snapshot import Snapshot
 from boto.ec2.volume import Volume
-from brkt_cli import service, util, encrypt_ami
+from brkt_cli import service, encrypt_ami
 from brkt_cli.service import retry_boto
 
 brkt_cli.log = logging.getLogger(__name__)
@@ -463,35 +462,6 @@ class TestEncryptionService(unittest.TestCase):
 
         with self.assertRaises(encrypt_ami.UnsupportedGuestError):
             encrypt_ami._wait_for_encryption(UnsupportedGuestService())
-
-
-class TestProgress(unittest.TestCase):
-
-    def test_estimate_seconds_remaining(self):
-        # 10 seconds elapsed, 5% completed.
-        now = time.time()
-        remaining = util.estimate_seconds_remaining(
-            start_time=now - 10,
-            now=now,
-            percent_complete=5
-        )
-        self.assertEqual(190, int(remaining))
-
-    def test_encryption_progress_message(self):
-        now = time.time()
-        self.assertEquals(
-            'Encryption is 0% complete',
-            encrypt_ami._get_encryption_progress_message(now, 0)
-        )
-
-        self.assertEquals(
-            'Encryption is 5% complete, 0:03:10 remaining',
-            encrypt_ami._get_encryption_progress_message(
-                start_time=now - 10,
-                percent_complete=5,
-                now=now,
-            )
-        )
 
 
 class TestRetry(unittest.TestCase):


### PR DESCRIPTION
Remove the encryption time estimate and log only percent done.  Turned
out that AWS disk I/O is not reliable enough to allow us to calculate a
realistic time estimate.