### PR TITLE
Specify subnet and security group for image encryption

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -42,7 +42,8 @@ class BaseAWSService(object):
                      image_id,
                      security_group_ids=None,
                      instance_type='m3.medium',
-                     block_device_map=None):
+                     block_device_map=None,
+                     subnet_id=None):
         pass
 
     @abc.abstractmethod
@@ -135,6 +136,10 @@ class BaseAWSService(object):
 
     @abc.abstractmethod
     def get_console_output(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def get_subnet(self, subnet_id):
         pass
 
 
@@ -230,17 +235,21 @@ class AWSService(BaseAWSService):
                      image_id,
                      security_group_ids=None,
                      instance_type='m3.medium',
-                     block_device_map=None):
+                     block_device_map=None,
+                     subnet_id=None):
         if security_group_ids is None:
             security_group_ids = []
         log.debug('Starting a new instance based on %s', image_id)
+        log.debug('Using security groups %s, subnet %s',
+                  security_group_ids, subnet_id)
         try:
             reservation = self.conn.run_instances(
                 image_id=image_id,
                 key_name=self.key_name,
                 instance_type=instance_type,
                 block_device_map=block_device_map,
-                security_group_ids=security_group_ids
+                security_group_ids=security_group_ids,
+                subnet_id=subnet_id
             )
             return reservation.instances[0]
         except EC2ResponseError:
@@ -388,10 +397,17 @@ class AWSService(BaseAWSService):
         sg = self.conn.create_security_group(name, description)
         return sg.id
 
-    @retry_boto(error_code_regexp=r'InvalidGroup\.NotFound')
-    def get_security_group(self, sg_id):
-        groups = self.conn.get_all_security_groups(group_ids=[sg_id])
-        return _get_first_element(groups, 'InvalidGroup.NotFound')
+    def get_security_group(self, sg_id, retry=True):
+        if retry:
+            @retry_boto(error_code_regexp=r'InvalidGroup\.NotFound')
+            def get_with_retry(sg_id):
+                groups = self.conn.get_all_security_groups(group_ids=[sg_id])
+                return _get_first_element(groups, 'InvalidGroup.NotFound')
+
+            get_with_retry(sg_id)
+        else:
+            groups = self.conn.get_all_security_groups(group_ids=[sg_id])
+            return _get_first_element(groups, 'InvalidGroup.NotFound')
 
     def add_security_group_rule(self, sg_id, **kwargs):
         kwargs['group_id'] = sg_id
@@ -410,6 +426,10 @@ class AWSService(BaseAWSService):
 
     def get_console_output(self, instance_id):
         return self.conn.get_console_output(instance_id)
+
+    def get_subnet(self, subnet_id):
+        subnets = self.conn.get_all_subnets(subnet_ids=[subnet_id])
+        return _get_first_element(subnets, 'InvalidSubnetID.NotFound')
 
 
 class ImageNameError(Exception):

--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -240,8 +240,12 @@ class AWSService(BaseAWSService):
         if security_group_ids is None:
             security_group_ids = []
         log.debug('Starting a new instance based on %s', image_id)
-        log.debug('Using security groups %s, subnet %s',
-                  security_group_ids, subnet_id)
+        if security_group_ids:
+            log.debug(
+                'Using security groups %s', ', '.join(security_group_ids))
+        if subnet_id:
+            log.debug('Running instance in %s', subnet_id)
+
         try:
             reservation = self.conn.run_instances(
                 image_id=image_id,

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -4,7 +4,7 @@ import argparse
 def setup_encrypt_ami_args(parser):
     parser.add_argument(
         'ami',
-        metavar='AMI_ID',
+        metavar='ID',
         help='The AMI that will be encrypted'
     )
     parser.add_argument(
@@ -32,6 +32,22 @@ def setup_encrypt_ami_args(parser):
         help='AWS region (e.g. us-west-2)',
         dest='region',
         required=True
+    )
+    parser.add_argument(
+        '--security-group',
+        metavar='ID',
+        dest='security_group_ids',
+        action='append',
+        help=(
+            'Use this security group when running the encryptor instance. '
+            'May be specified multiple times.'
+        )
+    )
+    parser.add_argument(
+        '--subnet',
+        metavar='ID',
+        dest='subnet_id',
+        help='Launch instances in this subnet'
     )
 
     # Optional AMI ID that's used to launch the encryptor instance.  This

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -1,12 +1,8 @@
-import boto
 import logging
-import sys
-import time
-from boto.exception import EC2ResponseError
 from brkt_cli import (
     encrypt_ami,
-    encryptor_service,
-    util)
+    encryptor_service
+)
 from brkt_cli.util import Deadline
 
 log = logging.getLogger(__name__)
@@ -26,7 +22,7 @@ def snapshot_updater_ami_block_devices(aws_service,
         guest_snapshot,
         volume_size,
         guest_encrypted_image,
-        sg_id,
+        security_group_ids=[sg_id],
         update_ami=True)
     host_ip = mv_instance.ip_address
     enc_svc = encryptor_service.EncryptorService(host_ip)
@@ -35,7 +31,7 @@ def snapshot_updater_ami_block_devices(aws_service,
     encrypt_ami.wait_for_encryptor_up(enc_svc, Deadline(600))
     try:
         encrypt_ami.wait_for_encryption(enc_svc)
-    except EncryptionError as e:
+    except encrypt_ami.EncryptionError as e:
         log.error(
             'Update failed.  Check console output of instance %s '
             'for details.',


### PR DESCRIPTION
Add --subnet and --security-group options to the encrypt-ami subcommand.
The subnet is used when running both the snapshotter and encryptor
instances.  The security groups are used when running the encryptor
instance.

Clean up the command line parsing code to check the subparser name
instead of referencing argv[0].  The old code broke when passing -v to
the brkt top-level command.