### PR TITLE
Wait for root disk to attach

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -407,7 +407,14 @@ def command_update_encrypted_ami(values, log):
     mv_image = aws_svc.get_image(encryptor_ami)
     if (guest_image.virtualization_type !=
             mv_image.virtualization_type):
-        log.error("Encryptor virtualization_type mismatch")
+        log.error(
+            'Virtualization type mismatch.  %s is %s, but encryptor %s is '
+            '%s.',
+            guest_image.id,
+            guest_image.virtualization_type,
+            mv_image.id,
+            mv_image.virtualization_type
+        )
         return 1
 
     encrypted_ami_name = values.encrypted_ami_name

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -202,7 +202,8 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             (mv_root_id, encrypted_guest.id)
         )
         aws_svc.attach_volume(mv_root_id, encrypted_guest.id, root_device_name)
-        encrypted_guest = aws_svc.get_instance(encrypted_guest.id)
+        encrypted_guest = encrypt_ami.wait_for_volume_attached(
+            aws_svc, encrypted_guest.id, root_device_name)
         guest_bdm[root_device_name] = \
             encrypted_guest.block_device_mapping[root_device_name]
         guest_bdm[root_device_name].delete_on_termination = True


### PR DESCRIPTION
After attaching the encrypted root volume to the guest instance, wait
for the device mapping to become available before continuing.  Add a
unit test for this code path.  Print more details when a virtualization
type mismatch occurs.