### PR TITLE
Handle long image name when updating

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -26,6 +26,7 @@ import boto.vpc
 import requests
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
+import brkt_cli.util
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
 from brkt_cli import encrypt_ami_args
@@ -221,7 +222,6 @@ def command_launch_gce_image(values, log):
 def command_update_encrypted_gce_image(values, log):
     session_id = util.make_nonce()
     default_tags = encrypt_ami.get_default_tags(session_id, "")
-    gce_svc = gce_service.GCEService(values.project, default_tags, log)
 
     encrypted_image_name = gce_service.get_image_name(values.encrypted_image_name, values.image)
     if not gce_svc.get_image(values.image):
@@ -482,6 +482,24 @@ def _validate_encryptor_ami(aws_svc, ami_id):
     return None
 
 
+def _get_updated_image_name(image_name, session_id):
+    """ Generate a new name, based on the existing name of the encrypted
+    image and the session id.
+
+    @return the new name
+    """
+    # Replace session id in the image name.
+    m = re.match('(.+) \(encrypted (\S+)\)', image_name)
+    suffix = ' (encrypted %s)' % session_id
+    if m:
+        encrypted_ami_name = util.append_suffix(
+            m.group(1), suffix, max_length=128)
+    else:
+        encrypted_ami_name = util.append_suffix(
+            image_name, suffix, max_length=128)
+    return encrypted_ami_name
+
+
 def command_update_encrypted_ami(values, log):
     nonce = util.make_nonce()
 
@@ -521,18 +539,16 @@ def command_update_encrypted_ami(values, log):
         return 1
 
     encrypted_ami_name = values.encrypted_ami_name
-    if not encrypted_ami_name:
-        # Replace nonce in AMI name
-        name = guest_image.name
-        m = re.match('(.+) \(encrypted (\S+)\)', name)
-        if m:
-            encrypted_ami_name = m.group(1) + ' (encrypted %s)' % (nonce,)
-        else:
-            encrypted_ami_name = name + ' (encrypted %s)' % (nonce,)
+    if encrypted_ami_name:
+        # Check for name collision.
         filters = {'name': encrypted_ami_name}
         if aws_svc.get_images(filters=filters, owners=['self']):
             raise ValidationError(
                 'You already own image named %s' % encrypted_ami_name)
+    else:
+        encrypted_ami_name = _get_updated_image_name(guest_image.name, nonce)
+    log.debug('Image name: %s', encrypted_ami_name)
+    aws_service.validate_image_name(encrypted_ami_name)
 
     brkt_env = None
     if values.brkt_env:

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -47,24 +47,24 @@ import time
 import urllib2
 from StringIO import StringIO
 
-from boto.exception import EC2ResponseError
 from boto.ec2.blockdevicemapping import (
     BlockDeviceMapping,
     EBSBlockDeviceType,
 )
 from boto.ec2.instance import InstanceAttribute
+from boto.exception import EC2ResponseError
 
 from brkt_cli import encryptor_service
-from brkt_cli.util import (
-    BracketError,
-    Deadline,
-    make_nonce,
-)
 from brkt_cli.user_data import (
     UserDataContainer,
     BRKT_CONFIG_CONTENT_TYPE,
     BRKT_FILES_CONTENT_TYPE
 )
+from brkt_cli.util import (
+    BracketError,
+    Deadline,
+    make_nonce,
+    append_suffix)
 
 # End user-visible terminology.  These are resource names and descriptions
 # that the user will see in his or her EC2 console.
@@ -351,20 +351,6 @@ def get_encrypted_suffix():
     the suffix is necessary because Amazon requires image names to be unique.
     """
     return NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': make_nonce()}
-
-
-def append_suffix(name, suffix, max_length=None):
-    """ Append the suffix to the given name.  If the appended length exceeds
-    max_length, truncate the name to make room for the suffix.
-
-    :return: The possibly truncated name with the suffix appended
-    """
-    if not suffix:
-        return name
-    if max_length:
-        truncated_length = max_length - len(suffix)
-        name = name[:truncated_length]
-    return name + suffix
 
 
 def get_encryptor_ami(region, hvm=False):

--- a/brkt_cli/gce_service.py
+++ b/brkt_cli/gce_service.py
@@ -10,6 +10,7 @@ from brkt_cli.util import (
     BracketError,
     Deadline,
     make_nonce,
+    append_suffix
 )
 from brkt_cli import encrypt_ami
 from googleapiclient import discovery
@@ -359,12 +360,12 @@ def get_image_name(encrypted_image_name, name):
     # Replace nonce in image name
     m = re.match('(.+)\-encrypted\-', name)
     if m:
-        encrypted_image_name = encrypt_ami.append_suffix(
+        encrypted_image_name = append_suffix(
                 m.group(1),
                 '-encrypted-%s' % (nonce,),
                 GCE_NAME_MAX_LENGTH)
     else:
-        encrypted_image_name = encrypt_ami.append_suffix(
+        encrypted_image_name = append_suffix(
                 name,
                 '-encrypted-%s' % (nonce,),
                 GCE_NAME_MAX_LENGTH)

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -55,3 +55,17 @@ def validate_dns_name_ip_address(hostname):
         hostname = hostname[:-1]
     valid = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(valid.match(x) for x in hostname.split("."))
+
+
+def append_suffix(name, suffix, max_length=None):
+    """ Append the suffix to the given name.  If the appended length exceeds
+    max_length, truncate the name to make room for the suffix.
+
+    :return: The possibly truncated name with the suffix appended
+    """
+    if not suffix:
+        return name
+    if max_length:
+        truncated_length = max_length - len(suffix)
+        name = name[:truncated_length]
+    return name + suffix


### PR DESCRIPTION
When updating an encrypted AMI, handle the possibility that the new name
may exceed 128 characters.  Refactor the image name generation logic
into a separate function, to make it more testable.  Move
append_suffix() into the util module, since it's now called from
multiple places.