### PR TITLE
Fix links to license file

### DIFF
--- a/brkt
+++ b/brkt
@@ -6,7 +6,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/brkt_cli/validation.py
+++ b/brkt_cli/validation.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/test.py
+++ b/test.py
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # A copy of the License is located at
 #
-# https://github.com/brkt/brkt-sdk-java/blob/master/LICENSE
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR


### PR DESCRIPTION
Update all of the license blocks to reference the LICENSE file in brkt-
cli.  They incorrectly referenced the LICENSE file in the Bracket Java
SDK.