### PR TITLE
Check Python version during setup

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -309,17 +309,6 @@ def command_update_encrypted_ami(values, log):
 
 
 def main():
-    # Check Python version.
-    version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
-    if version != '2.7':
-        print(
-            'brkt-cli requires Python 2.7.  Version',
-            version,
-            'is not supported.',
-            file=sys.stderr
-        )
-        return 1
-
     parser = argparse.ArgumentParser(
         description='Command-line interface to the Bracket Computing service.'
     )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@
 
 import re
 from setuptools import setup
+import sys
+
+# Check Python version.
+python_version = '%d.%d' % (sys.version_info[0], sys.version_info[1])
+if python_version != '2.7':
+    sys.exit(
+        'brkt-cli requires Python 2.7.  Version %s is not supported.' %
+        python_version)
 
 version = ''
 with open('brkt_cli/__init__.py', 'r') as fd:


### PR DESCRIPTION
    Checking inside main() was too late in the process.  Setup would fail on
    Python 2.6 because it couldn't load version 2.7.0 of the requests
    library.
