### PR TITLE
Updates reference VPC to include egress on 7001/2

### DIFF
--- a/reference_templates/README.md
+++ b/reference_templates/README.md
@@ -15,7 +15,7 @@ VPC with parallel public and private subnets in two availability zones
 in a single region. A pair of NAT instances will be created to allow
 instances in the private subnets Internet access. The default security
 groups and network ACLs in this template permit instances to access only
-tcp/80, tcp/443 and udp/123 (NTP) on the Internet. A security group
+tcp/80, tcp/443 tcp/7001 tcp/7002 and udp/123 (NTP) on the Internet. A security group
 named ``InternetClientSG`` is created and is intended to be applied to
 instances within the private subnet that need Internet access.
 

--- a/reference_templates/vpc-dual-az-with-nat.json
+++ b/reference_templates/vpc-dual-az-with-nat.json
@@ -234,6 +234,14 @@
                         "ToPort": "443"
                     },
                     {
+                        "FromPort": "7001",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "InternetClientSG"
+                        },
+                        "ToPort": "7002"
+                    },
+                    {
                         "FromPort": "123",
                         "IpProtocol": "udp",
                         "SourceSecurityGroupId": {
@@ -323,6 +331,23 @@
                 ]
             },
             "Type": "AWS::EC2::Instance"
+        },
+        "PrivateAllowBrktOut": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "true",
+                "NetworkAclId": {
+                    "Ref": "PrivateNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "7001",
+                    "To": "7002"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "140"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
         },
         "PrivateAllowHTTPOut": {
             "Properties": {
@@ -666,6 +691,40 @@
                 }
             },
             "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PublicAllowBrktIn": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "7001",
+                    "To": "7002"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "150"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "PublicAllowBrktOut": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "true",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "7001",
+                    "To": "7002"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "150"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
         },
         "PublicAllowHTTPOut": {
             "Properties": {

--- a/reference_templates/vpc-dual-az-with-nat.py
+++ b/reference_templates/vpc-dual-az-with-nat.py
@@ -217,7 +217,8 @@ public_egress_acl_entries = [
     ('PublicAllowHTTPOut', 110, 6, 80, '0.0.0.0/0'),
     ('PublicAllowTCPResponsesOut', 120, 6, (1024, 65535), '0.0.0.0/0'),
     ('PublicAllowSSHToPrivateInstances', 130, 6, 22, vpc_cidr),
-    ('PublicAllowNTPOut', 140, 17, 123, '0.0.0.0/0')
+    ('PublicAllowNTPOut', 140, 17, 123, '0.0.0.0/0'),
+    ('PublicAllowBrktOut', 150, 6, (7001, 7002), '0.0.0.0/0')
 ]
 for entry in public_egress_acl_entries:
     add_public_egress_acl_entry(*entry)
@@ -228,6 +229,7 @@ public_ingress_acl_entries = [
     ('PublicAllowHTTPSThrough', 120, 6, 443, vpc_cidr),
     ('PublicAllowHTTPThrough', 130, 6, 80, vpc_cidr),
     ('PublicAllowNTPResponsesIn', 140, 17, 123, '0.0.0.0/0'),
+    ('PublicAllowBrktIn', 150, 6, (7001, 7002), '0.0.0.0/0')
 ]
 for entry in public_ingress_acl_entries:
     add_public_ingress_acl_entry(*entry)
@@ -238,6 +240,7 @@ private_egress_acl_entries = [
     ('PrivateAllowHTTPOut', 110, 6, 80, '0.0.0.0/0'),
     ('PrivateAllowTCPResponsesOut', 120, 6, (1024, 65535), vpc_cidr),
     ('PrivateAllowNTPOut', 130, 17, 123, '0.0.0.0/0'),
+    ('PrivateAllowBrktOut', 140, 6, (7001, 7002), '0.0.0.0/0')
 ]
 for entry in private_egress_acl_entries:
     add_private_egress_acl_entry(*entry)
@@ -331,6 +334,13 @@ internet_client_rules = [
         IpProtocol="tcp",
         FromPort="443",
         ToPort="443",
+        SourceSecurityGroupId=Ref(internet_client_sg),
+    ),
+    # tcp/7001 tcp/7002 (brkt traffic)
+    SecurityGroupRule(
+        IpProtocol="tcp",
+        FromPort="7001",
+        ToPort="7002",
         SourceSecurityGroupId=Ref(internet_client_sg),
     ),
     # A rule to allow the use of udp/123 (NTP)


### PR DESCRIPTION
The brkt HSMProxy and API are now accessed via ports
7001 and 7002 respectively. This commit updates the
reference VPC to enable egress on ports 7001 and
7002