### PR TITLE
Don't attempt to encrypt an already encrypted image

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -909,7 +909,7 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
     log.info('Registered AMI %s based on the snapshots.', ami)
     wait_for_image(aws_svc, ami)
-    image = aws_svc.get_image(ami)
+    image = aws_svc.get_image(ami, retry=True)
     if encryptor_image.virtualization_type == 'paravirtual':
         name = NAME_METAVISOR_GRUB_SNAPSHOT
     else:
@@ -924,7 +924,7 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
     ami_info = {}
     ami_info['volume_device_map'] = []
-    result_image = aws_svc.get_image(ami)
+    result_image = aws_svc.get_image(ami, retry=True)
     for attach_point, bdt in result_image.block_device_mapping.iteritems():
         if bdt.snapshot_id:
             bdt_snapshot = aws_svc.get_snapshot(bdt.snapshot_id)

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -213,7 +213,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             block_device_mapping=guest_bdm
         )
         wait_for_image(aws_svc, ami)
-        image = aws_svc.get_image(ami)
+        image = aws_svc.get_image(ami, retry=True)
         aws_svc.create_tags(
             image.block_device_mapping[root_device_name].snapshot_id,
             name=boot_snap_name,


### PR DESCRIPTION
When checking the guest AMI, fail validation if we find tags that were
created during image encryption.

Refactor the validation code, so that it's more testable.  Move
validation logic out of AWSService and into brkt_cli.  This thins out
the AWSService implementation, and ensures that the validation logic
gets unit tested.

Add switchable retry logic to AWSService.get_image(), so that we don't
retry the operation for AMIs specified on the command line.  These AMIs
were created long enough ago that retry is not necessary.