### PR TITLE
Check the owner's images for name collisions

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -146,10 +146,10 @@ def _connect_and_validate(aws_svc, values, encryptor_ami_id):
 
         if values.encrypted_ami_name:
             filters = {'name': values.encrypted_ami_name}
-            if aws_svc.get_images(filters=filters):
+            if aws_svc.get_images(filters=filters, owners=['self']):
                 raise ValidationError(
-                        'There is already an image named %s' %
-                        values.encrypted_ami_name
+                    'You already own an image named %s' %
+                    values.encrypted_ami_name
                 )
     except EC2ResponseError as e:
         raise ValidationError(e.message)
@@ -420,11 +420,9 @@ def command_update_encrypted_ami(values, log):
         else:
             encrypted_ami_name = name + ' (encrypted %s)' % (nonce,)
         filters = {'name': encrypted_ami_name}
-        if aws_svc.get_images(filters=filters):
+        if aws_svc.get_images(filters=filters, owners=['self']):
             raise ValidationError(
-                    'There is already an image named %s' %
-                     encrypted_ami_name
-            )
+                'You already own image named %s' % encrypted_ami_name)
 
     brkt_env = None
     if values.brkt_env:

--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -118,7 +118,7 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def get_images(self, filters=None):
+    def get_images(self, filters=None, owners=None):
         pass
 
     @abc.abstractmethod
@@ -391,8 +391,8 @@ class AWSService(BaseAWSService):
             virtualization_type='paravirtual'
         )
 
-    def get_images(self, filters=None):
-        return self.conn.get_all_images(filters=filters)
+    def get_images(self, filters=None, owners=None):
+        return self.conn.get_all_images(filters=filters, owners=owners)
 
     def get_image(self, image_id, retry=False):
         if retry:

--- a/test.py
+++ b/test.py
@@ -299,7 +299,7 @@ class DummyAWSService(aws_service.BaseAWSService):
             e.error_code = 'InvalidAMIID.NotFound'
             raise e
 
-    def get_images(self, filters=None):
+    def get_images(self, filters=None, owners=None):
         # Only filtering by name is currently supported.
         name = filters.get('name', None)
         images = []


### PR DESCRIPTION
When checking for image name collisions, search only the images owned by
the current AWS account and not public images.