### PR TITLE
Make sure we refresh instance state after waitng for instance to stop

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -553,6 +553,7 @@ def _snapshot_root_volume(aws_svc, instance, image_id):
     wait_for_instance(aws_svc, instance.id, state='stopped')
 
     # Snapshot root volume.
+    instance = aws_svc.get_instance(instance.id)
     root_dev = instance.root_device_name
     bdm = instance.block_device_mapping
 


### PR DESCRIPTION
Otherwise the block device mapping shows up as {} and we get a key
error with '/dev/xvda' when snapshotting the root volume