### PR TITLE
Add proxy support to update-encrypted-ami

### DIFF
--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -351,7 +351,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
     brkt_data = {}
     deleted = None
     try:
-        encrypt_ami.add_brkt_env_to_user_data(brkt_env, brkt_data)
+        encrypt_ami.add_brkt_env_to_brkt_config(brkt_env, brkt_data)
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -55,7 +55,7 @@ log = logging.getLogger(__name__)
 def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
                enc_svc_class=encryptor_service.EncryptorService,
-               ntp_servers=None, brkt_env=None):
+               ntp_servers=None, brkt_env=None, proxy_config=None):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -69,10 +69,10 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
-        user_data = {'brkt': {'solo_mode': 'updater'}}
+        brkt_config = {'brkt': {'solo_mode': 'updater'}}
         if ntp_servers:
-            user_data['ntp-servers'] = ntp_servers
-        encrypt_ami.add_brkt_env_to_user_data(brkt_env, user_data)
+            brkt_config['ntp-servers'] = ntp_servers
+        encrypt_ami.add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 
         if not security_group_ids:
             vpc_id = None
@@ -89,17 +89,20 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             ebs_optimized=False,
             subnet_id=subnet_id,
             security_group_ids=security_group_ids,
-            user_data=json.dumps(user_data))
+            user_data=json.dumps(brkt_config))
         aws_svc.create_tags(
             encrypted_guest.id,
             name=NAME_GUEST_CREATOR,
             description=DESCRIPTION_GUEST_CREATOR % {'image_id': encrypted_ami}
         )
+
         # Run updater in same zone as guest so we can swap volumes
+        compressed_user_data = encrypt_ami.combine_user_data(
+            brkt_config, proxy_config)
         updater = aws_svc.run_instance(
             updater_ami,
             instance_type="m3.medium",
-            user_data=json.dumps(user_data),
+            user_data=compressed_user_data,
             ebs_optimized=False,
             subnet_id=subnet_id,
             placement=encrypted_guest.placement,

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -27,6 +27,25 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
+
+    proxy_group = parser.add_mutually_exclusive_group()
+    proxy_group.add_argument(
+        '--proxy',
+        metavar='HOST:PORT',
+        help=(
+            'Use this HTTPS proxy during encryption.  '
+            'May be specified multiple times.'
+        ),
+        dest='proxies',
+        action='append'
+    )
+    proxy_group.add_argument(
+        '--proxy-config-file',
+        metavar='PATH',
+        help='Path to proxy.yaml file that will be used during encryption',
+        dest='proxy_config_file'
+    )
+
     parser.add_argument(
         '--region',
         metavar='REGION',

--- a/test.py
+++ b/test.py
@@ -22,12 +22,17 @@ from boto.vpc import Subnet, VPC
 
 import brkt_cli
 from brkt_cli.proxy import Proxy
-from brkt_cli.user_data import UserDataContainer, BRKT_CONFIG_CONTENT_TYPE
+from brkt_cli.user_data import (
+    UserDataContainer,
+    BRKT_CONFIG_CONTENT_TYPE,
+    BRKT_FILES_CONTENT_TYPE
+)
 from brkt_cli.validation import ValidationError
 import email
 import inspect
 import logging
 import os
+import tempfile
 import unittest
 import uuid
 import zlib
@@ -734,6 +739,47 @@ class TestBrktEnv(unittest.TestCase):
             encryptor_ami=encryptor_image.id
         )
 
+    def test_brkt_env_update(self):
+        """ Test that the Bracket environment is passed through to metavisor
+        user data.
+        """
+        aws_svc, encryptor_image, guest_image = _build_aws_service()
+        encrypted_ami_id = encrypt_ami.encrypt(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id
+        )
+
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        brkt_env = brkt_cli._parse_brkt_env(
+            api_host_port + ',' + hsmproxy_host_port)
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                brkt_config = self._get_brkt_config_from_mime(args.user_data)
+                d = json.loads(brkt_config)
+                self.assertEquals(
+                    api_host_port,
+                    d['brkt']['api_host']
+                )
+                self.assertEquals(
+                    hsmproxy_host_port,
+                    d['brkt']['hsmproxy_host']
+                )
+                self.assertEquals(
+                    'updater',
+                    d['brkt']['solo_mode']
+                )
+
+        aws_svc.run_instance_callback = run_instance_callback
+        update_ami(
+            aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
+            enc_svc_class=DummyEncryptorService,
+            brkt_env=brkt_env
+        )
+
 
 class TestRunUpdate(unittest.TestCase):
 
@@ -769,46 +815,6 @@ class TestRunUpdate(unittest.TestCase):
 
         self.assertEqual(2, self.call_count)
         self.assertIsNotNone(ami_id)
-
-    def test_brkt_env_update(self):
-        """ Test that the Bracket environment is through to metavisor user
-        data.
-        """
-        aws_svc, encryptor_image, guest_image = _build_aws_service()
-        encrypted_ami_id = encrypt_ami.encrypt(
-            aws_svc=aws_svc,
-            enc_svc_cls=DummyEncryptorService,
-            image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
-        )
-
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        brkt_env = brkt_cli._parse_brkt_env(
-            api_host_port + ',' + hsmproxy_host_port)
-
-        def run_instance_callback(args):
-            if args.image_id == encryptor_image.id:
-                d = json.loads(args.user_data)
-                self.assertEquals(
-                    api_host_port,
-                    d['brkt']['api_host']
-                )
-                self.assertEquals(
-                    hsmproxy_host_port,
-                    d['brkt']['hsmproxy_host']
-                )
-                self.assertEquals(
-                    'updater',
-                    d['brkt']['solo_mode']
-                )
-
-        aws_svc.run_instance_callback = run_instance_callback
-        update_ami(
-            aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
-            enc_svc_class=DummyEncryptorService,
-            brkt_env=brkt_env
-        )
 
 
 class ExpiredDeadline(object):
@@ -965,6 +971,8 @@ class DummyValues(object):
         self.validate = True
         self.ami = None
         self.encryptor_ami = None
+        self.proxies = []
+        self.proxy_config_file = None
 
 
 class TestValidation(unittest.TestCase):
@@ -1291,6 +1299,35 @@ class TestUserData(unittest.TestCase):
         mime = udc.to_mime_text()
         self.assertTrue('test.txt: {contents: 1 2 3}' in mime)
 
+    def test_combine_user_data(self):
+        """ Test combining Bracket config data with HTTP proxy config data.
+        """
+        brkt_config = {'foo': 'bar'}
+        p = Proxy(host='proxy1.example.com', port=8001)
+        proxy_config = proxy.generate_proxy_config(p)
+        compressed_mime_data = encrypt_ami.combine_user_data(
+            brkt_config,
+            proxy_config
+        )
+        mime_data = zlib.decompress(compressed_mime_data, 16 + zlib.MAX_WBITS)
+
+        msg = email.message_from_string(mime_data)
+        found_brkt_config = False
+        found_brkt_files = False
+
+        for part in msg.walk():
+            if part.get_content_type() == BRKT_CONFIG_CONTENT_TYPE:
+                found_brkt_config = True
+                content = part.get_payload(decode=True)
+                self.assertEqual('{"foo": "bar"}', content)
+            if part.get_content_type() == BRKT_FILES_CONTENT_TYPE:
+                found_brkt_files = True
+                content = part.get_payload(decode=True)
+                self.assertTrue('/var/brkt/ami_config/proxy.yaml:' in content)
+
+        self.assertTrue(found_brkt_config)
+        self.assertTrue(found_brkt_files)
+
 
 class TestCommandLineOptions(unittest.TestCase):
     """ Test handling of command line options."""
@@ -1351,3 +1388,32 @@ class TestCommandLineOptions(unittest.TestCase):
         with self.assertRaises(ValidationError):
             brkt_cli._parse_brkt_env('a:7,b?:8')
 
+    def test_get_proxy_config(self):
+        """ Test reading proxy config from the --proxy and --proxy-config-file
+        command line options.
+        """
+        # No proxy.
+        values = DummyValues()
+        self.assertIsNone(brkt_cli._get_proxy_config(values))
+
+        # --proxy specified.
+        values.proxies = ['proxy.example.com:8000']
+        proxy_yaml = brkt_cli._get_proxy_config(values)
+        d = yaml.load(proxy_yaml)
+        self.assertEquals('proxy.example.com', d['proxies'][0]['host'])
+
+        # --proxy-config-file references a file that doesn't exist.
+        values.proxy = None
+        values.proxy_config_file = 'bogus.yaml'
+        with self.assertRaises(ValidationError):
+            brkt_cli._get_proxy_config(values)
+
+        # --proxy-config-file references a valid file.
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(proxy_yaml)
+            f.flush()
+            values.proxy_config_file = f.name
+            proxy_yaml = brkt_cli._get_proxy_config(values)
+
+        d = yaml.load(proxy_yaml)
+        self.assertEquals('proxy.example.com', d['proxies'][0]['host'])


### PR DESCRIPTION
Add --proxy and --proxy-config-file options to the update-encrypted-ami
subcommand.

Add a _get_proxy_config() utility function for loading proxy.yaml
content.  This function is called during encryption and update.

Add a combine_user_data() function, which generates the gzipped MIME
blob that is passed to the metavisor.  This allows us to write dedicated
unit tests for this logic.

Minor terminology changes:
* user data: the actual user data bytes that are sent to the instance
* brkt env: host/port of the api service and HSM proxy
* brkt config: the dictionary that stores brkt env, ntp servers, etc.