### PR TITLE
Support specifying the guest instance type

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -392,7 +392,8 @@ def command_encrypt_ami(values, log):
         security_group_ids=values.security_group_ids,
         brkt_env=brkt_env,
         ntp_servers=values.ntp_servers,
-        proxy_config=proxy_config
+        proxy_config=proxy_config,
+        guest_instance_type=values.guest_instance_type
     )
     # Print the AMI ID to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
@@ -564,7 +565,8 @@ def command_update_encrypted_ami(values, log):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         ntp_servers=values.ntp_servers,
-        brkt_env=brkt_env
+        brkt_env=brkt_env,
+        guest_instance_type=values.guest_instance_type
     )
     print(updated_ami_id)
     return 0

--- a/brkt_cli/aws_service.py
+++ b/brkt_cli/aws_service.py
@@ -277,12 +277,11 @@ class AWSService(BaseAWSService):
                      instance_profile_name=None):
         if security_group_ids is None:
             security_group_ids = []
-        log.debug('Starting a new instance based on %s', image_id)
-        if security_group_ids:
-            log.debug(
-                'Using security groups %s', ', '.join(security_group_ids))
-        if subnet_id:
-            log.debug('Running instance in %s', subnet_id)
+        log.debug(
+            'run_instance: %s, security groups=%s, subnet=%s, '
+            'type=%s',
+            image_id, security_group_ids, subnet_id, instance_type
+        )
         if user_data and log.isEnabledFor(logging.DEBUG):
             with tempfile.NamedTemporaryFile(
                 prefix='user-data-',

--- a/brkt_cli/encrypt_ami.py
+++ b/brkt_cli/encrypt_ami.py
@@ -448,10 +448,11 @@ def run_encryptor_instance(aws_svc, encryptor_image_id,
     return instance
 
 
-def run_guest_instance(aws_svc, image_id, subnet_id=None):
+def run_guest_instance(aws_svc, image_id, subnet_id=None,
+                       instance_type='m3.medium'):
     instance = aws_svc.run_instance(
         image_id, subnet_id=subnet_id,
-        instance_type='m3.medium', ebs_optimized=False)
+        instance_type=instance_type, ebs_optimized=False)
     log.info(
         'Launching instance %s to snapshot root disk for %s',
         instance.id, image_id)
@@ -907,7 +908,8 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
 def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            ntp_servers=None, proxy_config=None):
+            ntp_servers=None, proxy_config=None,
+            guest_instance_type='m3.medium'):
     encryptor_instance = None
     ami = None
     snapshot_id = None
@@ -944,7 +946,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
         legacy = True
     try:
         guest_instance = run_guest_instance(aws_svc,
-            image_id, subnet_id=subnet_id)
+            image_id, subnet_id=subnet_id, instance_type=guest_instance_type)
         wait_for_instance(aws_svc, guest_instance.id)
         snapshot_id, root_dev, size, vol_type, iops = _snapshot_root_volume(
             aws_svc, guest_instance, image_id

--- a/brkt_cli/encrypt_ami_args.py
+++ b/brkt_cli/encrypt_ami_args.py
@@ -5,7 +5,7 @@ def setup_encrypt_ami_args(parser):
     parser.add_argument(
         'ami',
         metavar='ID',
-        help='The AMI that will be encrypted'
+        help='The guest AMI that will be encrypted'
     )
     parser.add_argument(
         '--encrypted-ami-name',
@@ -13,6 +13,15 @@ def setup_encrypt_ami_args(parser):
         dest='encrypted_ami_name',
         help='Specify the name of the generated encrypted AMI',
         required=False
+    )
+    parser.add_argument(
+        '--guest-instance-type',
+        metavar='TYPE',
+        dest='guest_instance_type',
+        help=(
+            'The instance type to use when running the unencrypted guest '
+            'instance'),
+        default='m3.medium'
     )
     parser.add_argument(
         '--hvm',

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -61,7 +61,8 @@ log = logging.getLogger(__name__)
 def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
                enc_svc_class=encryptor_service.EncryptorService,
-               ntp_servers=None, brkt_env=None):
+               ntp_servers=None, brkt_env=None,
+               guest_instance_type='m3.medium'):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -91,7 +92,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
 
         encrypted_guest = aws_svc.run_instance(
             encrypted_ami,
-            instance_type="m3.medium",
+            instance_type=guest_instance_type,
             ebs_optimized=False,
             subnet_id=subnet_id,
             security_group_ids=security_group_ids,

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -5,7 +5,7 @@ def setup_update_encrypted_ami(parser):
     parser.add_argument(
         'ami',
         metavar='ID',
-        help='The AMI that will be encrypted'
+        help='The encrypted AMI that will be updated'
     )
     parser.add_argument(
         '--encrypted-ami-name',
@@ -13,6 +13,15 @@ def setup_update_encrypted_ami(parser):
         dest='encrypted_ami_name',
         help='Specify the name of the generated encrypted AMI',
         required=False
+    )
+    parser.add_argument(
+        '--guest-instance-type',
+        metavar='TYPE',
+        dest='guest_instance_type',
+        help=(
+            'The instance type to use when running the unencrypted guest '
+            'instance'),
+        default='m3.medium'
     )
     parser.add_argument(
         '--hvm',


### PR DESCRIPTION
Add a --guest-instance-type option to the encrypt-ami and update-
encrypted-ami subcommands.  This allows the user to specify the guest
instance type when the default of m3.medium is incompatible with the
guest AMI.

Clean up the original test_instance_type() test, so that it switches on
the AMI ID instead of making assumptions about the order in which
instances are launched.