### PR TITLE
Refactor brkt_cli library to enable extension.

### DIFF
--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -18,11 +18,14 @@ import logging
 import re
 import urllib2
 
+ENCRYPT_DOWNLOADING = 'downloading'
+ENCRYPT_RUNNING = 'encrypting'
 ENCRYPT_SUCCESSFUL = 'finished'
 ENCRYPT_FAILED = 'failed'
 ENCRYPT_ENCRYPTING = 'encrypting'
 ENCRYPTOR_STATUS_PORT = 8000
 FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
+FAILURE_CODE_AWS_PERMISSIONS = 'insufficient_aws_permissions'
 
 log = logging.getLogger(__name__)
 
@@ -48,13 +51,14 @@ class EncryptorService(BaseEncryptorService):
     def is_encryptor_up(self):
         try:
             self.get_status()
+            log.debug("Successfully got encryptor status")
             return True
         except Exception as e:
             log.debug("Couldn't get encryptor status: %s", e)
             return False
 
     def get_status(self, timeout_secs=2):
-        url = 'http://%s:%d/encryption_status' % (self.hostname, self.port)
+        url = 'http://%s:%d' % (self.hostname, self.port)
         r = urllib2.urlopen(url, timeout=timeout_secs)
         data = r.read()
         info = json.loads(data)

--- a/test.py
+++ b/test.py
@@ -281,8 +281,8 @@ class TestEncryptedImageName(unittest.TestCase):
     def test_encrypted_image_suffix(self):
         """ Test that generated suffixes are unique.
         """
-        s1 = encrypt_ami._get_encrypted_suffix()
-        s2 = encrypt_ami._get_encrypted_suffix()
+        s1 = encrypt_ami.get_encrypted_suffix()
+        s2 = encrypt_ami.get_encrypted_suffix()
         self.assertNotEqual(s1, s2)
 
     def test_append_suffix(self):
@@ -290,14 +290,14 @@ class TestEncryptedImageName(unittest.TestCase):
         """
         name = 'Boogie nights are always the best in town'
         suffix = ' (except Tuesday)'
-        encrypted_name = encrypt_ami._append_suffix(
+        encrypted_name = encrypt_ami.append_suffix(
             name, suffix, max_length=128)
         self.assertTrue(encrypted_name.startswith(name))
         self.assertTrue(encrypted_name.endswith(suffix))
 
         # Make sure we truncate the original name when it's too long.
         name += ('X' * 100)
-        encrypted_name = encrypt_ami._append_suffix(
+        encrypted_name = encrypt_ami.append_suffix(
             name, suffix, max_length=128)
         self.assertEqual(128, len(encrypted_name))
         self.assertTrue(encrypted_name.startswith('Boogie nights'))
@@ -611,7 +611,7 @@ class TestInstance(unittest.TestCase):
         aws_svc, encryptor_image, guest_image = _build_aws_service()
         instance = aws_svc.run_instance(guest_image.id)
         aws_svc.terminate_instance(instance.id)
-        result = encrypt_ami._wait_for_instance(
+        result = encrypt_ami.wait_for_instance(
             aws_svc, instance.id, state='terminated', timeout=100)
         self.assertEquals(instance, result)
 
@@ -623,7 +623,7 @@ class TestInstance(unittest.TestCase):
         instance = aws_svc.run_instance(guest_image.id)
         instance._state.name = 'error'
         try:
-            encrypt_ami._wait_for_instance(aws_svc, instance.id, timeout=100)
+            encrypt_ami.wait_for_instance(aws_svc, instance.id, timeout=100)
         except encrypt_ami.InstanceError as e:
             self.assertTrue('error state' in e.message)
 
@@ -635,7 +635,7 @@ class TestInstance(unittest.TestCase):
         instance = aws_svc.run_instance(guest_image.id)
         aws_svc.terminate_instance(instance.id)
         try:
-            encrypt_ami._wait_for_instance(
+            encrypt_ami.wait_for_instance(
                 aws_svc, instance.id, state='running', timeout=100)
         except encrypt_ami.InstanceError as e:
             self.assertTrue('unexpectedly terminated' in e.message)


### PR DESCRIPTION
- aws_service instance launch now takes user-data and instance profile
name args.
- change inputs to register_new_ami()
- accept a new 'insufficient_permissions' failure code from the encryptor
- remove requests dependency (replaced with urllib2)
- rename some encrypt_ami functions to public (no underscore)