### PR TITLE
Update update-encrypted-ami usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,17 @@ optional arguments:
 ```
 ```
 $ brkt update-encrypted-ami --help
-usage: brkt update-encrypted-ami [-h] --updater-ami UPDATER_AMI_ID --region
-                                 REGION [--encrypted-ami-name NAME]
+usage: brkt update-encrypted-ami [-h] --updater-ami ID --region REGION
+                                 [--encrypted-ami-name NAME]
                                  [--no-validate-ami]
-                                 AMI_ID
+                                 ID
 
 positional arguments:
-  AMI_ID                The AMI that will be encrypted
+  ID                    The AMI that will be encrypted
 
 optional arguments:
   -h, --help            show this help message and exit
-  --updater-ami UPDATER_AMI_ID
-                        The metavisor updater AMI that will be used
+  --updater-ami ID      The metavisor updater AMI that will be used
   --region REGION       AWS region (e.g. us-west-2)
   --encrypted-ami-name NAME
                         Specify the name of the generated encrypted AMI

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -4,12 +4,12 @@ import argparse
 def setup_update_encrypted_ami(parser):
     parser.add_argument(
         'ami',
-        metavar='AMI_ID',
+        metavar='ID',
         help='The AMI that will be encrypted'
     )
     parser.add_argument(
         '--updater-ami',
-        metavar='UPDATER_AMI_ID',
+        metavar='ID',
         help='The metavisor updater AMI that will be used',
         dest='updater_ami',
         required=True


### PR DESCRIPTION
Use "ID" instead of AMI_ID, UPDATER_AMI_ID to be consistent with the
usage of encrypt-ami.