### PR TITLE
Adds retry to gce api calls that need it

### DIFF
--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -38,6 +38,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()
 
+        log.info('Launching guest instance')
         gce_svc.run_instance(zone, instance_name, image_id, image_project=image_project)
         gce_svc.delete_instance(zone, instance_name)
         log.info('Guest instance terminated')


### PR DESCRIPTION
Adds a retry method to utils. Also adds
execute_gce_api_call which wraps a googleapiclient
request object to make it retry-able.

API are wrapped with a retry where appropriate.
Example of an appropriate place: wait_instance
where we are waiting for a resource we created

Example of a bad place to put it: create_disk
if that fails it almost definitely is a real
problem

It's also worth noting that if for some reason
someone wanted to retry create_disk they could
I only added retries to methods in the gce_service
that clearly need it.

Testing: encrypted and updated a gce image