### PR TITLE
Improve error handling during cleanup

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -78,6 +78,10 @@ class BaseAWSService(object):
 
     @abc.abstractmethod
     def delete_volume(self, volume_id):
+        """ Delete the given volume.
+        :return: True if the volume was deleted
+        :raise: EC2ResponseError if an error occurred
+        """
         pass
 
     @abc.abstractmethod
@@ -288,7 +292,12 @@ class AWSService(BaseAWSService):
 
     def delete_volume(self, volume_id):
         log.debug('Deleting volume %s', volume_id)
-        return self.conn.delete_volume(volume_id)
+        try:
+            self.conn.delete_volume(volume_id)
+        except EC2ResponseError as e:
+            if e.error_code != 'InvalidVolume.NotFound':
+                raise
+        return True
 
     def validate_guest_ami(self, ami_id):
         try:


### PR DESCRIPTION
If something unexpected happens during cleanup, log the traceback, so
that we know where the problem occurred.  Move the bulk of the cleanup
code into its own function, to avoid a massive finally block inside the
encrypt() function.

When deleting a volume, ignore InvalidVolume.NotFound.  This can happen
when AWS deletes a volume that was attached to a terminated instance,
and we then attempt to delete the volume explicitly.

Remove extra log message that was printed when encryption completes.