### PR TITLE
Disable sriov support.

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -188,6 +188,10 @@ class BaseAWSService(object):
     def get_default_vpc(self):
         pass
 
+    @abc.abstractmethod
+    def get_instance_attribute(self, instance_id, attribute, dry_run=False):
+        pass
+
 
 def retry_boto(error_code_regexp, max_retries=5, initial_sleep_seconds=0.25):
     """ Call a boto function repeatedly until it succeeds.  If the call
@@ -539,6 +543,11 @@ class AWSService(BaseAWSService):
         if len(vpcs) > 0:
             return vpcs[0]
         return None
+
+    def get_instance_attribute(self, instance_id, attribute, dry_run=False):
+        return self.conn.get_instance_attribute(instance_id,
+                                                attribute,
+                                                dry_run=dry_run)
 
 
 def validate_image_name(name):

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -50,6 +50,7 @@ from boto.ec2.blockdevicemapping import (
     BlockDeviceMapping,
     EBSBlockDeviceType,
 )
+from boto.ec2.instance import InstanceAttribute
 
 from brkt_cli import encryptor_service
 from brkt_cli.util import (
@@ -861,7 +862,8 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
         guest_id = encryptor_instance.id
         # Explicitly detach/delete all but root drive
         bdm = encryptor_instance.block_device_mapping
-        for d in ['/dev/sda2', '/dev/sda3', '/dev/sda4', '/dev/sda5']:
+        for d in ['/dev/sda2', '/dev/sda3', '/dev/sda4',
+                  '/dev/sda5', '/dev/sdf', '/dev/sdg']:
             if not bdm.get(d):
                 continue
             aws_svc.detach_volume(
@@ -983,6 +985,19 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
         snapshot_id, root_dev, size, vol_type, iops = _snapshot_root_volume(
             aws_svc, guest_instance, image_id
         )
+
+        if 'sriovNetSupport' not in InstanceAttribute.ValidValues:
+            log.warn("boto out of date: Added sriovNetSupport to valid "
+                     "values of instance attribute")
+            InstanceAttribute.ValidValues.append('sriovNetSupport')
+
+        net_sriov_attr = aws_svc.get_instance_attribute(guest_instance.id,
+                                                        "sriovNetSupport")
+        if (net_sriov_attr.get("sriovNetSupport") == "simple"):
+            log.warn("Guest Operating System license information will not be "
+                     "preserved because guest has sriovNetSupport enabled and "
+                     "metavisor does not have sriovNet support")
+            legacy = True
 
         if not security_group_ids:
             vpc_id = None


### PR DESCRIPTION
1. Metavisor does not support sriov. So, if guest instance has sriov 
support, then use legacy mode to create the encrypted ami.
2. Fix the HVM legacy path by removing the unencrypted and encrypted
guests disks from the encryptor instance.