### PR TITLE
Pass HTTP proxy config during encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python: "2.7"
-install: pip install boto requests google-api-python-client
+install: pip install boto requests google-api-python-client PyYAML
 script: python -m unittest test

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -22,6 +22,16 @@ def setup_encrypt_ami_args(parser):
         help="Don't validate AMIs, subnet, and security groups"
     )
     parser.add_argument(
+        '--proxy',
+        metavar='HOST:PORT',
+        help=(
+            'Use this HTTPS proxy during encryption.  '
+            'May be specified multiple times.'
+        ),
+        dest='proxies',
+        action='append'
+    )
+    parser.add_argument(
         '--region',
         metavar='NAME',
         help='AWS region (e.g. us-west-2)',

--- a/brkt_cli/proxy.py
+++ b/brkt_cli/proxy.py
@@ -1,0 +1,43 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+PROXY_ITEM_TEMPLATE = """  - host: %(host)s
+    port: %(port)d
+    protocol: https
+    usage: encryptor
+"""
+
+
+class Proxy(object):
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+
+def generate_proxy_config(*proxies):
+    """ Return a proxy config YAML file based on the given proxies.
+
+    :param proxies: a list of Proxy objects
+    :return: the config file contents as a string
+    """
+    contents = 'version: 2.0\nproxies:\n'
+    for p in proxies:
+        item = PROXY_ITEM_TEMPLATE % {
+            'host': p.host,
+            'port': p.port
+        }
+        contents += item
+
+    return contents

--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -1,0 +1,151 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from email import charset
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import yaml
+
+# The directory for files saved on the Metavisor. We require that the dest
+# path for all --brkt-files be within this directory.
+BRKT_FILE_PREFIX = '/var/brkt/instance_config'
+
+BRKT_FILES_CONTENT_TYPE = 'text/brkt-files'
+GUEST_FILES_CONTENT_TYPE = 'text/brkt-guest-files'
+
+# Load the part handler.  Note that this is only used on the guest.
+# On metavisor, we handle the parts in the cloudinit handler.
+file_writer_handler = """
+#part-handler
+
+import os
+import yaml
+import pwd
+import grp
+
+
+def list_types():
+    return ["text/brkt-files", "text/brkt-guest-files"]
+
+
+def str2oct(s):
+    '''Returns an integer from an octal string.'''
+    return int(s, 8)
+
+
+def output(msg):
+    with open('/tmp/file_writer.out', 'a') as fd:
+        fd.write('file_writer.handler: %s\\n' % (msg,))
+    print "file_writer.handler: %s" % (msg,)
+
+
+def handle_part(data, ctype, filename, payload):
+    if ctype in ('__begin__', '__end__'):
+        return
+
+    file_config = yaml.safe_load(payload)
+
+    for filename, config in file_config.iteritems():
+        output('working on %s' % (filename,))
+        file_dir = os.path.dirname(filename)
+        if config.get('permissions'):
+            file_mask = 0777 - config['permissions']
+            dir_mask = 0777 - (config['permissions'] + 0111)
+
+        # Use the current user as the owner of the file, unless they specify
+        # them
+        chowner = [-1, -1]
+        if config.get('owner'):
+            owner = config['owner']
+            if isinstance(owner, str):
+                owner = pwd.getpwnam(owner).pw_uid
+            chowner[0] = owner
+        if config.get('group'):
+            group = config['group']
+            if isinstance(group, str):
+                group = grp.getgrnam(group).gr_gid
+            chowner[1] = group
+
+        if not os.path.exists(file_dir):
+            old_umask = None
+            if config.get('permissions'):
+                old_umask = os.umask(dir_mask)
+            output('creating directory %s' % (file_dir,))
+            os.makedirs(file_dir)
+            if old_umask is not None:
+                os.umask(old_umask)
+            os.chown(file_dir, *chowner)
+
+        old_umask = None
+        if config.get('permissions'):
+            old_umask = os.umask(file_mask)
+        with open(filename, 'w') as fd:
+            output('writing file %s' % (filename,))
+            fd.write(config.get('contents', ''))
+        if old_umask is not None:
+            os.umask(old_umask)
+        os.chown(filename, *chowner)
+"""
+
+
+# Avoid base64 encoding the MIME parts
+UTF8_CHARSET = charset.Charset('utf-8')
+UTF8_CHARSET.body_encoding = None  # Python defaults to BASE64
+
+
+def _new_mime_part(container, content_type, payload):
+    # MIMEText will prepend to the content_type
+    content_type = re.sub(r'^text/', '', content_type)
+    message = MIMEText(payload, content_type, 'utf-8')
+    del message['Content-Transfer-Encoding']
+    message.set_payload(payload, UTF8_CHARSET)
+    container.attach(message)
+
+
+class UserDataContainer(object):
+    def __init__(self):
+        self.parts = []
+        self.files_config = {}
+        self.add_part('text/part-handler', file_writer_handler)
+
+    def add_part(self, mimetype, content):
+        self.parts.append((mimetype, content))
+
+    def add_file(self, filename, content, content_type):
+        if content_type not in self.files_config:
+            self.files_config[content_type] = {}
+        self.files_config[content_type][filename] = {
+            'contents': content,
+        }
+
+    def add_instance_config_file(self, filename, content):
+        self.add_file(filename, content, BRKT_FILES_CONTENT_TYPE)
+
+    def to_mime_text(self):
+        # These hard coded strings are to avoid having diffs in userdata
+        # when nothing changed. Without this AWS sees the userdata has changed
+        # (the MIME boundary or "unixfrom" changed) and it relaunches the
+        # instance to give it new data.
+        container = MIMEMultipart(boundary='--===============HI-20131203==--')
+        container._unixfrom = 'From nobody Tue Dec  3 19:00:57 2013'
+        for part in self.parts:
+            _new_mime_part(container, part[0], part[1])
+
+        if self.files_config:
+            for (content_type, files) in self.files_config.iteritems():
+                _new_mime_part(container, content_type, yaml.safe_dump(files))
+
+        return str(container)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,12 @@ setup(
     url='http://brkt.com',
     license='Apache 2.0',
     packages=['brkt_cli'],
-    install_requires=['boto>=2.38.0', 'requests>=2.7.0', 'oauth2client>=2.0.0', 'google-api-python-client>=1.5.0'],
+    install_requires=[
+        'boto>=2.38.0',
+        'requests>=2.7.0',
+        'oauth2client>=2.0.0',
+        'google-api-python-client>=1.5.0',
+        'PyYaml>=3.11'],
     zip_safe=False,
     entry_points={
         'console_scripts': [

--- a/test.py
+++ b/test.py
@@ -1262,15 +1262,18 @@ class TestProxy(unittest.TestCase):
         # Valid
         proxies = brkt_cli._parse_proxies(
             'example1.com:8001',
-            'example2.com:8002'
+            'example2.com:8002',
+            '192.168.1.1:8003'
         )
-        self.assertEquals(2, len(proxies))
-        p1 = proxies[0]
-        p2 = proxies[1]
+        self.assertEquals(3, len(proxies))
+        (p1, p2, p3) = proxies[0:3]
+
         self.assertEquals('example1.com', p1.host)
         self.assertEquals(8001, p1.port)
         self.assertEquals('example2.com', p2.host)
         self.assertEquals(8002, p2.port)
+        self.assertEquals('192.168.1.1', p3.host)
+        self.assertEquals(8003, p3.port)
 
         # Invalid
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Add a new --proxy option for specifying one or more HTTPS proxies to use
during encryption.  Proxies are specified as host:port.  When proxies
are specified, we generate a proxy.yaml file and pass it to the
encryptor instance via user data.

To do:
* Specify HTTPS proxy when updating an AMI
* Read proxy.yaml from a file