### PR TITLE
Allow customers to configure use of their own NTP servers in metavisor.

### DIFF
--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -54,6 +54,16 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
+    # Optional NTP server to sync Metavisor clock.
+    # May be specified multiple times.
+    # Hidden because currently used only for development.
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_servers',
+        action='append',
+        help=argparse.SUPPRESS
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -26,6 +26,7 @@ ENCRYPT_ENCRYPTING = 'encrypting'
 ENCRYPTOR_STATUS_PORT = 8000
 FAILURE_CODE_UNSUPPORTED_GUEST = 'unsupported_guest'
 FAILURE_CODE_AWS_PERMISSIONS = 'insufficient_aws_permissions'
+FAILURE_CODE_INVALID_NTP_SERVERS = 'invalid_ntp_servers'
 
 log = logging.getLogger(__name__)
 
@@ -91,9 +92,11 @@ class EncryptorService(BaseEncryptorService):
 
             info = json.loads(data)
             info['percent_complete'] = 0
+            bytes_total = info.get('bytes_total')
             if info['state'] == ENCRYPT_SUCCESSFUL:
                 info['percent_complete'] = 100
-            elif info['bytes_total'] > 0:
+            elif ((bytes_total is not None) and
+                  (bytes_total > 0)):
                 ratio = float(info['bytes_written']) / info['bytes_total']
                 info['percent_complete'] = int(100 * ratio)
             successful_hostname = hostname

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -54,7 +54,8 @@ log = logging.getLogger(__name__)
 
 def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
-               enc_svc_class=encryptor_service.EncryptorService):
+               enc_svc_class=encryptor_service.EncryptorService,
+               ntp_servers=None):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -68,7 +69,10 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
-        user_data = json.dumps({'brkt': {'solo_mode': 'updater'}})
+        user_data = {'brkt': {'solo_mode': 'updater'}}
+        if ntp_servers:
+            user_data['ntp-servers'] = ntp_servers
+        user_data = json.dumps(user_data)
 
         if not security_group_ids:
             vpc_id = None

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -45,6 +45,16 @@ def setup_update_encrypted_ami(parser):
         dest='subnet_id',
         help='Launch instances in this subnet'
     )
+    # Optional NTP server to sync Metavisor clock.
+    # May be specified multiple times.
+    # Hidden because currently used only for development.
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_servers',
+        action='append',
+        help=argparse.SUPPRESS
+    )
     # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(
         '--brkt-env',

--- a/test.py
+++ b/test.py
@@ -943,6 +943,29 @@ class TestValidation(unittest.TestCase):
         self.assertTrue(
             'encrypted' in brkt_cli._validate_guest_ami(aws_svc, id))
 
+    def test_detect_valid_ntp_server(self):
+        """ Test that we allow only valid host names or IPv4 addresses to
+            to be configured as ntp servers.
+        """
+
+        # first test a valid collection of host names/IPv4 addresses
+        ntp_servers = ["0.netbsd.pool.ntp.org", "10.10.10.1",
+                       "ec2-52-36-60-215.us-west-2.compute.amazonaws.com",
+                       "abc.com."]
+        brkt_cli._validate_ntp_servers(ntp_servers)
+
+        # test invalid host name is rejected
+        ntp_servers = ["ec2_52_36_60_215.us-west-2.compute.amazonaws.com"]
+        with self.assertRaises(ValidationError):
+            brkt_cli._validate_ntp_servers(ntp_servers)
+
+        # test IPv6 address is rejected
+        ntp_servers = ["2001:db8:a0b:12f0::1"]
+        with self.assertRaises(ValidationError):
+            brkt_cli._validate_ntp_servers(ntp_servers)
+        ntp_servers = ["2001:0db8:0a0b:12f0:0001:0001:0001:0001"]
+        with self.assertRaises(ValidationError):
+            brkt_cli._validate_ntp_servers(ntp_servers)
 
 class TestEncryptAMIBackwardsCompatibility(unittest.TestCase):
 


### PR DESCRIPTION
Adding ntp-server, a brkt-cli option to allow customers to override
the default NTP server in ntp configuration of metavisor.
This option is supported for both encryption and update process.
ntp-server is provided as user-data to the encryptor/updater instance.
Error out if ntp-server is not a valid host name or ipv4 address.
Finally, handle errors reported by the Bracket Updater instance.