### PR TITLE
Remove --validate-ami and --no-validate-ami options

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -313,20 +313,6 @@ def main():
     aws_service.log.setLevel(log_level)
     encryptor_service.log.setLevel(log_level)
 
-    if values.validate_ami:
-        print(
-            'The --validate-ami option has been replaced with --no-validate. '
-            'It will be removed in a future release.', file=sys.stderr
-        )
-        values.validate = True
-
-    if values.no_validate_ami:
-        print(
-            'The --validate-ami option has been replaced with --no-validate. '
-            'It will be removed in a future release.', file=sys.stderr
-        )
-        values.validate = False
-
     try:
         if values.subparser_name == 'encrypt-ami':
             return command_encrypt_ami(values, log)

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -83,18 +83,3 @@ def setup_encrypt_ami_args(parser):
         help=argparse.SUPPRESS,
         dest='key_name'
     )
-
-    # These options were deprecated in 0.9.10. Keep them hidden for a while,
-    # to maintain backward compatibility.
-    parser.add_argument(
-        '--validate-ami',
-        dest='validate_ami',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
-    parser.add_argument(
-        '--no-validate-ami',
-        dest='no_validate_ami',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -81,18 +81,3 @@ def setup_update_encrypted_ami(parser):
         help=argparse.SUPPRESS,
         dest='encryptor_ami'
     )
-
-    # These options were deprecated in 0.9.10. Keep them hidden for a while,
-    # to maintain backward compatibility.
-    parser.add_argument(
-        '--validate-ami',
-        dest='validate_ami',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
-    parser.add_argument(
-        '--no-validate-ami',
-        dest='no_validate_ami',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )


### PR DESCRIPTION
Remove options that were deprecated in 0.9.10.