### PR TITLE
Allow customers to configure use of their own NTP servers in metavisor.

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -93,6 +93,32 @@ def _validate_subnet_and_security_groups(aws_svc,
                 )
 
 
+def _validate_dns_name_ip_address(hostname):
+    """ Verifies that the input hostname is indeed a valid
+    host name or ip address
+
+    :return True if valid, returns False otherwise
+    """
+    # ensure length does not exceed 255 characters
+    if (len(hostname) > 255):
+        return False
+    # remove the last dot from the end
+    if (hostname[-1] == "."):
+        hostname = hostname[:-1]
+    valid = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(valid.match(x) for x in hostname.split("."))
+
+
+def _validate_ntp_servers(ntp_servers):
+    if ntp_servers is None:
+        return
+    for server in ntp_servers:
+        if (_validate_dns_name_ip_address(server) is False):
+            raise ValidationError(
+                'Invalid ntp-server %s configured. '
+                'Should be either a host name or an IPv4 address' % server)
+
+
 def _validate_region(aws_svc, region):
     """ Return the region specified on the command line.
 
@@ -175,6 +201,7 @@ def command_encrypt_ami(values, log):
     default_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
     default_tags.update(_parse_tags(values.tags))
     aws_svc.default_tags = default_tags
+    _validate_ntp_servers(values.ntp_servers)
 
     _connect_and_validate(aws_svc, values, encryptor_ami)
     error_msg = _validate_guest_ami(aws_svc, values.ami)
@@ -191,7 +218,8 @@ def command_encrypt_ami(values, log):
         encrypted_ami_name=values.encrypted_ami_name,
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
-        brkt_env=values.brkt_env
+        brkt_env=values.brkt_env,
+        ntp_servers=values.ntp_servers
     )
     # Print the AMI ID to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
@@ -270,6 +298,7 @@ def command_update_encrypted_ami(values, log):
     default_tags.update(_parse_tags(values.tags))
     aws_svc.default_tags = default_tags
 
+    _validate_ntp_servers(values.ntp_servers)
     _connect_and_validate(aws_svc, values, encryptor_ami)
 
     encrypted_ami = values.ami
@@ -307,7 +336,8 @@ def command_update_encrypted_ami(values, log):
     updated_ami_id = update_ami(
         aws_svc, encrypted_ami, encryptor_ami, encrypted_ami_name,
         subnet_id=values.subnet_id,
-        security_group_ids=values.security_group_ids)
+        security_group_ids=values.security_group_ids,
+        ntp_servers=values.ntp_servers)
     print(updated_ami_id)
     return 0
 

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -54,6 +54,16 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
+    # Optional NTP server to sync Metavisor clock.
+    # May be specified multiple times.
+    # Hidden because currently used only for development.
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_servers',
+        action='append',
+        help=argparse.SUPPRESS
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -26,6 +26,7 @@ ENCRYPT_ENCRYPTING = 'encrypting'
 ENCRYPTOR_STATUS_PORT = 8000
 FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
 FAILURE_CODE_AWS_PERMISSIONS = 'insufficient_aws_permissions'
+FAILURE_CODE_INVALID_NTP_SERVERS = 'invalid ntp servers'
 
 log = logging.getLogger(__name__)
 
@@ -93,6 +94,8 @@ class EncryptorService(BaseEncryptorService):
             info['percent_complete'] = 0
             if info['state'] == ENCRYPT_SUCCESSFUL:
                 info['percent_complete'] = 100
+            elif info['state'] == ENCRYPT_FAILED:
+                info['percent_complete'] = 0
             elif info['bytes_total'] > 0:
                 ratio = float(info['bytes_written']) / info['bytes_total']
                 info['percent_complete'] = int(100 * ratio)

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -54,7 +54,8 @@ log = logging.getLogger(__name__)
 
 def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
-               enc_svc_class=encryptor_service.EncryptorService):
+               enc_svc_class=encryptor_service.EncryptorService,
+               ntp_servers=None):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -68,7 +69,10 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
-        user_data = json.dumps({'brkt': {'solo_mode': 'updater'}})
+        user_data = {'brkt': {'solo_mode': 'updater'}}
+        if ntp_servers:
+            user_data['ntp-servers'] = ntp_servers
+        user_data = json.dumps(user_data)
 
         if not security_group_ids:
             vpc_id = None

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -45,6 +45,16 @@ def setup_update_encrypted_ami(parser):
         dest='subnet_id',
         help='Launch instances in this subnet'
     )
+    # Optional NTP server to sync Metavisor clock.
+    # May be specified multiple times.
+    # Hidden because currently used only for development.
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_servers',
+        action='append',
+        help=argparse.SUPPRESS
+    )
     # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(
         '--brkt-env',


### PR DESCRIPTION
Adding ntp-server, a brkt-cli option to allow customers to override
the default NTP server in ntp configuration of metavisor.
This option is supported for both encryption and update process.
ntp-server is provided as user-data to the encryptor/updater instance.
Error out if ntp-server is not a valid host name or ipv4 address.
Finally, handle errors reported by the Bracket Updater instance.