### PR TITLE
Allow customers to configure use of their own NTP servers in metavisor.

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -191,7 +191,8 @@ def command_encrypt_ami(values, log):
         encrypted_ami_name=values.encrypted_ami_name,
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
-        brkt_env=values.brkt_env
+        brkt_env=values.brkt_env,
+        ntp_server=values.ntp_server
     )
     # Print the AMI ID to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
@@ -307,7 +308,8 @@ def command_update_encrypted_ami(values, log):
     updated_ami_id = update_ami(
         aws_svc, encrypted_ami, encryptor_ami, encrypted_ami_name,
         subnet_id=values.subnet_id,
-        security_group_ids=values.security_group_ids)
+        security_group_ids=values.security_group_ids,
+        ntp_server=values.ntp_server)
     print(updated_ami_id)
     return 0
 

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -471,7 +471,7 @@ def create_encryptor_security_group(aws_svc, vpc_id=None):
 def run_encryptor_instance(aws_svc, encryptor_image_id,
            snapshot, root_size,
            guest_image_id, brkt_env=None, security_group_ids=None,
-           subnet_id=None, zone=None):
+           subnet_id=None, zone=None, ntp_server=None):
     bdm = BlockDeviceMapping()
     user_data = {}
     if brkt_env:
@@ -480,6 +480,9 @@ def run_encryptor_instance(aws_svc, encryptor_image_id,
             'api_host': endpoints[0],
             'hsmproxy_host': endpoints[1],
         }
+
+    if ntp_server:
+        user_data['ntp-server'] = ntp_server
 
     image = aws_svc.get_image(encryptor_image_id)
     virtualization_type = image.virtualization_type
@@ -953,7 +956,8 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
 
 def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
-            encrypted_ami_name=None, subnet_id=None, security_group_ids=None):
+            encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
+            ntp_server=None):
     encryptor_instance = None
     ami = None
     snapshot_id = None
@@ -1025,6 +1029,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             security_group_ids=security_group_ids,
             subnet_id=subnet_id,
             zone=guest_instance.placement,
+            ntp_server=ntp_server,
         )
 
 

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -54,6 +54,15 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_server',
+        action='append',
+        help=(
+            'NTP server to sync Metavisor clock.'
+        )
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -54,7 +54,8 @@ log = logging.getLogger(__name__)
 
 def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
-               enc_svc_class=encryptor_service.EncryptorService):
+               enc_svc_class=encryptor_service.EncryptorService,
+               ntp_server=None):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -68,7 +69,10 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
-        user_data = json.dumps({'brkt': {'solo_mode': 'updater'}})
+        user_data = {'brkt': {'solo_mode': 'updater'}}
+        if ntp_server:
+            user_data['ntp-server'] = ntp_server
+        user_data = json.dumps(user_data)
 
         if not security_group_ids:
             vpc_id = None

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -45,6 +45,15 @@ def setup_update_encrypted_ami(parser):
         dest='subnet_id',
         help='Launch instances in this subnet'
     )
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_server',
+        action='append',
+        help=(
+            'NTP server to sync Metavisor clock.'
+        )
+    )
     # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(
         '--brkt-env',


### PR DESCRIPTION
Adding ntp-server, a brkt-cli option to allow customers to override
the default NTP server in ntp configuration of metavisor.
This option is supported for both encryption and update process.
ntp-server is provided as user-data to the encryptor/updater instance.