### PR TITLE
Make GCE commands more error tolerant

### DIFF
--- a/brkt_cli/update_gce_image.py
+++ b/brkt_cli/update_gce_image.py
@@ -35,6 +35,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, brkt_env):
     snap_created = None
     instance = None
+
     try:
         instance_name = 'brkt-updater-' + gce_svc.get_session_id()
         updater = instance_name + '-metavisor'


### PR DESCRIPTION
GCE commands now give more meaningful errors
and clean up encryptor instances if necessary

Testing: Encrypted and updated an image