### PR TITLE
Launch-gce-image resizes guest to snapshot size

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -216,6 +216,7 @@ def command_launch_gce_image(values, log):
                             values.instance_name,
                             values.zone,
                             values.delete_boot,
+                            values.instance_type,
                             {})
     return 0
 

--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -152,13 +152,15 @@ class GCEService:
     def disk_from_snapshot(self, zone, snapshot, name):
         if self.disk_exists(zone, name):
             return
+        snap_info = self.compute.snapshots().get(project=self.project,
+                                                 snapshot=snapshot).execute()
         base = "projects/%s/zones/%s" % (self.project, zone)
         body = {
                 "name": name,
                 "zone": base,
                 "type": base + "/diskTypes/pd-ssd",
                 "sourceSnapshot": "projects/%s/global/snapshots/%s" % (self.project, snapshot),
-                "sizeGb": "25"
+                "sizeGb": snap_info['diskSizeGb']
         }
         self.compute.disks().insert(project=self.project,
                 zone=zone, body=body).execute()

--- a/brkt_cli/launch_gce_image.py
+++ b/brkt_cli/launch_gce_image.py
@@ -4,8 +4,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, metadata={}):
-    guest = instance_name + 'guest'
+def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, metadata={}):
+    guest = instance_name + '-guest'
     log.info("Creating guest root disk from snapshot")
     gce_svc.disk_from_snapshot(zone, image_id, guest)
     gce_svc.wait_for_disk(zone, guest)
@@ -16,5 +16,5 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, metadata={}
                          [gce_svc.get_disk(zone, guest)],
                          metadata,
                          delete_boot,
-                         'n1-standard-1')
+                         instance_type)
     gce_svc.wait_instance(instance_name, zone)

--- a/brkt_cli/launch_gce_image_args.py
+++ b/brkt_cli/launch_gce_image_args.py
@@ -17,6 +17,13 @@ def setup_launch_gce_image_args(parser):
         required=True
     )
     parser.add_argument(
+        '--instance-type',
+        help='Instance type',
+        dest='instance_type',
+        default='n1-standard-1',
+        required=False
+    )
+    parser.add_argument(
         '--no-validate',
         dest='validate',
         action='store_false',
@@ -28,7 +35,7 @@ def setup_launch_gce_image_args(parser):
         help='GCE zone to operate in',
         dest='zone',
         default='us-central1-a',
-        required=True
+        required=False
     )
     parser.add_argument(
         '--delete-boot',


### PR DESCRIPTION
Guest root disk now matches encrypted guest
snapshot size instead of defaulting to 25GB

Also adds option for specifying instance type
in the launch-gce-image command

Testing: launched a range of instance types
from 21GB snapshot.