### PR TITLE
Update encrypted ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **brkt-cli** is a command-line interface to the [Bracket Computing](http://www.brkt.com)
 service.  It produces an encrypted version of an Amazon Machine Image, which can then be
-launched in EC2.
+launched in EC2. It can also update an already encrypted version of an Amazon Machine Image,
+which can then be launched in EC2.
 
 ## Requirements
 
@@ -47,6 +48,25 @@ optional arguments:
   --no-validate-ami     Don't validate AMI properties
   --region NAME         AWS region (e.g. us-west-2)
 ```
+```
+$ python brkt update-encrypted-ami --help
+usage: brkt update-encrypted-ami [-h] --updater-ami UPDATER_AMI_ID --region
+                                 REGION [--encrypted-ami-name NAME]
+                                 [--no-validate-ami]
+                                 AMI_ID
+
+positional arguments:
+  AMI_ID                The AMI that will be encrypted
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --updater-ami UPDATER_AMI_ID
+                        The metavisor updater AMI that will be used
+  --region REGION       AWS region (e.g. us-west-2)
+  --encrypted-ami-name NAME
+                        Specify the name of the generated encrypted AMI
+  --no-validate-ami     Don't validate encrypted AMI properties
+```
 
 ## Configuration
 
@@ -78,6 +98,30 @@ $ brkt encrypt-ami --key my-aws-key --region us-east-1 ami-76e27e1e
 15:57:12 Deleting snapshot copy of original root volume snap-847da3e1
 15:57:12 Done.
 ami-07c2a262
+```
+
+When the process completes, the new AMI id is written to stdout.  All log
+messages are written to stderr.
+
+## Updating an encrypted AMI
+
+Run **brkt update-encrypted-ami** to update an encrypted AMI based on an existing
+encrypted image:
+
+```
+$ brkt update-encrypted-ami --region us-east-1 --updater-ami ami-32430158 ami-72094e18
+13:38:14 Using zone us-east-1a
+13:38:15 Updating ami-72094e18
+13:38:15 Creating guest volume snapshot
+...
+13:39:25 Encrypted root drive created.
+...
+13:39:28 waiting for snapshot ready
+13:39:48 metavisor updater snapshots ready
+...
+13:39:54 Created encrypted AMI ami-63733e09 based on ami-72094e18
+13:39:54 Done.
+ami-63733e09
 ```
 
 When the process completes, the new AMI id is written to stdout.  All log

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -26,6 +26,8 @@ from boto.exception import EC2ResponseError, NoAuthHandlerFound
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
 from brkt_cli import encrypt_ami_args
+from brkt_cli import update_encrypted_ami
+from brkt_cli import update_encrypted_ami_args
 from brkt_cli import encryptor_service
 from brkt_cli import util
 
@@ -34,39 +36,7 @@ VERSION = '0.9.6'
 log = None
 
 
-def main():
-    # Check Python version.
-    version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
-    if version != '2.7':
-        print(
-            'brkt-cli requires Python 2.7.  Version',
-            version,
-            'is not supported.',
-            file=sys.stderr
-        )
-        return 1
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='verbose',
-        action='store_true',
-        help='Print status information to the console'
-    )
-    parser.add_argument(
-        '--version',
-        action='version',
-        version='brkt-cli version %s' % VERSION
-    )
-
-    subparsers = parser.add_subparsers()
-
-    encrypt_ami_parser = subparsers.add_parser('encrypt-ami')
-    encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
-
-    argv = sys.argv[1:]
-    values = parser.parse_args(argv)
+def command_encrypt_ami(values, log):
     region = values.region
 
     # Initialize logging.  Log messages are written to stderr and are
@@ -78,16 +48,6 @@ def main():
         # Boto logs auth errors and 401s at ERROR level by default.
         boto.log.setLevel(logging.FATAL)
         log_level = logging.INFO
-
-    # Set the log level of our modules explicitly.  We can't set the
-    # default log level to INFO because we would see INFO messages from
-    # boto and other 3rd party libraries in the command output.
-    logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%H:%M:%S')
-    global log
-    log = logging.getLogger(__name__)
-    log.setLevel(log_level)
-    aws_service.log.setLevel(log_level)
-    encryptor_service.log.setLevel(log_level)
 
     if values.encrypted_ami_name:
         try:
@@ -120,7 +80,7 @@ def main():
     try:
         # Connect to AWS.
         aws_svc = aws_service.AWSService(
-            session_id, encryptor_ami, default_tags=default_tags)
+            session_id, default_tags=default_tags)
         aws_svc.connect(region, key_name=values.key_name)
     except NoAuthHandlerFound:
         msg = (
@@ -196,6 +156,136 @@ def main():
         else:
             log.error('Interrupted by user')
     return 1
+
+
+def command_update_encrypted_ami(values, log):
+    encrypted_ami_name = None
+    if values.encrypted_ami_name:
+        try:
+            aws_service.validate_image_name(values.encrypted_ami_name)
+            encrypted_ami_name = values.encrypted_ami_name
+        except aws_service.ImageNameError as e:
+            print(e.message, file=sys.stderr)
+            return 1
+    region = values.region
+    nonce = util.make_nonce()
+    default_tags = encrypt_ami.get_default_tags(nonce, '')
+    aws_svc = aws_service.AWSService(
+        nonce, default_tags=default_tags)
+    if not aws_svc.validate_region(region):
+        print ('Invalid region %s' % region,
+               file=sys.stderr)
+        return 1
+    aws_svc.connect(region)
+    encrypted_ami = values.ami
+    if not values.no_validate_ami:
+        guest_ami_error = aws_svc.validate_guest_encrypted_ami(encrypted_ami)
+        if guest_ami_error:
+            print ('Encrypted AMI verification failed: %s' % guest_ami_error,
+                   file=sys.stderr)
+            return 1
+    else:
+        log.info('skipping AMI verification')
+    updater_ami = values.updater_ami
+    updater_ami_error = aws_svc.validate_encryptor_ami(values.updater_ami)
+    if updater_ami_error:
+        log.error('Update failed: %s', updater_ami_error)
+        return 1
+    # Initial validation done
+    log.info('Updating %s', encrypted_ami)
+    # snapshot the guest's volume
+    guest_snapshot, volume_info, error = \
+        update_encrypted_ami.retrieve_guest_volume_snapshot(
+            aws_svc,
+            encrypted_ami)
+    if not guest_snapshot:
+        log.error('failed to launch instance %s: %s' % (encrypted_ami, error))
+        return 1
+    log.info('Launching metavisor update encryptor instance')
+    updater_ami_block_devices = \
+        update_encrypted_ami.snapshot_updater_ami_block_devices(
+            aws_svc,
+            encrypted_ami,
+            updater_ami,
+            guest_snapshot.id,
+            volume_info['size'])
+    ami = encrypt_ami.register_new_ami(
+        aws_svc,
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT],
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT],
+        updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT],
+        guest_snapshot,
+        volume_info['type'],
+        volume_info['iops'],
+        encrypted_ami,
+        encrypted_ami_name=encrypted_ami_name)
+    log.info('Done.')
+    print(ami)
+    return 0
+
+
+def main():
+    # Check Python version.
+    version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
+    if version != '2.7':
+        print(
+            'brkt-cli requires Python 2.7.  Version',
+            version,
+            'is not supported.',
+            file=sys.stderr
+        )
+        return 1
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='brkt-cli version %s' % VERSION
+    )
+
+    subparsers = parser.add_subparsers()
+
+    encrypt_ami_parser = subparsers.add_parser('encrypt-ami')
+    encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
+
+    update_encrypted_ami_parser = \
+        subparsers.add_parser('update-encrypted-ami')
+    update_encrypted_ami_args.setup_update_encrypted_ami(
+        update_encrypted_ami_parser)
+
+    argv = sys.argv[1:]
+    values = parser.parse_args(argv)
+    # Initialize logging.  Log messages are written to stderr and are
+    # prefixed with a compact timestamp, so that the user knows how long
+    # each operation took.
+    if values.verbose:
+        log_level = logging.DEBUG
+    else:
+        # Boto logs auth errors and 401s at ERROR level by default.
+        boto.log.setLevel(logging.FATAL)
+        log_level = logging.INFO
+    # Set the log level of our modules explicitly.  We can't set the
+    # default log level to INFO because we would see INFO messages from
+    # boto and other 3rd party libraries in the command output.
+    logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%H:%M:%S')
+    global log
+    log = logging.getLogger(__name__)
+    log.setLevel(log_level)
+    aws_service.log.setLevel(log_level)
+    encryptor_service.log.setLevel(log_level)
+    if argv[0] == 'encrypt-ami':
+        return command_encrypt_ami(values, log)
+
+    if argv[0] == 'update-encrypted-ami':
+        return command_update_encrypted_ami(values, log)
+
 
 if __name__ == '__main__':
     exit_status = main()

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -1,0 +1,119 @@
+import boto
+import logging
+import sys
+import time
+from boto.exception import EC2ResponseError
+from brkt_cli import (
+    encrypt_ami,
+    encryptor_service,
+    util)
+from brkt_cli.util import Deadline
+
+log = logging.getLogger(__name__)
+
+
+def snapshot_updater_ami_block_devices(aws_service,
+                                       guest_encrypted_image,
+                                       mv_updater_ami,
+                                       guest_snapshot,
+                                       volume_size):
+    # Retrieves the most recent updater AMI, launches it, snapshots
+    # its volumes, returns the snapshots
+    sg_id = encrypt_ami.create_encryptor_security_group(aws_service)
+    mv_instance = encrypt_ami.run_encryptor_instance(
+        aws_service,
+        mv_updater_ami,
+        guest_snapshot,
+        volume_size,
+        guest_encrypted_image,
+        sg_id,
+        update_ami=True)
+    host_ip = mv_instance.ip_address
+    enc_svc = encryptor_service.EncryptorService(host_ip)
+    log.info('Waiting for encryption service on %s at %s',
+             mv_instance.id, host_ip)
+    encrypt_ami.wait_for_encryptor_up(enc_svc, Deadline(600))
+    try:
+        encrypt_ami.wait_for_encryption(enc_svc)
+    except EncryptionError as e:
+        log.error(
+            'Update failed.  Check console output of instance %s '
+            'for details.',
+            mv_instance.id
+        )
+
+        e.console_output_file = encrypt_ami.write_console_output(
+            aws_service, mv_instance.id)
+        if e.console_output_file:
+            log.error(
+                'Wrote console output for instance %s to %s',
+                mv_instance.id,
+                e.console_output_file.name
+            )
+        else:
+            log.error(
+                'Encryptor console output is not currently available.  '
+                'Wait a minute and check the console output for '
+                'instance %s in the EC2 Management '
+                'Console.',
+                mv_instance.id
+            )
+        raise e
+    bdm = mv_instance.block_device_mapping
+    log.info('Stopping metavisor updater instance %s', mv_instance.id)
+    aws_service.stop_instance(mv_instance.id)
+    description = \
+        encrypt_ami.DESCRIPTION_SNAPSHOT % {'image_id': guest_encrypted_image}
+
+    # Snapshot volumes.
+    mv_root_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda2'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT,
+        description=description
+    )
+    mv_grub_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda1'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT,
+        description=description
+    )
+    mv_log_snapshot = aws_service.create_snapshot(
+        bdm['/dev/sda3'].volume_id,
+        name=encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT,
+        description=description
+    )
+    log.info('waiting for snapshot ready')
+    encrypt_ami.wait_for_snapshots(
+        aws_service,
+        mv_root_snapshot.id,
+        mv_grub_snapshot.id,
+        mv_log_snapshot.id)
+    log.info('metavisor updater snapshots ready')
+    encrypt_ami.terminate_instance(
+        aws_service,
+        id=mv_instance.id,
+        name='encryptor',
+        terminated_instance_ids=set()
+    )
+    return {
+        encrypt_ami.NAME_METAVISOR_ROOT_SNAPSHOT: mv_root_snapshot,
+        encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT: mv_grub_snapshot,
+        encrypt_ami.NAME_METAVISOR_LOG_SNAPSHOT: mv_log_snapshot
+    }
+
+
+def retrieve_guest_volume_snapshot(aws_service,
+                                   encrypted_ami_id):
+    # Verify expected device mapping is present, return with info
+    encrypted_image = aws_service.get_image(encrypted_ami_id)
+    guest_volume_mapping = \
+        encrypted_image.block_device_mapping.get('/dev/sda5')
+    if not guest_volume_mapping:
+        return None, None,\
+            'Invalid block device mapping: /dev/sda5 not present'
+    # Need to recover the volume iops and size
+    volume_info = {'iops': guest_volume_mapping.iops,
+                   'size': guest_volume_mapping.size,
+                   'type': guest_volume_mapping.volume_type}
+    guest_volume_snapshot = aws_service.get_snapshot(
+        guest_volume_mapping.snapshot_id)
+    return guest_volume_snapshot, volume_info, None

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -1,0 +1,46 @@
+import argparse
+
+
+def setup_update_encrypted_ami(parser):
+    parser.add_argument(
+        'ami',
+        metavar='AMI_ID',
+        help='The AMI that will be encrypted'
+    )
+    parser.add_argument(
+        '--updater-ami',
+        metavar='UPDATER_AMI_ID',
+        help='The metavisor updater AMI that will be used',
+        dest='updater_ami',
+        required=True
+    )
+    parser.add_argument(
+        '--region',
+        metavar='REGION',
+        help='AWS region (e.g. us-west-2)',
+        dest='region',
+        default='us-west-2',
+        required=True
+    )
+    parser.add_argument(
+        '--encrypted-ami-name',
+        metavar='NAME',
+        dest='encrypted_ami_name',
+        help='Specify the name of the generated encrypted AMI',
+        required=False
+    )
+    parser.add_argument(
+        '--no-validate-ami',
+        dest='no_validate_ami',
+        action='store_true',
+        help="Don't validate encrypted AMI properties"
+    )
+    # Optional EC2 SSH key pair name to use for launching the snapshotter
+    # and encryptor instances.  This argument is hidden because it's only
+    # used for development.
+    parser.add_argument(
+        '--key',
+        metavar='KEY',
+        help=argparse.SUPPRESS,
+        dest='key_name'
+    )

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -11,17 +11,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import boto
+import sys
 import time
 import uuid
 
 
 class BracketError(Exception):
     pass
-
-
-def make_nonce():
-    """Returns a 32bit nonce in hex encoding"""
-    return str(uuid.uuid4()).split('-')[0]
 
 
 class Deadline(object):
@@ -38,3 +35,8 @@ class Deadline(object):
             True if the deadline has passed. False otherwise.
         """
         return self.clock.time() >= self.deadline
+
+
+def make_nonce():
+    """Returns a 32bit nonce in hex encoding"""
+    return str(uuid.uuid4()).split('-')[0]


### PR DESCRIPTION
This change adds the update-encrypted-ami option to the
brkt_cli. It allows a user to retrieve a metavisor
upgrader AMI and use it to upgrade an already encrypted
AMI. This provides a speed improvement for users who
wish to update their encrypted AMIs.

The user must specify the metavisor updater AMI as an
argument. This requirement will be taken away in a
near-future commit.