### PR TITLE
Adds brkt-env option

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -140,7 +140,8 @@ def command_encrypt_ami(values, log):
             encryptor_ami=encryptor_ami,
             encrypted_ami_name=values.encrypted_ami_name,
             subnet_id=values.subnet_id,
-            security_group_ids=values.security_group_ids
+            security_group_ids=values.security_group_ids,
+            brkt_env=values.brkt_env
         )
         # Print the AMI ID to stdout, in case the caller wants to process
         # the output.  Log messages go to stderr.
@@ -244,8 +245,8 @@ def command_update_encrypted_ami(values, log):
             encrypted_ami,
             updater_ami,
             guest_snapshot.id,
-            volume_info['size'])
-
+            volume_info['size'],
+            values.brkt_env)
     ami = encrypt_ami.register_new_ami(
         aws_svc,
         updater_ami_block_devices[encrypt_ami.NAME_METAVISOR_GRUB_SNAPSHOT],

--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -263,7 +263,7 @@ class AWSService(BaseAWSService):
                 instance_profile_name=instance_profile_name
             )
             return reservation.instances[0]
-        except EC2ResponseError as e:
+        except EC2ResponseError:
             log.debug('Failed to launch instance for %s', image_id)
             raise
 

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -50,6 +50,14 @@ def setup_encrypt_ami_args(parser):
         help='Launch instances in this subnet'
     )
 
+    # Optional yeti endpoints. Hidden because it's only used for development
+    parser.add_argument(
+        '--brkt-env',
+        default='prod',
+        dest='brkt_env',
+        help=argparse.SUPPRESS
+    )
+
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(

--- a/brkt_cli/update_encrypted_ami.py
+++ b/brkt_cli/update_encrypted_ami.py
@@ -12,7 +12,8 @@ def snapshot_updater_ami_block_devices(aws_service,
                                        guest_encrypted_image,
                                        mv_updater_ami,
                                        guest_snapshot,
-                                       volume_size):
+                                       volume_size,
+                                       brkt_env):
     # Retrieves the most recent updater AMI, launches it, snapshots
     # its volumes, returns the snapshots
     sg_id = encrypt_ami.create_encryptor_security_group(aws_service).id
@@ -22,6 +23,7 @@ def snapshot_updater_ami_block_devices(aws_service,
         guest_snapshot,
         volume_size,
         guest_encrypted_image,
+        brkt_env,
         security_group_ids=[sg_id],
         update_ami=True)
     host_ip = mv_instance.ip_address

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -35,6 +35,15 @@ def setup_update_encrypted_ami(parser):
         action='store_true',
         help="Don't validate encrypted AMI properties"
     )
+
+    # Optional yeti endpoints. Hidden because it's only used for development
+    parser.add_argument(
+        '--brkt-env',
+        default='prod',
+        dest='brkt_env',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
     # Optional EC2 SSH key pair name to use for launching the snapshotter
     # and encryptor instances.  This argument is hidden because it's only
     # used for development.

--- a/test.py
+++ b/test.py
@@ -97,6 +97,7 @@ class DummyAWSService(aws_service.BaseAWSService):
                      image_id,
                      security_group_ids=None,
                      instance_type='m3.medium',
+                     user_data="",
                      block_device_map=None,
                      subnet_id=None):
         instance = Instance()
@@ -349,6 +350,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
+            brkt_env="",
             encryptor_ami=encryptor_image.id
         )
         self.assertIsNotNone(encrypted_ami_id)
@@ -364,6 +366,7 @@ class TestRun(unittest.TestCase):
                 aws_svc=aws_svc,
                 enc_svc_cls=FailedEncryptionService,
                 image_id=guest_image.id,
+                brkt_env="",
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
@@ -386,6 +389,7 @@ class TestRun(unittest.TestCase):
                 aws_svc=aws_svc,
                 enc_svc_cls=FailedEncryptionService,
                 image_id=guest_image.id,
+                brkt_env="",
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
@@ -416,6 +420,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
+            brkt_env="",
             encryptor_ami=encryptor_image.id
         )
 
@@ -434,6 +439,7 @@ class TestRun(unittest.TestCase):
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
             encryptor_ami=encryptor_image.id,
+            brkt_env="",
             encrypted_ami_name=name
         )
         ami = aws_svc.get_image(image_id)
@@ -465,6 +471,7 @@ class TestRun(unittest.TestCase):
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
             encryptor_ami=encryptor_image.id,
+            brkt_env="",
             subnet_id='subnet-1',
             security_group_ids=['sg-1', 'sg-2']
         )
@@ -493,6 +500,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
+            brkt_env="",
             encryptor_ami=encryptor_image.id,
             subnet_id='subnet-1'
         )


### PR DESCRIPTION
Currently metavisors determine what yeti to
contact by reading an s3 bucket. The brkt-env
option will tell the encryptor what address to
write into the metavisor image.

Testing: launched encryptor instance and verified
userdata was set properly.