### PR TITLE
Check and accept EULA in brkt-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python: "2.7"
-install: pip install boto requests
+install: pip install boto requests brkt_sdk
 script: python -m unittest test

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -15,27 +15,81 @@
 from __future__ import print_function
 
 import argparse
+import getpass
+import os
+
 import boto
 import boto.ec2
 import boto.vpc
 import logging
 import sys
+import warnings
 
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
+from requests.packages import urllib3
 
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
 from brkt_cli import encrypt_ami_args
 from brkt_cli import encryptor_service
 from brkt_cli import util
+from brkt_cli.bracket_service import BracketService, BracketAuthError
 
+PROD_API_ROOT = 'https://api.mgmt.brkt.com'
+STAGE_API_ROOT = 'https://api.stage.mgmt.brkt.com'
 VERSION = '0.9.5'
 
 log = None
 
+EULA_CONFIRMATION_TEXT = \
+    """Please take a moment to review the terms of the Bracket
+Computing, Inc. Evaluation Agreement, which govern the access
+to and use of the Bracket Service. You can find it at
+
+    https://brkt.com/license.html
+
+You must accept these terms to access the Bracket Service. Type
+"YES" to accept the terms of the Bracket Computing, Inc. Evaluation
+Agreement: """
+
+
+def _check_eula(api_root, username, password, verify_cert=True):
+    """ Authenticate with the Bracket service, and ask the user to accept
+        the EULA if necessary.
+    :return: True if the EULA was accepted
+    :raise IOEError if the connection fails
+    :raise BracketAuthError if auth fails
+    """
+    # Authenticate and verify that the user has registered and signed the
+    # EULA.
+    brkt_svc = BracketService(
+        api_root, username, password, verify_cert=verify_cert)
+    brkt_svc.authenticate()
+
+    if not brkt_svc.is_eula_accepted():
+        sys.stdout.write(EULA_CONFIRMATION_TEXT)
+        accepted = raw_input()
+        if accepted.strip().lower() != 'yes':
+            return False
+        brkt_svc.accept_eula()
+    return True
+
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-u', '--username',
+        metavar='EMAIL',
+        dest='username',
+        help='Bracket service user email address',
+        required=True
+    )
+    parser.add_argument(
+        '-p', '--password',
+        metavar='PASSWORD',
+        dest='password',
+        help='Bracket service password'
+    )
     parser.add_argument(
         '-v',
         '--verbose',
@@ -48,7 +102,24 @@ def main():
         action='version',
         version='brkt-cli version %s' % VERSION
     )
+    # Tell the HTTP client to accept self-signed certs.  This option is
+    # hidden because it's only used for development.
+    parser.add_argument(
+        '--no-verify-cert',
+        action='store_false',
+        dest='verify_cert',
+        default=True,
+        help=argparse.SUPPRESS
+    )
 
+    # Optional Bracket server API root.  This argument is hidden because
+    # it's only used for development.
+    parser.add_argument(
+        '--api-root',
+        metavar='URL',
+        help=argparse.SUPPRESS,
+        dest='api_root'
+    )
     subparsers = parser.add_subparsers()
 
     encrypt_ami_parser = subparsers.add_parser('encrypt-ami')
@@ -77,13 +148,49 @@ def main():
     log.setLevel(log_level)
     aws_service.log.setLevel(log_level)
     encryptor_service.log.setLevel(log_level)
+    bracket_service.log.setLevel(log_level)
 
+    if not values.verify_cert:
+        warnings.filterwarnings(
+            'ignore',
+            category=urllib3.exceptions.InsecureRequestWarning
+        )
+
+    # Validate the AMI name.
     if values.encrypted_ami_name:
         try:
             aws_service.validate_image_name(values.encrypted_ami_name)
         except aws_service.ImageNameError as e:
             print(e.message, file=sys.stderr)
             return 1
+
+    password = values.password or getpass.getpass('Password:')
+    if values.api_root:
+        api_root = values.api_root
+    else:
+        if os.getenv('BRACKET_ENVIRONMENT') == 'stage':
+            api_root = STAGE_API_ROOT
+        else:
+            api_root = PROD_API_ROOT
+
+    try:
+        eula_accepted = _check_eula(
+            api_root,
+            values.username,
+            password,
+            verify_cert=values.verify_cert
+        )
+        if not eula_accepted:
+            return 1
+    except BracketAuthError:
+        print('Invalid username or password', file=sys.stderr)
+        return 1
+    except IOError as e:
+        if values.verbose:
+            log.exception('Unable to connect to the Bracket Service')
+        else:
+            print('Unable to connect to the Bracket Service: %s' % e)
+        return 1
 
     # Validate the region.
     regions = [str(r.name) for r in boto.vpc.regions()]

--- a/brkt_cli/bracket_service.py
+++ b/brkt_cli/bracket_service.py
@@ -1,0 +1,94 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import logging
+
+import brkt_requests
+import requests
+
+
+log = logging.getLogger(__name__)
+
+
+class BracketAuthError(Exception):
+    pass
+
+
+class BracketService(object):
+
+    def __init__(self, api_root, username, password, verify_cert=True):
+        self.api_root = api_root
+        self.username = username
+        self.password = password
+        self.verify_cert = verify_cert
+
+        # Session will be initialized during auth.
+        self.session = None
+
+    def authenticate(self):
+        """ Authenticate with the bracket service.
+
+        :raise BracketAuthError if the username or password is invalid
+        """
+        log.debug(
+            'Authenticating with the Bracket service at %s as %s',
+            self.api_root,
+            self.username
+        )
+        r = requests.post(
+            '%s/oauth/credentials' % self.api_root,
+            json={
+                'username': self.username,
+                'password': self.password,
+                'grant_type': 'password'
+            },
+            headers={'Content-Type': 'application/json'},
+            verify=self.verify_cert
+        )
+
+        if r.status_code == 401:
+            raise BracketAuthError()
+        if r.status_code / 100 != 2:
+            raise Exception('Error %d: %s' % (r.status_code, r.content))
+        resp = r.json()
+        self.session = brkt_requests.APISession(
+            access_token=resp["access_token"],
+            mac_key=resp["mac_key"],
+            verify=self.verify_cert
+        )
+
+    def is_eula_accepted(self):
+        r = self.session.get('%s/api/v1/customer/self' % self.api_root)
+
+        if r.status_code / 100 != 2:
+            raise Exception('Error %d: %s' % (r.status_code, r.content))
+        return r.json.get('eula_accepted', False)
+
+    def get_eula(self):
+        r = requests.get(self.get_eula_url(), verify=False)
+        if r.status_code / 100 != 2:
+            raise Exception('Unable to download EULA: %d %s' % (
+                r.status_code, r.content))
+        return r.text
+
+    def accept_eula(self):
+        r = self.session.post(
+            '%s/api/v1/customer/self' % self.api_root,
+            json={
+                'eula_accepted': True
+            }
+        )
+        if r.status_code / 100 != 2:
+            raise Exception('Error %d: %s' % (r.status_code, r.content))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     url='http://brkt.com',
     license='Apache 2.0',
     packages=['brkt_cli'],
-    install_requires=['boto>=2.38.0', 'requests>=2.7.0'],
+    install_requires=['boto>=2.38.0', 'requests>=2.7.0', 'brkt_sdk>=0.1.1'],
     zip_safe=False,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Add the following options at the top level of the brkt command:

--username (required)
--password (optional)
--api-root (hidden, development only)
--no-verify-cert (hidden, development only)

brkt-cli now authenticates with the Bracket service before doing
any work.

If --password is not specified, prompt the user for the password.
If the EULA has not been signed, prompt the user with the link to the
EULA text.  The user must type the word "YES" (case-insensitive) in
order to accept the EULA.

Add a new BracketService class for code that talks to the Bracket
service API.