### PR TITLE
Move generic encryption methods to encryptor_service.py

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -26,7 +26,6 @@ import boto.vpc
 import requests
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
-import brkt_cli.util
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
 from brkt_cli import encrypt_ami_args
@@ -46,8 +45,8 @@ from brkt_cli.validation import ValidationError
 from encrypt_ami import (
     TAG_ENCRYPTOR,
     TAG_ENCRYPTOR_AMI,
-    TAG_ENCRYPTOR_SESSION_ID,
-    BracketEnvironment)
+    TAG_ENCRYPTOR_SESSION_ID)
+from encryptor_service import BracketEnvironment
 from update_ami import update_ami
 
 VERSION = '0.9.15pre1'
@@ -221,8 +220,7 @@ def command_launch_gce_image(values, log):
 
 def command_update_encrypted_gce_image(values, log):
     session_id = util.make_nonce()
-    default_tags = encrypt_ami.get_default_tags(session_id, "")
-
+    gce_svc = gce_service.GCEService(values.project, session_id, log)
     encrypted_image_name = gce_service.get_image_name(values.encrypted_image_name, values.image)
     # check that image to be updated exists
     if not gce_svc.image_exists(values.image):
@@ -272,8 +270,7 @@ def command_update_encrypted_gce_image(values, log):
 
 def command_encrypt_gce_image(values, log):
     session_id = util.make_nonce()
-    default_tags = encrypt_ami.get_default_tags(session_id, "")
-    gce_svc = gce_service.GCEService(values.project, default_tags, log)
+    gce_svc = gce_service.GCEService(values.project, session_id, log)
 
     brkt_env = None
     if values.brkt_env:

--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -3,13 +3,13 @@
 import logging
 
 from brkt_cli.util import (
+    add_brkt_env_to_user_data,
     Deadline,
 )
 
 from gce_service import gce_metadata_from_userdata
-from brkt_cli import encrypt_ami
-from encrypt_ami import wait_for_encryption
-from encrypt_ami import wait_for_encryptor_up
+from encryptor_service import wait_for_encryption
+from encryptor_service import wait_for_encryptor_up
 
 
 log = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
     brkt_data = {}
     deleted = None
     try:
-        encrypt_ami.add_brkt_env_to_user_data(brkt_env, brkt_data)
+        add_brkt_env_to_user_data(brkt_env, brkt_data)
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()

--- a/brkt_cli/gce_service.py
+++ b/brkt_cli/gce_service.py
@@ -11,7 +11,6 @@ from brkt_cli.util import (
     make_nonce,
     append_suffix
 )
-from brkt_cli import encrypt_ami
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 
@@ -21,10 +20,6 @@ LATEST_IMAGE = 'latest.image.tar.gz'
 log = logging.getLogger(__name__)
 
 
-class InstanceError(BracketError):
-    pass
-
-
 brkt_image_buckets = {
     'prod': 'brkt-prod-images',
     'stage': 'brkt-stage-images',
@@ -32,11 +27,15 @@ brkt_image_buckets = {
 }
 
 
+class InstanceError(BracketError):
+    pass
+
+
 class GCEService:
-    def __init__(self, project, tags, logger):
+    def __init__(self, project, session_id, logger):
         self.log = logger
         self.project = project
-        self.tags = tags
+        self.session_id = session_id
         self.credentials = GoogleCredentials.get_application_default()
         self.compute = discovery.build('compute', 'v1',
                 credentials=self.credentials)
@@ -53,7 +52,7 @@ class GCEService:
         return zones
 
     def get_session_id(self):
-        return self.tags[encrypt_ami.TAG_ENCRYPTOR_SESSION_ID]
+        return self.session_id
 
     def get_snapshot(self, name):
         return self.compute.snapshots().get(project=self.project,

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -28,8 +28,15 @@ import os
 from boto.ec2.blockdevicemapping import EBSBlockDeviceType
 
 from brkt_cli import encryptor_service
-from brkt_cli.util import Deadline
+from brkt_cli.util import (
+        add_brkt_env_to_user_data,
+        Deadline
+)
 import encrypt_ami
+from encryptor_service import (
+    wait_for_encryptor_up,
+    wait_for_encryption,
+)
 from encrypt_ami import (
     clean_up,
     create_encryptor_security_group,
@@ -37,8 +44,6 @@ from encrypt_ami import (
     wait_for_instance,
     wait_for_image,
     wait_for_snapshots,
-    wait_for_encryptor_up,
-    wait_for_encryption,
     DESCRIPTION_GUEST_CREATOR,
     DESCRIPTION_METAVISOR_UPDATER,
     DESCRIPTION_SNAPSHOT,
@@ -73,7 +78,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         user_data = {'brkt': {'solo_mode': 'updater'}}
         if ntp_servers:
             user_data['ntp-servers'] = ntp_servers
-        encrypt_ami.add_brkt_env_to_user_data(brkt_env, user_data)
+        add_brkt_env_to_user_data(brkt_env, user_data)
 
         if not security_group_ids:
             vpc_id = None

--- a/brkt_cli/update_gce_image.py
+++ b/brkt_cli/update_gce_image.py
@@ -15,11 +15,11 @@
 import logging
 
 from brkt_cli.util import (
+    add_brkt_env_to_user_data,
     Deadline,
 )
-import encrypt_ami
-from encrypt_ami import wait_for_encryption
-from encrypt_ami import wait_for_encryptor_up
+from encryptor_service import wait_for_encryption
+from encryptor_service import wait_for_encryptor_up
 from gce_service import gce_metadata_from_userdata
 from encrypt_gce_image import cleanup
 
@@ -52,7 +52,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
 
         log.info("Launching encrypted updater")
         brkt_data = {'brkt': {'solo_mode': 'updater'}}
-        encrypt_ami.add_brkt_env_to_user_data(brkt_env, brkt_data)
+        add_brkt_env_to_user_data(brkt_env, brkt_data)
         user_data = gce_metadata_from_userdata(brkt_data)
         gce_svc.run_instance(zone,
                              updater,

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -16,6 +16,9 @@ import time
 import uuid
 
 
+SLEEP_ENABLED = True
+
+
 class BracketError(Exception):
     pass
 
@@ -34,6 +37,22 @@ class Deadline(object):
             True if the deadline has passed. False otherwise.
         """
         return self.clock.time() >= self.deadline
+
+
+def sleep(seconds):
+    if SLEEP_ENABLED:
+        time.sleep(seconds)
+
+
+def add_brkt_env_to_user_data(brkt_env, user_data):
+    if brkt_env:
+        if 'brkt' not in user_data:
+            user_data['brkt'] = {}
+        api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
+        hsmproxy_host_port = '%s:%d' % (
+            brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
+        user_data['brkt']['api_host'] = api_host_port
+        user_data['brkt']['hsmproxy_host'] = hsmproxy_host_port
 
 
 def make_nonce():

--- a/test.py
+++ b/test.py
@@ -467,7 +467,7 @@ def _build_aws_service():
 class TestRunEncryption(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        brkt_cli.util.SLEEP_ENABLED = False
 
     def test_smoke(self):
         """ Run the entire process and test that nothing obvious is broken.
@@ -496,7 +496,7 @@ class TestRunEncryption(unittest.TestCase):
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
-        except encrypt_ami.EncryptionError as e:
+        except encryptor_service.EncryptionError as e:
             with open(e.console_output_file.name) as f:
                 content = f.read()
                 self.assertEquals(CONSOLE_OUTPUT_TEXT, content)
@@ -518,7 +518,7 @@ class TestRunEncryption(unittest.TestCase):
                 encryptor_ami=encryptor_image.id
             )
             self.fail('Encryption should have failed')
-        except encrypt_ami.EncryptionError as e:
+        except encryptor_service.EncryptionError as e:
             self.assertIsNone(e.console_output_file)
 
     def test_delete_orphaned_volumes(self):
@@ -736,7 +736,7 @@ class TestRunEncryption(unittest.TestCase):
 class TestBrktEnv(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        brkt_cli.util.SLEEP_ENABLED = False
 
     def _get_brkt_config_from_mime(self, compressed_mime_data):
         """Look for a 'brkt-config' part in the multi-part MIME input"""
@@ -784,7 +784,7 @@ class TestBrktEnv(unittest.TestCase):
 class TestRunUpdate(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        brkt_cli.util.SLEEP_ENABLED = False
 
     def test_subnet_and_security_groups(self):
         """ Test that the subnet and security group ids are passed through
@@ -876,19 +876,19 @@ class FailedEncryptionService(encryptor_service.BaseEncryptorService):
 class TestEncryptionService(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        brkt_cli.util.SLEEP_ENABLED = False
 
     def test_service_fails_to_come_up(self):
         svc = DummyEncryptorService()
         deadline = ExpiredDeadline()
         with self.assertRaisesRegexp(Exception, 'Unable to contact'):
-            encrypt_ami.wait_for_encryptor_up(svc, deadline)
+            encryptor_service.wait_for_encryptor_up(svc, deadline)
 
     def test_encryption_fails(self):
         svc = FailedEncryptionService('192.168.1.1')
         with self.assertRaisesRegexp(
-                encrypt_ami.EncryptionError, 'Encryption failed'):
-            encrypt_ami.wait_for_encryption(svc)
+                encryptor_service.EncryptionError, 'Encryption failed'):
+            encryptor_service.wait_for_encryption(svc)
 
     def test_unsupported_guest(self):
         class UnsupportedGuestService(encryptor_service.BaseEncryptorService):
@@ -906,8 +906,8 @@ class TestEncryptionService(unittest.TestCase):
                     'percent_complete': 0
                 }
 
-        with self.assertRaises(encrypt_ami.UnsupportedGuestError):
-            encrypt_ami.wait_for_encryption(UnsupportedGuestService())
+        with self.assertRaises(encryptor_service.UnsupportedGuestError):
+            encryptor_service.wait_for_encryption(UnsupportedGuestService())
 
     def test_encryption_progress_timeout(self):
         class NoProgressService(encryptor_service.BaseEncryptorService):
@@ -923,8 +923,8 @@ class TestEncryptionService(unittest.TestCase):
                     'percent_complete': 0
                 }
 
-        with self.assertRaises(encrypt_ami.EncryptionError):
-            encrypt_ami.wait_for_encryption(
+        with self.assertRaises(encryptor_service.EncryptionError):
+            encryptor_service.wait_for_encryption(
                 NoProgressService(),
                 progress_timeout=0.100
             )
@@ -962,7 +962,7 @@ class TestRetry(unittest.TestCase):
 class TestInstance(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        brkt_cli.util.SLEEP_ENABLED = False
 
     def test_wait_for_instance_terminated(self):
         """ Test waiting for an instance to terminate.


### PR DESCRIPTION
Some code shared by gce and aws (and likely other csps)
was in encrypt_ami.py. It makes more sense for this code
to be in the generic encryption service file.

Testing: encrypted and updated gce images