### PR TITLE
Metavisor requires the root disk to be attached at "/dev/sda1".

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -972,6 +972,10 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             log.warn("AMI must have root_device_name in block_device_mapping "
                     "in order to preserve guest OS license information")
             legacy = True
+    if (guest_image.root_device_name != "/dev/sda1"):
+        log.warn("The root device for the guest AMI should be /dev/sda1 "
+                 "in order to preserve guest OS license information")
+        legacy = True
     try:
         guest_instance = run_guest_instance(aws_svc,
             image_id, subnet_id=subnet_id)


### PR DESCRIPTION
If the guest AMI's root disk is attached at at different
attach-point, then treat as legacy mode which will use
the metavisor instance to create the AMI instead of the guest
instance. However, for such AMIs, the guest license information
will be lost.

Testing.
Works for Centos 7.1 AMI ami-7bc3f94b which attaches root disk
at /dev/sda.