### PR TITLE
Compress userdata for encryptor instance

### DIFF
--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -23,6 +23,7 @@ import yaml
 # path for all --brkt-files be within this directory.
 BRKT_FILE_PREFIX = '/var/brkt/instance_config'
 
+BRKT_CONFIG_CONTENT_TYPE = 'text/brkt-config'
 BRKT_FILES_CONTENT_TYPE = 'text/brkt-files'
 GUEST_FILES_CONTENT_TYPE = 'text/brkt-guest-files'
 


### PR DESCRIPTION
[Squashed version of PR#167]

The encryptor AMI only looks for multi-part MIME userdata in the case that it finds the userdata to be compressed.  So we'll compress it, which is probably a good thing to do anyway.
Also, make the test_brkt_env_encrypt() test expect the userdata to be in compressed MIME format, rather than plain JSON.