### PR TITLE
Remove default for brkt-env option

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -439,11 +439,14 @@ def tag_encryptor_volumes(aws_svc, instance, update_ami=False):
 
 
 def run_encryptor_instance(aws_svc, encryptor_image_id, snapshot, root_size,
-                           guest_image_id, brkt_env='prod', security_group_ids=None,
+                           guest_image_id, brkt_env=None, security_group_ids=None,
                            subnet_id=None, update_ami=False):
     bdm = BlockDeviceMapping()
     user_data = {}
-    user_data['brkt'] = {'yeti_endpoints':brkt_env}
+    if brkt_env:
+        endpoints = brkt_env.split(',')
+        user_data['brkt'] = {'api_host':endpoints[0]}
+        user_data['brkt'] = {'hsmproxy_host':endpoints[1]}
     guest_unencrypted_root = EBSBlockDeviceType(
         volume_type='gp2',
         snapshot_id=snapshot,
@@ -845,7 +848,7 @@ def make_encrypted_ami(aws_svc, enc_svc_cls, encryptor_instance, encryptor_ami,
     return ami_info
 
 
-def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env='prod',
+def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             encrypted_ami_name=None, subnet_id=None,
             security_group_ids=None):
     encryptor_instance = None

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -51,9 +51,11 @@ def setup_encrypt_ami_args(parser):
     )
 
     # Optional yeti endpoints. Hidden because it's only used for development
+    # if you're using this option, it should be passed as a comma separated list
+    # of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the endpoints
+    # must also be in order: api_host,hsmproxy_host
     parser.add_argument(
         '--brkt-env',
-        default='prod',
         dest='brkt_env',
         help=argparse.SUPPRESS
     )

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -39,9 +39,7 @@ def setup_update_encrypted_ami(parser):
     # Optional yeti endpoints. Hidden because it's only used for development
     parser.add_argument(
         '--brkt-env',
-        default='prod',
         dest='brkt_env',
-        action='store_true',
         help=argparse.SUPPRESS
     )
     # Optional EC2 SSH key pair name to use for launching the snapshotter

--- a/test.py
+++ b/test.py
@@ -350,7 +350,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env="",
+            brkt_env=None,
             encryptor_ami=encryptor_image.id
         )
         self.assertIsNotNone(encrypted_ami_id)
@@ -366,7 +366,7 @@ class TestRun(unittest.TestCase):
                 aws_svc=aws_svc,
                 enc_svc_cls=FailedEncryptionService,
                 image_id=guest_image.id,
-                brkt_env="",
+                brkt_env=None,
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
@@ -389,7 +389,7 @@ class TestRun(unittest.TestCase):
                 aws_svc=aws_svc,
                 enc_svc_cls=FailedEncryptionService,
                 image_id=guest_image.id,
-                brkt_env="",
+                brkt_env=None,
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
@@ -420,7 +420,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env="",
+            brkt_env=None,
             encryptor_ami=encryptor_image.id
         )
 
@@ -439,7 +439,7 @@ class TestRun(unittest.TestCase):
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
             encryptor_ami=encryptor_image.id,
-            brkt_env="",
+            brkt_env=None,
             encrypted_ami_name=name
         )
         ami = aws_svc.get_image(image_id)
@@ -471,7 +471,7 @@ class TestRun(unittest.TestCase):
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
             encryptor_ami=encryptor_image.id,
-            brkt_env="",
+            brkt_env=None,
             subnet_id='subnet-1',
             security_group_ids=['sg-1', 'sg-2']
         )
@@ -500,7 +500,7 @@ class TestRun(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env="",
+            brkt_env=None,
             encryptor_ami=encryptor_image.id,
             subnet_id='subnet-1'
         )


### PR DESCRIPTION
Brkt-env now defaults to an empty string
instead of 'prod'. The MV will use s3 if
an empty string is passed.