### PR TITLE
Load proxy.yaml from a file

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -381,8 +381,19 @@ def command_encrypt_ami(values, log):
     if values.brkt_env:
         brkt_env = _parse_brkt_env(values.brkt_env)
 
+    # Handle proxy config.
     proxy_config = None
-    if values.proxies:
+    if values.proxy_config_file:
+        path = values.proxy_config_file
+        log.debug('Loading proxy config from %s', path)
+        try:
+            with open(path) as f:
+                proxy_config = f.read()
+        except IOError as e:
+            log.debug('Unable to read %s', path, e)
+            raise ValidationError('Unable to read %s' % path)
+        proxy.validate_proxy_config(proxy_config)
+    elif values.proxies:
         proxies = _parse_proxies(*values.proxies)
         proxy_config = proxy.generate_proxy_config(*proxies)
 

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -27,7 +27,9 @@ def setup_encrypt_ami_args(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
-    parser.add_argument(
+
+    proxy_group = parser.add_mutually_exclusive_group()
+    proxy_group.add_argument(
         '--proxy',
         metavar='HOST:PORT',
         help=(
@@ -37,6 +39,13 @@ def setup_encrypt_ami_args(parser):
         dest='proxies',
         action='append'
     )
+    proxy_group.add_argument(
+        '--proxy-config-file',
+        metavar='PATH',
+        help='Path to proxy.yaml file that will be used during encryption',
+        dest='proxy_config_file'
+    )
+
     parser.add_argument(
         '--region',
         metavar='NAME',


### PR DESCRIPTION
Add a --proxy-config-file option to the encrypt-ami subcommand.  This
allows the user to pass in the entire proxy.yaml file, when specifying
proxies as host:port is not enough.