### PR TITLE
Allow specifying a GCE image project

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -295,7 +295,8 @@ def command_encrypt_gce_image(values, log):
                                                encryptor,
                                                values.bucket)
 
-    encrypt_gce_image.validate_images(gce_svc, encrypted_image_name, encryptor, values.image)
+    encrypt_gce_image.validate_images(gce_svc, encrypted_image_name, encryptor,
+                                      values.image, values.image_project)
 
     log.info('Starting encryptor session %s', gce_svc.get_session_id())
     encrypted_image_id = encrypt_gce_image.encrypt(
@@ -305,7 +306,8 @@ def command_encrypt_gce_image(values, log):
         encryptor_image=encryptor,
         encrypted_image_name=encrypted_image_name,
         zone=values.zone,
-        brkt_env=brkt_env
+        brkt_env=brkt_env,
+        image_project=values.image_project
     )
     # Print the image name to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.

--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -15,9 +15,9 @@ from encryptor_service import wait_for_encryptor_up
 
 log = logging.getLogger(__name__)
 
-def validate_images(gce_svc, encrypted_image_name,  encryptor, guest_image):
+def validate_images(gce_svc, encrypted_image_name,  encryptor, guest_image, image_project=None):
     # check that image to be updated exists
-    if not gce_svc.image_exists(guest_image):
+    if not gce_svc.image_exists(guest_image, image_project):
         raise ValidationError('Image %s does not exist. Cannot update.' % guest_image)
 
     # check that encryptor exists
@@ -30,7 +30,7 @@ def validate_images(gce_svc, encrypted_image_name,  encryptor, guest_image):
 
 
 def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
-            encrypted_image_name, zone, brkt_env):
+            encrypted_image_name, zone, brkt_env, image_project=None):
     brkt_data = {}
     try:
         add_brkt_env_to_user_data(brkt_env, brkt_data)
@@ -38,7 +38,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()
 
-        gce_svc.run_instance(zone, instance_name, image_id)
+        gce_svc.run_instance(zone, instance_name, image_id, image_project)
         gce_svc.delete_instance(zone, instance_name)
         log.info('Guest instance terminated')
         log.info('Waiting for guest root disk to become ready')

--- a/brkt_cli/encrypt_gce_image_args.py
+++ b/brkt_cli/encrypt_gce_image_args.py
@@ -37,6 +37,12 @@ def setup_encrypt_gce_image_args(parser):
         required=True
     )
     parser.add_argument(
+        '--image-project',
+        help='GCE project which owns the image',
+        dest='image_project',
+        required=False
+    )
+    parser.add_argument(
         '--encryptor-image',
         dest='encryptor_image',
         required=False

--- a/brkt_cli/gce_service.py
+++ b/brkt_cli/gce_service.py
@@ -211,13 +211,17 @@ class GCEService(BaseGCEService):
                 return
             time.sleep(5)
 
-    def get_image(self, image):
-        return self.compute.images().get(project=self.project,
+    def get_image(self, image, image_project=None):
+        if image_project:
+            return self.compute.images().get(project=image_project,
+                image=image).execute()
+        else:
+            return self.compute.images().get(project=self.project,
                image=image).execute()
 
-    def image_exists(self, image):
+    def image_exists(self, image, image_project=None):
         try:
-            self.get_image(image)
+            self.get_image(image, image_project)
         except:
             return False
         return True
@@ -408,6 +412,7 @@ class GCEService(BaseGCEService):
                      zone,
                      name,
                      image,
+                     image_project=None,
                      disks=[],
                      metadata={},
                      delete_boot=False,
@@ -416,7 +421,11 @@ class GCEService(BaseGCEService):
         # if boot disk doesn't autodelete we need to track it
         if not delete_boot:
             self.disks.append(name)
-        source_disk_image = "projects/%s/global/images/%s" % (self.project,
+        if image_project:
+            source_disk_image = "projects/%s/global/images/%s" % (image_project,
+                image)
+        else:
+            source_disk_image = "projects/%s/global/images/%s" % (self.project,
                 image)
         machine_type = "zones/%s/machineTypes/%s" % (zone, instance_type)
 


### PR DESCRIPTION
YETI-819: Added an optional "image-project" attribute to the brkt-cli for GCE image encryption process. This is required to allow users to be able to directly encrypt a "public" GCE image without have to have a local copy of that image in their account (like we do with AWS). This was tested with the following conditions:
1. Encrypting a public GCE image without specifying an image project (failed)
2. Encrypting a public GCE image from a different image project to the one specified (failed)
3. Encrypting a public GCE image in the same image project specified (successful)
4. Encrypting a private GCE image without specifying an image project (successful)