### PR TITLE
Revert "Add proxy support to update-encrypted-ami"

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -355,32 +355,6 @@ def _parse_proxies(*proxy_host_ports):
     return proxies
 
 
-def _get_proxy_config(values):
-    """ Read proxy config specified by either the --proxy or
-    --proxy-config-file option.
-
-    @return: the contents of the proxy.yaml file, or None if not specified
-    @raise ValidationError if the file cannot be read or is malformed
-    """
-    proxy_config = None
-    if values.proxy_config_file:
-        path = values.proxy_config_file
-        log.debug('Loading proxy config from %s', path)
-        try:
-            with open(path) as f:
-                proxy_config = f.read()
-        except IOError as e:
-            log.debug('Unable to read %s', path, e)
-            raise ValidationError('Unable to read %s' % path)
-        proxy.validate_proxy_config(proxy_config)
-    elif values.proxies:
-        proxies = _parse_proxies(*values.proxies)
-        proxy_config = proxy.generate_proxy_config(*proxies)
-        log.debug('Using proxy configuration:\n%s', proxy_config)
-
-    return proxy_config
-
-
 def command_encrypt_ami(values, log):
     session_id = util.make_nonce()
 
@@ -408,7 +382,21 @@ def command_encrypt_ami(values, log):
     if values.brkt_env:
         brkt_env = _parse_brkt_env(values.brkt_env)
 
-    proxy_config = _get_proxy_config(values)
+    # Handle proxy config.
+    proxy_config = None
+    if values.proxy_config_file:
+        path = values.proxy_config_file
+        log.debug('Loading proxy config from %s', path)
+        try:
+            with open(path) as f:
+                proxy_config = f.read()
+        except IOError as e:
+            log.debug('Unable to read %s', path, e)
+            raise ValidationError('Unable to read %s' % path)
+        proxy.validate_proxy_config(proxy_config)
+    elif values.proxies:
+        proxies = _parse_proxies(*values.proxies)
+        proxy_config = proxy.generate_proxy_config(*proxies)
 
     encrypted_image_id = encrypt_ami.encrypt(
         aws_svc=aws_svc,
@@ -560,7 +548,6 @@ def command_update_encrypted_ami(values, log):
     brkt_env = None
     if values.brkt_env:
         brkt_env = _parse_brkt_env(values.brkt_env)
-    proxy_config = _get_proxy_config(values)
 
     # Initial validation done
     log.info('Updating %s with new metavisor %s', encrypted_ami, encryptor_ami)
@@ -570,8 +557,7 @@ def command_update_encrypted_ami(values, log):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         ntp_servers=values.ntp_servers,
-        brkt_env=brkt_env,
-        proxy_config=proxy_config
+        brkt_env=brkt_env
     )
     print(updated_ami_id)
     return 0

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -499,44 +499,15 @@ def create_encryptor_security_group(aws_svc, vpc_id=None):
     return sg
 
 
-def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
+def add_brkt_env_to_user_data(brkt_env, user_data):
     if brkt_env:
-        if 'brkt' not in brkt_config:
-            brkt_config['brkt'] = {}
+        if 'brkt' not in user_data:
+            user_data['brkt'] = {}
         api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
         hsmproxy_host_port = '%s:%d' % (
             brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
-        brkt_config['brkt']['api_host'] = api_host_port
-        brkt_config['brkt']['hsmproxy_host'] = hsmproxy_host_port
-
-
-def combine_user_data(brkt_config=None, proxy_config=None):
-    """ Combine the user data dictionary with the given proxy configuration
-    into the gzipped multipart MIME binary that will be sent to the
-    metavisor instance.
-
-    :param brkt_config: dictionary of Bracket config values
-    :param proxy_config: proxy.yaml contents
-    :return: a gzipped multipart MIME binary
-    """
-    udc = UserDataContainer()
-
-    brkt_config = brkt_config or {}
-    brkt_config_string = json.dumps(brkt_config)
-    udc.add_part(BRKT_CONFIG_CONTENT_TYPE, brkt_config_string)
-
-    if proxy_config:
-        udc.add_file(
-            '/var/brkt/ami_config/proxy.yaml',
-            proxy_config,
-            BRKT_FILES_CONTENT_TYPE
-        )
-
-    user_data_string = udc.to_mime_text()
-    out = StringIO()
-    with gzip.GzipFile(fileobj=out, mode="w") as f:
-        f.write(user_data_string)
-    return out.getvalue()
+        user_data['brkt']['api_host'] = api_host_port
+        user_data['brkt']['hsmproxy_host'] = hsmproxy_host_port
 
 
 def run_encryptor_instance(aws_svc, encryptor_image_id,
@@ -544,11 +515,11 @@ def run_encryptor_instance(aws_svc, encryptor_image_id,
            guest_image_id, brkt_env=None, security_group_ids=None,
            subnet_id=None, zone=None, ntp_servers=None, proxy_config=None):
     bdm = BlockDeviceMapping()
-    brkt_config = {}
-    add_brkt_env_to_brkt_config(brkt_env, brkt_config)
+    user_data = {}
+    add_brkt_env_to_user_data(brkt_env, user_data)
 
     if ntp_servers:
-        brkt_config['ntp-servers'] = ntp_servers
+        user_data['ntp-servers'] = ntp_servers
 
     image = aws_svc.get_image(encryptor_image_id)
     virtualization_type = image.virtualization_type
@@ -578,7 +549,24 @@ def run_encryptor_instance(aws_svc, encryptor_image_id,
         bdm['/dev/sdf'] = guest_unencrypted_root
         bdm['/dev/sdg'] = guest_encrypted_root
 
-    compressed_user_data = combine_user_data(brkt_config, proxy_config)
+    udc = UserDataContainer()
+
+    brkt_config_string = json.dumps(user_data)
+    udc.add_part(BRKT_CONFIG_CONTENT_TYPE, brkt_config_string)
+
+    if proxy_config:
+        udc.add_file(
+            '/var/brkt/ami_config/proxy.yaml',
+            proxy_config,
+            BRKT_FILES_CONTENT_TYPE
+        )
+
+    user_data_string = udc.to_mime_text()
+    out = StringIO()
+    with gzip.GzipFile(fileobj=out, mode="w") as f:
+        f.write(user_data_string)
+    compressed_user_data = out.getvalue()
+
     instance = aws_svc.run_instance(encryptor_image_id,
                                     security_group_ids=security_group_ids,
                                     user_data=compressed_user_data,

--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -351,7 +351,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
     brkt_data = {}
     deleted = None
     try:
-        encrypt_ami.add_brkt_env_to_brkt_config(brkt_env, brkt_data)
+        encrypt_ami.add_brkt_env_to_user_data(brkt_env, brkt_data)
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -27,25 +27,6 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
-
-    proxy_group = parser.add_mutually_exclusive_group()
-    proxy_group.add_argument(
-        '--proxy',
-        metavar='HOST:PORT',
-        help=(
-            'Use this HTTPS proxy during encryption.  '
-            'May be specified multiple times.'
-        ),
-        dest='proxies',
-        action='append'
-    )
-    proxy_group.add_argument(
-        '--proxy-config-file',
-        metavar='PATH',
-        help='Path to proxy.yaml file that will be used during encryption',
-        dest='proxy_config_file'
-    )
-
     parser.add_argument(
         '--region',
         metavar='REGION',


### PR DESCRIPTION
This reverts commit 606df19b8c2941b8405cc68f44053b47296a426a.

(we must first have Metavisor support MIME userdata when in 'updater' mode -- sorry I neglected to consider this during the original PR)