### PR TITLE
Add --ntp-servers to brkt-cli.

### DIFF
--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -70,15 +70,15 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
-    # Optional NTP server to sync Metavisor clock.
-    # May be specified multiple times.
-    # Hidden because currently used only for development.
     parser.add_argument(
         '--ntp-server',
         metavar='DNS Name',
         dest='ntp_servers',
         action='append',
-        help=argparse.SUPPRESS
+        help=(
+            'Optional NTP server to sync Metavisor clock. '
+            'May be specified multiple times.'
+        )
     )
 
     # Optional yeti endpoints. Hidden because it's only used for development.

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -51,15 +51,15 @@ def setup_update_encrypted_ami(parser):
         dest='subnet_id',
         help='Launch instances in this subnet'
     )
-    # Optional NTP server to sync Metavisor clock.
-    # May be specified multiple times.
-    # Hidden because currently used only for development.
     parser.add_argument(
         '--ntp-server',
         metavar='DNS Name',
         dest='ntp_servers',
         action='append',
-        help=argparse.SUPPRESS
+        help=(
+            'Optional NTP server to sync Metavisor clock. '
+            'May be specified multiple times.'
+        )
     )
     # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(


### PR DESCRIPTION
--ntp-servers allow customers to configure locally hosted ntp-servers
for time synchronization. This commit makes this option visible.