### PR TITLE
Create temporary security group in the same VPC as the subnet

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -115,11 +115,11 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def create_security_group(self, name, description):
+    def create_security_group(self, name, description, vpc_id=None):
         pass
 
     @abc.abstractmethod
-    def get_security_group(self, sg_id):
+    def get_security_group(self, sg_id, retry=False):
         pass
 
     @abc.abstractmethod
@@ -397,9 +397,15 @@ class AWSService(BaseAWSService):
     def delete_snapshot(self, snapshot_id):
         return self.conn.delete_snapshot(snapshot_id)
 
-    def create_security_group(self, name, description):
-        sg = self.conn.create_security_group(name, description)
-        return sg.id
+    def create_security_group(self, name, description, vpc_id=None):
+        log.debug(
+            'Creating security group: name=%s, description=%s',
+            name, description
+        )
+        if vpc_id:
+            log.debug('Using %s', vpc_id)
+
+        return self.conn.create_security_group(name, description, vpc_id=vpc_id)
 
     def get_security_group(self, sg_id, retry=True):
         if retry:

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -15,7 +15,7 @@ def snapshot_updater_ami_block_devices(aws_service,
                                        volume_size):
     # Retrieves the most recent updater AMI, launches it, snapshots
     # its volumes, returns the snapshots
-    sg_id = encrypt_ami.create_encryptor_security_group(aws_service)
+    sg_id = encrypt_ami.create_encryptor_security_group(aws_service).id
     mv_instance = encrypt_ami.run_encryptor_instance(
         aws_service,
         mv_updater_ami,


### PR DESCRIPTION
When a subnet is specified but security groups are not, create the
temporary security group in the VPC of the given subnet.  When both are
specified, make sure that they are in the same VPC.

Change the return type of create_security_group(), so that it returns an
object instead of an id.  This is consistent with the other create_xxx()
methods in AWSService.

Remove log level cruft from command_encrypt_ami().  We initialize
logging in main().