### PR TITLE
Fetch latest encryptor_instance data before use

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -775,6 +775,9 @@ def make_encrypted_ami(aws_svc, enc_svc_cls, encryptor_instance, encryptor_ami,
 
     log.info('Encrypted root drive is ready.')
 
+    # Making a get_instance call has the same underlying cost as boto's
+    # convenience update() method.
+    encryptor_instance = aws_svc.get_instance(encryptor_instance.id)
     bdm = encryptor_instance.block_device_mapping
 
     # Stop the encryptor instance.  Wait for it to stop before


### PR DESCRIPTION
The S3 encryptor version modifies the instance bdm post launch.
Once the encryptor instance is done running, update its local attributes
before reading them.