### PR TITLE
Update encrypted images

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ optional arguments:
 $ python brkt update-encrypted-ami --help
 usage: brkt update-encrypted-ami [-h] --updater-ami UPDATER_AMI_ID --region
                                  REGION [--encrypted-ami-name NAME]
+                                 [--no-validate-ami]
                                  AMI_ID
 
 positional arguments:
@@ -64,6 +65,7 @@ optional arguments:
   --region REGION       AWS region (e.g. us-west-2)
   --encrypted-ami-name NAME
                         Specify the name of the generated encrypted AMI
+  --no-validate-ami     Don't validate encrypted AMI properties
 ```
 
 ## Configuration
@@ -103,23 +105,23 @@ messages are written to stderr.
 
 ## Updating an encrypted AMI
 
-Run **brkt update-encrypted-ami** to update anw encrypted AMI based on an existing
+Run **brkt update-encrypted-ami** to update an encrypted AMI based on an existing
 encrypted image:
 
 ```
 $ brkt update-encrypted-ami --region us-east-1 --updater-ami ami-32430158 ami-72094e18
-11:09:46 Commencing update for AMI ami-72094e18
-11:09:46 Creating guest volume snapshot
-11:10:18 Launching metavisor updater instance
+13:38:14 Using zone us-east-1a
+13:38:15 Updating ami-72094e18
+13:38:15 Creating guest volume snapshot
 ...
-11:11:53 metavisor updater snapshots ready
+13:39:25 Encrypted root drive created.
 ...
-11:11:53 Terminating encryptor instance i-9ecfe120
+13:39:28 waiting for snapshot ready
+13:39:48 metavisor updater snapshots ready
 ...
-11:11:55 Registered AMI ami-b9d795d3 based on the snapshots.
-11:12:00 Created encrypted AMI ami-b9d795d3 based on ami-72094e18
-Done.
-ami-b9d795d3
+13:39:54 Created encrypted AMI ami-63733e09 based on ami-72094e18
+13:39:54 Done.
+ami-63733e09
 ```
 
 When the process completes, the new AMI id is written to stdout.  All log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **brkt-cli** is a command-line interface to the [Bracket Computing](http://www.brkt.com)
 service.  It produces an encrypted version of an Amazon Machine Image, which can then be
-launched in EC2.
+launched in EC2. It can also update an already encrypted version of an Amazon Machine Image,
+which can then be launched in EC2.
 
 ## Requirements
 
@@ -47,6 +48,23 @@ optional arguments:
   --no-validate-ami     Don't validate AMI properties
   --region NAME         AWS region (e.g. us-west-2)
 ```
+```
+$ python brkt update-encrypted-ami --help
+usage: brkt update-encrypted-ami [-h] --updater-ami UPDATER_AMI_ID --region
+                                 REGION [--encrypted-ami-name NAME]
+                                 AMI_ID
+
+positional arguments:
+  AMI_ID                The AMI that will be encrypted
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --updater-ami UPDATER_AMI_ID
+                        The metavisor updater AMI that will be used
+  --region REGION       AWS region (e.g. us-west-2)
+  --encrypted-ami-name NAME
+                        Specify the name of the generated encrypted AMI
+```
 
 ## Configuration
 
@@ -78,6 +96,30 @@ $ brkt encrypt-ami --key my-aws-key --region us-east-1 ami-76e27e1e
 15:57:12 Deleting snapshot copy of original root volume snap-847da3e1
 15:57:12 Done.
 ami-07c2a262
+```
+
+When the process completes, the new AMI id is written to stdout.  All log
+messages are written to stderr.
+
+## Updating an encrypted AMI
+
+Run **brkt update-encrypted-ami** to update anw encrypted AMI based on an existing
+encrypted image:
+
+```
+$ brkt update-encrypted-ami --region us-east-1 --updater-ami ami-32430158 ami-72094e18
+11:09:46 Commencing update for AMI ami-72094e18
+11:09:46 Creating guest volume snapshot
+11:10:18 Launching metavisor updater instance
+...
+11:11:53 metavisor updater snapshots ready
+...
+11:11:53 Terminating encryptor instance i-9ecfe120
+...
+11:11:55 Registered AMI ami-b9d795d3 based on the snapshots.
+11:12:00 Created encrypted AMI ami-b9d795d3 based on ami-72094e18
+Done.
+ami-b9d795d3
 ```
 
 When the process completes, the new AMI id is written to stdout.  All log

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -177,9 +177,6 @@ def command_update_encrypted_ami(values, log):
                file=sys.stderr)
         return 1
     aws_svc.connect(region)
-    zones = [str(z.name) for z in aws_svc.conn.get_all_zones()]
-    zone = zones[0]
-    log.info('Using zone %s', zone)
     encrypted_ami = values.ami
     if not values.no_validate_ami:
         guest_ami_error = aws_svc.validate_guest_encrypted_ami(encrypted_ami)
@@ -200,8 +197,7 @@ def command_update_encrypted_ami(values, log):
     guest_snapshot, volume_info, error = \
         update_encrypted_ami.retrieve_guest_volume_snapshot(
             aws_svc,
-            encrypted_ami,
-            zone)
+            encrypted_ami)
     if not guest_snapshot:
         log.error('failed to launch instance %s: %s' % (encrypted_ami, error))
         return 1

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -26,6 +26,8 @@ from boto.exception import EC2ResponseError, NoAuthHandlerFound
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
 from brkt_cli import encrypt_ami_args
+from brkt_cli import update_encrypted_ami
+from brkt_cli import update_encrypted_ami_args
 from brkt_cli import encryptor_service
 from brkt_cli import util
 
@@ -34,39 +36,7 @@ VERSION = '0.9.6'
 log = None
 
 
-def main():
-    # Check Python version.
-    version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
-    if version != '2.7':
-        print(
-            'brkt-cli requires Python 2.7.  Version',
-            version,
-            'is not supported.',
-            file=sys.stderr
-        )
-        return 1
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='verbose',
-        action='store_true',
-        help='Print status information to the console'
-    )
-    parser.add_argument(
-        '--version',
-        action='version',
-        version='brkt-cli version %s' % VERSION
-    )
-
-    subparsers = parser.add_subparsers()
-
-    encrypt_ami_parser = subparsers.add_parser('encrypt-ami')
-    encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
-
-    argv = sys.argv[1:]
-    values = parser.parse_args(argv)
+def command_encrypt_ami(values, log):
     region = values.region
 
     # Initialize logging.  Log messages are written to stderr and are
@@ -78,16 +48,6 @@ def main():
         # Boto logs auth errors and 401s at ERROR level by default.
         boto.log.setLevel(logging.FATAL)
         log_level = logging.INFO
-
-    # Set the log level of our modules explicitly.  We can't set the
-    # default log level to INFO because we would see INFO messages from
-    # boto and other 3rd party libraries in the command output.
-    logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%H:%M:%S')
-    global log
-    log = logging.getLogger(__name__)
-    log.setLevel(log_level)
-    aws_service.log.setLevel(log_level)
-    encryptor_service.log.setLevel(log_level)
 
     if values.encrypted_ami_name:
         try:
@@ -196,6 +156,136 @@ def main():
         else:
             log.error('Interrupted by user')
     return 1
+
+
+def command_update_encrypted_ami(values, log):
+    encrypted_ami_name = None
+    if values.encrypted_ami_name:
+        try:
+            aws_service.validate_image_name(values.encrypted_ami_name)
+            encrypted_ami_name = values.encrypted_ami_name
+        except aws_service.ImageNameError as e:
+            print(e.message, file=sys.stderr)
+            return 1
+    region = values.region
+    if util.validate_region(region) == 1:
+        print ('Invalid region %s' % region,
+               file=sys.stderr)
+        return 1
+    nonce = util.make_nonce()
+    default_tags = encrypt_ami.get_default_tags(nonce, '')
+    aws_svc = aws_service.AWSService(
+        nonce, None, default_tags=default_tags)
+    aws_svc.connect(region)
+    zones = [str(z.name) for z in aws_svc.conn.get_all_zones()]
+    zone = zones[0]
+    log.info('Using zone %s', zone)
+    encrypted_ami = values.ami
+    guest_ami_error = aws_svc.validate_guest_ami(encrypted_ami)
+    if guest_ami_error:
+        print(guest_ami_error, file=sys.stderr)
+        return 1
+    updater_ami = values.updater_ami
+    updater_ami_error = aws_svc.validate_encryptor_ami(values.updater_ami)
+    if updater_ami_error:
+        log.error('Update failed: %s', updater_ami_error)
+        return 1
+    # Initial validation done
+    log.info('Commencing update for AMI %s', encrypted_ami)
+    # snapshot the guest's volume
+    guest_snapshot, volume, vol_type, error = \
+        update_encrypted_ami.retrieve_guest_volume_snapshot(
+            aws_svc,
+            encrypted_ami,
+            zone)
+    if not guest_snapshot:
+        log.error('failed to launch instance %s: %s' % (encrypted_ami, error))
+        return 1
+    log.info('Launching metavisor update encryptor instance')
+    updater_ami_block_devices = \
+        update_encrypted_ami.snapshot_updater_ami_block_devices(
+            aws_svc,
+            encrypted_ami,
+            updater_ami,
+            guest_snapshot.id,
+            volume.size)
+    ami = encrypt_ami.register_new_ami(
+        aws_svc,
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT],
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT],
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT],
+        guest_snapshot,
+        vol_type,
+        volume.iops,
+        encrypted_ami,
+        encrypted_ami_name=encrypted_ami_name)
+    log.info('Done.')
+    print(ami)
+    return 0
+
+
+def main():
+    # Check Python version.
+    version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
+    if version != '2.7':
+        print(
+            'brkt-cli requires Python 2.7.  Version',
+            version,
+            'is not supported.',
+            file=sys.stderr
+        )
+        return 1
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='brkt-cli version %s' % VERSION
+    )
+
+    subparsers = parser.add_subparsers()
+
+    encrypt_ami_parser = subparsers.add_parser('encrypt-ami')
+    encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
+
+    update_encrypted_ami_parser = \
+        subparsers.add_parser('update-encrypted-ami')
+    update_encrypted_ami_args.setup_update_encrypted_ami(
+        update_encrypted_ami_parser)
+
+    argv = sys.argv[1:]
+    values = parser.parse_args(argv)
+    # Initialize logging.  Log messages are written to stderr and are
+    # prefixed with a compact timestamp, so that the user knows how long
+    # each operation took.
+    if values.verbose:
+        log_level = logging.DEBUG
+    else:
+        # Boto logs auth errors and 401s at ERROR level by default.
+        boto.log.setLevel(logging.FATAL)
+        log_level = logging.INFO
+    # Set the log level of our modules explicitly.  We can't set the
+    # default log level to INFO because we would see INFO messages from
+    # boto and other 3rd party libraries in the command output.
+    logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%H:%M:%S')
+    global log
+    log = logging.getLogger(__name__)
+    log.setLevel(log_level)
+    aws_service.log.setLevel(log_level)
+    encryptor_service.log.setLevel(log_level)
+    if argv[0] == 'encrypt-ami':
+        return command_encrypt_ami(values, log)
+
+    if argv[0] == 'update-encrypted-ami':
+        return command_update_encrypted_ami(values, log)
+
 
 if __name__ == '__main__':
     exit_status = main()

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -102,8 +102,7 @@ def snapshot_updater_ami_block_devices(aws_service,
 
 
 def retrieve_guest_volume_snapshot(aws_service,
-                                   encrypted_ami_id,
-                                   zone):
+                                   encrypted_ami_id):
     # Verify expected device mapping is present, return with info
     log.info('Creating guest volume snapshot')
     encrypted_image = aws_service.get_image(encrypted_ami_id)

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -1,0 +1,135 @@
+import boto
+import logging
+import sys
+import time
+from boto.exception import EC2ResponseError
+from brkt_cli import (
+    encrypt_ami,
+    encryptor_service,
+    util)
+from brkt_cli.util import Deadline
+
+log = logging.getLogger(__name__)
+
+
+def snapshot_updater_ami_block_devices(aws_service,
+                                       guest_encrypted_image,
+                                       mv_updater_ami,
+                                       guest_snapshot,
+                                       volume_size):
+    # Retrieves the most recent updater AMI, launches it, snapshots
+    # its volumes, returns the snapshots
+    sg_id = encrypt_ami.create_encryptor_security_group(aws_service)
+    mv_instance = encrypt_ami.run_encryptor_instance(
+        aws_service,
+        mv_updater_ami,
+        guest_snapshot,
+        volume_size,
+        guest_encrypted_image,
+        sg_id,
+        update_ami=True)
+    host_ip = mv_instance.ip_address
+    enc_svc = encryptor_service.EncryptorService(host_ip)
+    log.info('Waiting for encryption service on %s at %s',
+             mv_instance.id, host_ip)
+    encrypt_ami.wait_for_encryptor_up(enc_svc, Deadline(600))
+    try:
+        encrypt_ami.wait_for_encryption(enc_svc)
+    except EncryptionError as e:
+        log.error(
+            'Update failed.  Check console output of instance %s '
+            'for details.',
+            mv_instance.id
+        )
+
+        e.console_output_file = encrypt_ami.write_console_output(
+            aws_service, mv_instance.id)
+        if e.console_output_file:
+            log.error(
+                'Wrote console output for instance %s to %s',
+                mv_instance.id,
+                e.console_output_file.name
+            )
+        else:
+            log.error(
+                'Encryptor console output is not currently available.  '
+                'Wait a minute and check the console output for '
+                'instance %s in the EC2 Management '
+                'Console.',
+                mv_instance.id
+            )
+        raise e
+    bdm = mv_instance.block_device_mapping
+    log.info('Stopping metavisor updater instance %s', mv_instance.id)
+    aws_service.stop_instance(mv_instance.id)
+    description = \
+        encrypt_ami.DESCRIPTION_SNAPSHOT % {'image_id': guest_encrypted_image}
+
+    # Snapshot volumes.
+    mv_root_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda2'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT,
+        description=description
+    )
+    mv_grub_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda1'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT,
+        description=description
+    )
+    mv_log_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda3'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT,
+        description=description
+    )
+    log.info('waiting for snapshot ready')
+    encrypt_ami.wait_for_snapshots(
+        aws_service,
+        mv_root_snapshot.id,
+        mv_grub_snapshot.id,
+        mv_log_snapshot.id)
+    log.info('metavisor updater snapshots ready')
+    encrypt_ami.terminate_instance(
+        aws_service,
+        id=mv_instance.id,
+        name='encryptor',
+        terminated_instance_ids=set()
+    )
+    return {
+        encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT: mv_root_snapshot,
+        encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT: mv_grub_snapshot,
+        encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT: mv_log_snapshot
+    }
+
+
+def retrieve_guest_volume_snapshot(aws_service,
+                                   encrypted_ami_id,
+                                   zone):
+    # Verify expected device mapping is present, return with info
+    log.info('Creating guest volume snapshot')
+    encrypted_image = aws_service.conn.get_image(encrypted_ami_id)
+    guest_volume_mapping = \
+        encrypted_image.block_device_mapping.get('/dev/sda5')
+    if not guest_volume_mapping:
+        return None, None, None, \
+            'Invalid block device mapping: /dev/sda5 not present'
+    snapshot = aws_service.conn.get_all_snapshots(
+        guest_volume_mapping.snapshot_id)[0]
+    # Create new volume off this snapshot, snapshot the volume and
+    # return the snapshot
+    guest_volume = snapshot.create_volume(zone)
+    # Wait for volume to be ready
+    volume_available = False
+    while not volume_available:
+        encrypt_ami.sleep(5)
+        guest_volume = aws_service.conn.get_all_volumes(guest_volume.id)[0]
+        if guest_volume.status == 'error':
+            return None, None, None, \
+                'Error creating volume %s' % guest_volume.id
+        if guest_volume.status == 'available':
+            volume_available = True
+    guest_volume_snapshot = guest_volume.create_snapshot()
+    encrypt_ami.wait_for_snapshots(aws_service, guest_volume_snapshot.id)
+    # Delete volume
+    aws_service.delete_volume(guest_volume.id)
+    return guest_volume_snapshot, guest_volume, \
+        guest_volume_mapping.volume_type, None

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -29,6 +29,12 @@ def setup_update_encrypted_ami(parser):
         help='Specify the name of the generated encrypted AMI',
         required=False
     )
+    parser.add_argument(
+        '--no-validate-ami',
+        dest='no_validate_ami',
+        action='store_true',
+        help="Don't validate encrypted AMI properties"
+    )
     # Optional EC2 SSH key pair name to use for launching the snapshotter
     # and encryptor instances.  This argument is hidden because it's only
     # used for development.

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -1,0 +1,40 @@
+import argparse
+
+
+def setup_update_encrypted_ami(parser):
+    parser.add_argument(
+        'ami',
+        metavar='AMI_ID',
+        help='The AMI that will be encrypted'
+    )
+    parser.add_argument(
+        '--updater-ami',
+        metavar='UPDATER_AMI_ID',
+        help='The metavisor updater AMI that will be used',
+        dest='updater_ami',
+        required=True
+    )
+    parser.add_argument(
+        '--region',
+        metavar='REGION',
+        help='AWS region (e.g. us-west-2)',
+        dest='region',
+        default='us-west-2',
+        required=True
+    )
+    parser.add_argument(
+        '--encrypted-ami-name',
+        metavar='NAME',
+        dest='encrypted_ami_name',
+        help='Specify the name of the generated encrypted AMI',
+        required=False
+    )
+    # Optional EC2 SSH key pair name to use for launching the snapshotter
+    # and encryptor instances.  This argument is hidden because it's only
+    # used for development.
+    parser.add_argument(
+        '--key',
+        metavar='KEY',
+        help=argparse.SUPPRESS,
+        dest='key_name'
+    )

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -11,17 +11,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import boto
+import sys
 import time
 import uuid
 
 
 class BracketError(Exception):
     pass
-
-
-def make_nonce():
-    """Returns a 32bit nonce in hex encoding"""
-    return str(uuid.uuid4()).split('-')[0]
 
 
 class Deadline(object):
@@ -38,3 +35,23 @@ class Deadline(object):
             True if the deadline has passed. False otherwise.
         """
         return self.clock.time() >= self.deadline
+
+
+def make_nonce():
+    """Returns a 32bit nonce in hex encoding"""
+    return str(uuid.uuid4()).split('-')[0]
+
+
+def validate_ami_name(name):
+    try:
+        service.validate_image_name(name)
+        return 0
+    except service.ImageNameError as e:
+        return 1
+
+
+def validate_region(region):
+    regions = [str(r.name) for r in boto.vpc.regions()]
+    if region not in regions:
+        return 1
+    return 0

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -40,18 +40,3 @@ class Deadline(object):
 def make_nonce():
     """Returns a 32bit nonce in hex encoding"""
     return str(uuid.uuid4()).split('-')[0]
-
-
-def validate_ami_name(name):
-    try:
-        service.validate_image_name(name)
-        return 0
-    except service.ImageNameError as e:
-        return 1
-
-
-def validate_region(region):
-    regions = [str(r.name) for r in boto.vpc.regions()]
-    if region not in regions:
-        return 1
-    return 0


### PR DESCRIPTION
This change adds the update-encrypted-ami option to the brkt_cli.
It allows a user to retrieve a metavisor upgrader AMI and use it
to upgrade an already encrypted AMI. This provides a speed
improvement for users who wish to update their encrypted AMIs.

The user must specify the metavisor updater AMI as an argument.
This requirement will be taken away in a near-future commit.