### PR TITLE
Provide a means to add a startup-script for GCE instances

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -208,6 +208,10 @@ def _parse_brkt_env(brkt_env_string):
 
 def command_launch_gce_image(values, log):
     gce_svc = gce_service.GCEService(values.project, None, log)
+    if values.startup_script:
+        metadata = {'items': [{'key': 'startup-script', 'value': values.startup_script}]}
+    else:
+        metadata = {}
     launch_gce_image.launch(log,
                             gce_svc,
                             values.image,
@@ -215,7 +219,7 @@ def command_launch_gce_image(values, log):
                             values.zone,
                             values.delete_boot,
                             values.instance_type,
-                            {})
+                            metadata)
     return 0
 
 

--- a/brkt_cli/launch_gce_image_args.py
+++ b/brkt_cli/launch_gce_image_args.py
@@ -42,6 +42,13 @@ def setup_launch_gce_image_args(parser):
         dest='project',
         required=True
     )
+    parser.add_argument(
+        '--startup-script',
+        help='GCE instance startup script',
+        dest='startup_script',
+        metavar='SCRIPT',
+        required=False
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/launch_gce_image_args.py
+++ b/brkt_cli/launch_gce_image_args.py
@@ -50,6 +50,17 @@ def setup_launch_gce_image_args(parser):
         required=False
     )
 
+    # Optional startup script. Hidden because it is only used for development
+    # and testing. It should be passed as a string containing a multi-line
+    # script (bash, python etc.)
+    parser.add_argument(
+        '--startup-script',
+        help=argsparse.SUPPRESS,
+        dest='startup_script',
+        metavar='SCRIPT',
+        required=False
+    )
+
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated
     # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the

--- a/brkt_cli/launch_gce_image_args.py
+++ b/brkt_cli/launch_gce_image_args.py
@@ -42,9 +42,13 @@ def setup_launch_gce_image_args(parser):
         dest='project',
         required=True
     )
+
+    # Optional startup script. Hidden because it is only used for development
+    # and testing. It should be passed as a string containing a multi-line
+    # script (bash, python etc.)
     parser.add_argument(
         '--startup-script',
-        help='GCE instance startup script',
+        help=argsparse.SUPPRESS,
         dest='startup_script',
         metavar='SCRIPT',
         required=False

--- a/brkt_cli/launch_gce_image_args.py
+++ b/brkt_cli/launch_gce_image_args.py
@@ -54,17 +54,6 @@ def setup_launch_gce_image_args(parser):
         required=False
     )
 
-    # Optional startup script. Hidden because it is only used for development
-    # and testing. It should be passed as a string containing a multi-line
-    # script (bash, python etc.)
-    parser.add_argument(
-        '--startup-script',
-        help=argsparse.SUPPRESS,
-        dest='startup_script',
-        metavar='SCRIPT',
-        required=False
-    )
-
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated
     # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the


### PR DESCRIPTION
Added a startup-script option to the launch-gce-image command
to provide an ability to specify a startup script during instance
launch. This can be used for testing cloud-init and similar
testing (see YETI-822).

Jira: YETI-822