### PR TITLE
Improve security group validation, add --no-validate option

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -183,6 +183,10 @@ class BaseAWSService(object):
     def attach_volume(self, vol_id, instance_id, device):
         pass
 
+    @abc.abstractmethod
+    def get_default_vpc(self):
+        pass
+
 
 def retry_boto(error_code_regexp, max_retries=5, initial_sleep_seconds=0.25):
     """ Call a boto function repeatedly until it succeeds.  If the call
@@ -528,6 +532,12 @@ class AWSService(BaseAWSService):
     @retry_boto(error_code_regexp=r'VolumeInUse')
     def attach_volume(self, vol_id, instance_id, device):
         return self.conn.attach_volume(vol_id, instance_id, device)
+
+    def get_default_vpc(self):
+        vpcs = self.conn.get_all_vpcs(filters={'is-default': 'true'})
+        if len(vpcs) > 0:
+            return vpcs[0]
+        return None
 
 
 class ImageNameError(Exception):

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -15,16 +15,11 @@ def setup_encrypt_ami_args(parser):
         required=False
     )
     parser.add_argument(
-        '--validate-ami',
-        dest='no_validate_ami',
-        action='store_true',
-        help="Validate AMI properties (default)"
-    )
-    parser.add_argument(
-        '--no-validate-ami',
-        dest='no_validate_ami',
+        '--no-validate',
+        dest='validate',
         action='store_false',
-        help="Don't validate AMI properties"
+        default=True,
+        help="Don't validate AMIs, subnet, and security groups"
     )
     parser.add_argument(
         '--region',
@@ -50,8 +45,8 @@ def setup_encrypt_ami_args(parser):
         help='Launch instances in this subnet'
     )
 
-    # Optional yeti endpoints. Hidden because it's only used for development
-    # if you're using this option, it should be passed as a comma separated
+    # Optional yeti endpoints. Hidden because it's only used for development.
+    # If you're using this option, it should be passed as a comma separated
     # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
     # endpoints must also be in order: api_host,hsmproxy_host
     parser.add_argument(
@@ -77,4 +72,19 @@ def setup_encrypt_ami_args(parser):
         metavar='NAME',
         help=argparse.SUPPRESS,
         dest='key_name'
+    )
+
+    # These options were deprecated in 0.9.9. Keep them hidden for a while,
+    # to maintain backward compatibility.
+    parser.add_argument(
+        '--validate-ami',
+        dest='validate_ami',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        '--no-validate-ami',
+        dest='no_validate_ami',
+        action='store_true',
+        help=argparse.SUPPRESS
     )

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -15,10 +15,11 @@ def setup_update_encrypted_ami(parser):
         required=False
     )
     parser.add_argument(
-        '--no-validate-ami',
-        dest='no_validate_ami',
-        action='store_true',
-        help="Don't validate encrypted AMI properties"
+        '--no-validate',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate AMIs, subnet, and security groups"
     )
     parser.add_argument(
         '--region',
@@ -52,7 +53,7 @@ def setup_update_encrypted_ami(parser):
         required=True
     )
 
-    # Optional yeti endpoints. Hidden because it's only used for development
+    # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(
         '--brkt-env',
         dest='brkt_env',
@@ -66,4 +67,19 @@ def setup_update_encrypted_ami(parser):
         metavar='KEY',
         help=argparse.SUPPRESS,
         dest='key_name'
+    )
+
+    # These options were deprecated in 0.9.9. Keep them hidden for a while,
+    # to maintain backward compatibility.
+    parser.add_argument(
+        '--validate-ami',
+        dest='validate_ami',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        '--no-validate-ami',
+        dest='no_validate_ami',
+        action='store_true',
+        help=argparse.SUPPRESS
     )

--- a/reference_templates/brkt-cli-iam-permissions.json
+++ b/reference_templates/brkt-cli-iam-permissions.json
@@ -25,6 +25,7 @@
                 "ec2:DescribeSnapshots",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVolumes",
+                "ec2:DescribeVpcs",
                 "ec2:GetConsoleOutput",
                 "ec2:RegisterImage",
                 "ec2:RunInstances",


### PR DESCRIPTION
When the subnet isn't specified, make sure that the specified security
groups are in the default VPC.  Add a get_default_vpc() method to
AWSService.

Replace the --validate-ami and --no-validate-ami options with a new
--no-validate option that controls validation of AMIs, subnets, and
security groups.  Hide the old options for the short term so that we
don't break backward compatibility.

Add support for a default VPC to the test framework.  Create test
security groups in that VPC when the VPC id is not specified.