### PR TITLE
Pass --brkt-env value when updating AMI

### DIFF
--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -281,6 +281,8 @@ class AWSService(BaseAWSService):
                 'Using security groups %s', ', '.join(security_group_ids))
         if subnet_id:
             log.debug('Running instance in %s', subnet_id)
+        if user_data:
+            log.debug('User data: %s', user_data)
 
         try:
             reservation = self.conn.run_instances(

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -139,6 +139,22 @@ class InstanceError(BracketError):
     pass
 
 
+class BracketEnvironment(object):
+    def __init__(self):
+        self.api_host = None
+        self.api_port = None
+        self.hsmproxy_host = None
+        self.hsmproxy_port = None
+
+    def __repr__(self):
+        return '<BracketEnvironment api=%s:%d, hsmproxy=%s:%d>' % (
+            self.api_host,
+            self.api_port,
+            self.hsmproxy_host,
+            self.hsmproxy_port
+        )
+
+
 def get_default_tags(session_id, encryptor_ami):
     default_tags = {
         TAG_ENCRYPTOR: True,
@@ -483,10 +499,12 @@ def run_encryptor_instance(aws_svc, encryptor_image_id,
     bdm = BlockDeviceMapping()
     user_data = {}
     if brkt_env:
-        endpoints = brkt_env.split(',')
+        api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
+        hsmproxy_host_port = '%s:%d' % (
+            brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
         user_data['brkt'] = {
-            'api_host': endpoints[0],
-            'hsmproxy_host': endpoints[1],
+            'api_host': api_host_port,
+            'hsmproxy_host': hsmproxy_host_port
         }
 
     if ntp_servers:

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -11,6 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import re
 import time
 import uuid
 
@@ -38,3 +39,19 @@ class Deadline(object):
 def make_nonce():
     """Returns a 32bit nonce in hex encoding"""
     return str(uuid.uuid4()).split('-')[0]
+
+
+def validate_dns_name_ip_address(hostname):
+    """ Verifies that the input hostname is indeed a valid
+    host name or ip address
+
+    :return True if valid, returns False otherwise
+    """
+    # ensure length does not exceed 255 characters
+    if len(hostname) > 255:
+        return False
+    # remove the last dot from the end
+    if hostname[-1] == ".":
+        hostname = hostname[:-1]
+    valid = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(valid.match(x) for x in hostname.split("."))

--- a/test.py
+++ b/test.py
@@ -652,7 +652,30 @@ class TestRunEncryption(unittest.TestCase):
 
         self.assertTrue(self.terminate_instance_called)
 
-    def test_brkt_env(self):
+
+class TestBrktEnv(unittest.TestCase):
+
+    def setUp(self):
+        encrypt_ami.SLEEP_ENABLED = False
+
+    def test_parse_brkt_env(self):
+        """ Test parsing of the command-line --brkt-env value.
+        """
+        be = brkt_cli._parse_brkt_env(
+            'api.example.com:777,hsmproxy.example.com:888')
+        self.assertEqual('api.example.com', be.api_host)
+        self.assertEqual(777, be.api_port)
+        self.assertEqual('hsmproxy.example.com', be.hsmproxy_host)
+        self.assertEqual(888, be.hsmproxy_port)
+
+        with self.assertRaises(ValidationError):
+            brkt_cli._parse_brkt_env('a')
+        with self.assertRaises(ValidationError):
+            brkt_cli._parse_brkt_env('a:7,b:8:9')
+        with self.assertRaises(ValidationError):
+            brkt_cli._parse_brkt_env('a:7,b?:8')
+
+    def test_brkt_env_encrypt(self):
         """ Test that we parse the brkt_env value and pass the correct
         values to user_data when launching the encryptor instance.
         """
@@ -673,12 +696,14 @@ class TestRunEncryption(unittest.TestCase):
                     d['brkt']['hsmproxy_host']
                 )
 
+        brkt_env = brkt_cli._parse_brkt_env(
+            api_host_port + ',' + hsmproxy_host_port)
         aws_svc.run_instance_callback = run_instance_callback
         encrypt_ami.encrypt(
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env=api_host_port + ',' + hsmproxy_host_port,
+            brkt_env=brkt_env,
             encryptor_ami=encryptor_image.id
         )
 
@@ -693,7 +718,6 @@ class TestRunUpdate(unittest.TestCase):
         to run_instance().
         """
         aws_svc, encryptor_image, guest_image = _build_aws_service()
-        encrypt_ami.SLEEP_ENABLED = False
         encrypted_ami_id = encrypt_ami.encrypt(
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
@@ -718,6 +742,42 @@ class TestRunUpdate(unittest.TestCase):
 
         self.assertEqual(2, self.call_count)
         self.assertIsNotNone(ami_id)
+
+    def test_brkt_env_update(self):
+        """ Test that the Bracket environment is through to metavisor user
+        data.
+        """
+        aws_svc, encryptor_image, guest_image = _build_aws_service()
+        encrypted_ami_id = encrypt_ami.encrypt(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id
+        )
+
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        brkt_env = brkt_cli._parse_brkt_env(
+            api_host_port + ',' + hsmproxy_host_port)
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                d = json.loads(args.user_data)
+                self.assertEquals(
+                    api_host_port,
+                    d['brkt']['api_host']
+                )
+                self.assertEquals(
+                    hsmproxy_host_port,
+                    d['brkt']['hsmproxy_host']
+                )
+
+        aws_svc.run_instance_callback = run_instance_callback
+        update_ami(
+            aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
+            enc_svc_class=DummyEncryptorService,
+            brkt_env=brkt_env
+        )
 
 
 class ExpiredDeadline(object):


### PR DESCRIPTION
Parse the --brkt-env value and add it to userdata when updating an
encrypted AMI.  Break out the --brkt-env parsing logic into a separate.
Pass bracket environment data around as an object instead of as a
string.  This allows us to use the parsing code for both encryption and
updating, and also add unit tests.

Move the hostname validation function into util, so that it can be used
to validate the hostnames specified in the --brkt-env value.