### PR TITLE
Use NO_PROXY talking to private encryptor ip

### DIFF
--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -798,7 +798,7 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         host_ips.append(encryptor_instance.private_ip_address)
         log.info('Adding %s to NO_PROXY environment variable' %
                  encryptor_instance.private_ip_address)
-        if os.environ.get('NO_PROXY', None):
+        if os.environ.get('NO_PROXY'):
             os.environ['NO_PROXY'] += ",%s" % (
                 encryptor_instance.private_ip_address, )
         else:

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -799,8 +799,8 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         log.info('Adding %s to NO_PROXY environment variable' %
                  encryptor_instance.private_ip_address)
         if os.environ.get('NO_PROXY'):
-            os.environ['NO_PROXY'] += ",%s" % (
-                encryptor_instance.private_ip_address, )
+            os.environ['NO_PROXY'] += "," + \
+                encryptor_instance.private_ip_address
         else:
             os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
 

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -799,10 +799,10 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         log.info('Adding %s to NO_PROXY environment variable' %
                  encryptor_instance.private_ip_address)
         if os.environ.get('NO_PROXY', None):
-            os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
-        else:
             os.environ['NO_PROXY'] += ",%s" % (
                 encryptor_instance.private_ip_address, )
+        else:
+            os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
 
     enc_svc = enc_svc_cls(host_ips)
     log.info('Waiting for encryption service on %s (port %s on %s)',

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -801,7 +801,7 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         if os.environ.get('NO_PROXY', None):
             os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
         else:
-            os.environ['NO_PROXY'] = ",%s" % (
+            os.environ['NO_PROXY'] += ",%s" % (
                 encryptor_instance.private_ip_address, )
 
     enc_svc = enc_svc_cls(host_ips)

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -796,6 +796,13 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         host_ips.append(encryptor_instance.ip_address)
     if encryptor_instance.private_ip_address:
         host_ips.append(encryptor_instance.private_ip_address)
+        log.info('Adding %s to NO_PROXY environment variable' %
+                 encryptor_instance.private_ip_address)
+        if os.environ.get('NO_PROXY', None):
+            os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
+        else:
+            os.environ['NO_PROXY'] = ",%s" % (
+                encryptor_instance.private_ip_address, )
 
     enc_svc = enc_svc_cls(host_ips)
     log.info('Waiting for encryption service on %s (port %s on %s)',


### PR DESCRIPTION
In some customer envrionments, customers use http_proxy
environment variables in the shell they are encrypting images
and it is needed for the cli when validating version. This
change will ensure we don't try to communicate to encryptor
instances with private ips through the proxy by appending the
encryptor private ip to the NO_PROXY environment variable.