### PR TITLE
Refactor services

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -17,16 +17,9 @@ import re
 import boto
 import boto.sts
 import logging
-import json
-import urllib2
 
 from boto.exception import EC2ResponseError
 import time
-
-ENCRYPT_SUCCESSFUL = 'finished'
-ENCRYPT_FAILED = 'failed'
-ENCRYPTOR_STATUS_PORT = 8000
-FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
 
 PLATFORM_WINDOWS = 'windows'
 
@@ -384,47 +377,6 @@ class AWSService(BaseAWSService):
 
     def get_console_output(self, instance_id):
         return self.conn.get_console_output(instance_id)
-
-
-class BaseEncryptorService(object):
-    __metaclass__ = abc.ABCMeta
-
-    def __init__(self, hostname, port=ENCRYPTOR_STATUS_PORT):
-        self.hostname = hostname
-        self.port = port
-
-    @abc.abstractmethod
-    def is_encryptor_up(self):
-        pass
-
-    @abc.abstractmethod
-    def get_status(self):
-        pass
-
-
-class EncryptorService(BaseEncryptorService):
-
-    def is_encryptor_up(self):
-        try:
-            self.get_status()
-            return True
-        except Exception as e:
-            log.debug("Couldn't get encryptor status: %s", e)
-            return False
-
-    def get_status(self, timeout_secs=2):
-        url = 'http://%s:%d/encryption_status' % (self.hostname, self.port)
-        r = urllib2.urlopen(url, timeout=timeout_secs)
-        data = r.read()
-        info = json.loads(data)
-        ratio = 0
-        info['percent_complete'] = 0
-        if info['state'] == ENCRYPT_SUCCESSFUL:
-            info['percent_complete'] = 100
-        elif info['bytes_total'] > 0:
-            ratio = float(info['bytes_written']) / info['bytes_total']
-            info['percent_complete'] = int(100 * ratio)
-        return info
 
 
 class ImageNameError(Exception):

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -52,4 +52,3 @@ def setup_encrypt_ami_args(parser):
         help=argparse.SUPPRESS,
         dest='key_name'
     )
-

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -1,0 +1,66 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import json
+import logging
+import re
+import urllib2
+
+ENCRYPT_SUCCESSFUL = 'finished'
+ENCRYPT_FAILED = 'failed'
+ENCRYPTOR_STATUS_PORT = 8000
+FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
+
+log = logging.getLogger(__name__)
+
+
+class BaseEncryptorService(object):
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, hostname, port=ENCRYPTOR_STATUS_PORT):
+        self.hostname = hostname
+        self.port = port
+
+    @abc.abstractmethod
+    def is_encryptor_up(self):
+        pass
+
+    @abc.abstractmethod
+    def get_status(self):
+        pass
+
+
+class EncryptorService(BaseEncryptorService):
+
+    def is_encryptor_up(self):
+        try:
+            self.get_status()
+            return True
+        except Exception as e:
+            log.debug("Couldn't get encryptor status: %s", e)
+            return False
+
+    def get_status(self, timeout_secs=2):
+        url = 'http://%s:%d/encryption_status' % (self.hostname, self.port)
+        r = urllib2.urlopen(url, timeout=timeout_secs)
+        data = r.read()
+        info = json.loads(data)
+        info['percent_complete'] = 0
+        if info['state'] == ENCRYPT_SUCCESSFUL:
+            info['percent_complete'] = 100
+        elif info['bytes_total'] > 0:
+            ratio = float(info['bytes_written']) / info['bytes_total']
+            info['percent_complete'] = int(100 * ratio)
+        return info


### PR DESCRIPTION
Split the service module into encryptor_service and aws_service, so that
it doesn't become a dumping ground.  This is in preparation for adding
another module that talks to the Bracket service.

Test plan: Ran unit tests, encrypted an AMI.