### PR TITLE
Add proxy support to update-encrypted-ami

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -339,6 +339,32 @@ def _parse_proxies(*proxy_host_ports):
     return proxies
 
 
+def _get_proxy_config(values):
+    """ Read proxy config specified by either the --proxy or
+    --proxy-config-file option.
+
+    @return: the contents of the proxy.yaml file, or None if not specified
+    @raise ValidationError if the file cannot be read or is malformed
+    """
+    proxy_config = None
+    if values.proxy_config_file:
+        path = values.proxy_config_file
+        log.debug('Loading proxy config from %s', path)
+        try:
+            with open(path) as f:
+                proxy_config = f.read()
+        except IOError as e:
+            log.debug('Unable to read %s', path, e)
+            raise ValidationError('Unable to read %s' % path)
+        proxy.validate_proxy_config(proxy_config)
+    elif values.proxies:
+        proxies = _parse_proxies(*values.proxies)
+        proxy_config = proxy.generate_proxy_config(*proxies)
+        log.debug('Using proxy configuration:\n%s', proxy_config)
+
+    return proxy_config
+
+
 def command_encrypt_ami(values, log):
     session_id = util.make_nonce()
 
@@ -366,21 +392,7 @@ def command_encrypt_ami(values, log):
     if values.brkt_env:
         brkt_env = _parse_brkt_env(values.brkt_env)
 
-    # Handle proxy config.
-    proxy_config = None
-    if values.proxy_config_file:
-        path = values.proxy_config_file
-        log.debug('Loading proxy config from %s', path)
-        try:
-            with open(path) as f:
-                proxy_config = f.read()
-        except IOError as e:
-            log.debug('Unable to read %s', path, e)
-            raise ValidationError('Unable to read %s' % path)
-        proxy.validate_proxy_config(proxy_config)
-    elif values.proxies:
-        proxies = _parse_proxies(*values.proxies)
-        proxy_config = proxy.generate_proxy_config(*proxies)
+    proxy_config = _get_proxy_config(values)
 
     encrypted_image_id = encrypt_ami.encrypt(
         aws_svc=aws_svc,
@@ -556,6 +568,7 @@ def command_update_encrypted_ami(values, log):
     brkt_env = None
     if values.brkt_env:
         brkt_env = _parse_brkt_env(values.brkt_env)
+    proxy_config = _get_proxy_config(values)
 
     # Initial validation done
     log.info('Updating %s with new metavisor %s', encrypted_ami, encryptor_ami)
@@ -566,7 +579,8 @@ def command_update_encrypted_ami(values, log):
         security_group_ids=values.security_group_ids,
         ntp_servers=values.ntp_servers,
         brkt_env=brkt_env,
-        guest_instance_type=values.guest_instance_type
+        guest_instance_type=values.guest_instance_type,
+        proxy_config=proxy_config
     )
     print(updated_ami_id)
     return 0

--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -3,7 +3,7 @@
 import logging
 
 from brkt_cli.util import (
-    add_brkt_env_to_user_data,
+    add_brkt_env_to_brkt_config,
     Deadline,
 )
 
@@ -33,7 +33,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, brkt_env, image_project=None):
     brkt_data = {}
     try:
-        add_brkt_env_to_user_data(brkt_env, brkt_data)
+        add_brkt_env_to_brkt_config(brkt_env, brkt_data)
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()

--- a/brkt_cli/update_ami.py
+++ b/brkt_cli/update_ami.py
@@ -27,10 +27,10 @@ import os
 
 from boto.ec2.blockdevicemapping import EBSBlockDeviceType
 
-from brkt_cli import encryptor_service
+from brkt_cli import encryptor_service, user_data
 from brkt_cli.util import (
-        add_brkt_env_to_user_data,
-        Deadline
+    add_brkt_env_to_brkt_config,
+    Deadline
 )
 import encrypt_ami
 from encryptor_service import (
@@ -62,7 +62,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
                encrypted_ami_name, subnet_id=None, security_group_ids=None,
                enc_svc_class=encryptor_service.EncryptorService,
                ntp_servers=None, brkt_env=None,
-               guest_instance_type='m3.medium'):
+               guest_instance_type='m3.medium', proxy_config=None):
     encrypted_guest = None
     updater = None
     mv_root_id = None
@@ -76,10 +76,10 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
-        user_data = {'brkt': {'solo_mode': 'updater'}}
+        brkt_config = {'brkt': {'solo_mode': 'updater'}}
         if ntp_servers:
-            user_data['ntp-servers'] = ntp_servers
-        add_brkt_env_to_user_data(brkt_env, user_data)
+            brkt_config['ntp-servers'] = ntp_servers
+        add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 
         if not security_group_ids:
             vpc_id = None
@@ -96,17 +96,19 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             ebs_optimized=False,
             subnet_id=subnet_id,
             security_group_ids=security_group_ids,
-            user_data=json.dumps(user_data))
+            user_data=json.dumps(brkt_config))
         aws_svc.create_tags(
             encrypted_guest.id,
             name=NAME_GUEST_CREATOR,
             description=DESCRIPTION_GUEST_CREATOR % {'image_id': encrypted_ami}
         )
         # Run updater in same zone as guest so we can swap volumes
+        compressed_user_data = user_data.combine_user_data(
+            brkt_config, proxy_config)
         updater = aws_svc.run_instance(
             updater_ami,
             instance_type="m3.medium",
-            user_data=json.dumps(user_data),
+            user_data=compressed_user_data,
             ebs_optimized=False,
             subnet_id=subnet_id,
             placement=encrypted_guest.placement,

--- a/brkt_cli/update_encrypted_ami_args.py
+++ b/brkt_cli/update_encrypted_ami_args.py
@@ -36,6 +36,25 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
+
+    proxy_group = parser.add_mutually_exclusive_group()
+    proxy_group.add_argument(
+        '--proxy',
+        metavar='HOST:PORT',
+        help=(
+            'Use this HTTPS proxy during encryption.  '
+            'May be specified multiple times.'
+        ),
+        dest='proxies',
+        action='append'
+    )
+    proxy_group.add_argument(
+        '--proxy-config-file',
+        metavar='PATH',
+        help='Path to proxy.yaml file that will be used during encryption',
+        dest='proxy_config_file'
+    )
+
     parser.add_argument(
         '--region',
         metavar='REGION',

--- a/brkt_cli/update_gce_image.py
+++ b/brkt_cli/update_gce_image.py
@@ -15,7 +15,7 @@
 import logging
 
 from brkt_cli.util import (
-    add_brkt_env_to_user_data,
+    add_brkt_env_to_brkt_config,
     Deadline,
 )
 from encryptor_service import wait_for_encryption
@@ -48,7 +48,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
 
         log.info("Launching encrypted updater")
         brkt_data = {'brkt': {'solo_mode': 'updater'}}
-        add_brkt_env_to_user_data(brkt_env, brkt_data)
+        add_brkt_env_to_brkt_config(brkt_env, brkt_data)
         user_data = gce_metadata_from_userdata(brkt_data)
         gce_svc.run_instance(zone,
                              updater,

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -83,15 +83,21 @@ def sleep(seconds):
         time.sleep(seconds)
 
 
-def add_brkt_env_to_user_data(brkt_env, user_data):
+def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
+    """ Add BracketEnvironment values to the config dictionary
+    that will be passed to the metavisor via userdata.
+
+    :param brkt_env a BracketEnvironment object
+    :param brkt_config a dictionary that contains configuration data
+    """
     if brkt_env:
-        if 'brkt' not in user_data:
-            user_data['brkt'] = {}
+        if 'brkt' not in brkt_config:
+            brkt_config['brkt'] = {}
         api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
         hsmproxy_host_port = '%s:%d' % (
             brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
-        user_data['brkt']['api_host'] = api_host_port
-        user_data['brkt']['hsmproxy_host'] = hsmproxy_host_port
+        brkt_config['brkt']['api_host'] = api_host_port
+        brkt_config['brkt']['hsmproxy_host'] = hsmproxy_host_port
 
 
 def make_nonce():

--- a/test.py
+++ b/test.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 import json
+import tempfile
 
 import yaml
 from boto.ec2.keypair import KeyPair
@@ -23,7 +24,11 @@ from boto.vpc import Subnet, VPC
 import brkt_cli
 import brkt_cli.util
 from brkt_cli.proxy import Proxy
-from brkt_cli.user_data import UserDataContainer, BRKT_CONFIG_CONTENT_TYPE
+from brkt_cli.user_data import (
+    UserDataContainer,
+    BRKT_CONFIG_CONTENT_TYPE,
+    BRKT_FILES_CONTENT_TYPE
+)
 from brkt_cli.validation import ValidationError
 import email
 import inspect
@@ -43,8 +48,7 @@ from brkt_cli import (
     encryptor_service,
     update_ami
 )
-from brkt_cli import aws_service
-from brkt_cli import proxy
+from brkt_cli import aws_service, proxy, user_data
 
 brkt_cli.log = logging.getLogger(__name__)
 
@@ -797,11 +801,53 @@ class TestBrktEnv(unittest.TestCase):
             encryptor_ami=encryptor_image.id
         )
 
+    def test_brkt_env_update(self):
+        """ Test that the Bracket environment is passed through to metavisor
+        user data.
+        """
+        aws_svc, encryptor_image, guest_image = _build_aws_service()
+        encrypted_ami_id = encrypt_ami.encrypt(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id
+        )
+
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        brkt_env = brkt_cli._parse_brkt_env(
+            api_host_port + ',' + hsmproxy_host_port)
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                brkt_config = self._get_brkt_config_from_mime(args.user_data)
+                d = json.loads(brkt_config)
+                self.assertEquals(
+                    api_host_port,
+                    d['brkt']['api_host']
+                )
+                self.assertEquals(
+                    hsmproxy_host_port,
+                    d['brkt']['hsmproxy_host']
+                )
+                self.assertEquals(
+                    'updater',
+                    d['brkt']['solo_mode']
+                )
+
+        aws_svc.run_instance_callback = run_instance_callback
+        update_ami(
+            aws_svc, encrypted_ami_id, encryptor_image.id,
+            'Test updated AMI',
+            enc_svc_class=DummyEncryptorService,
+            brkt_env=brkt_env
+        )
+
 
 class TestRunUpdate(unittest.TestCase):
 
     def setUp(self):
-        brkt_cli.util.SLEEP_ENABLED = False
+        encrypt_ami.SLEEP_ENABLED = False
 
     def test_subnet_and_security_groups(self):
         """ Test that the subnet and security group ids are passed through
@@ -825,53 +871,14 @@ class TestRunUpdate(unittest.TestCase):
 
         aws_svc.run_instance_callback = run_instance_callback
         ami_id = update_ami(
-            aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
+            aws_svc, encrypted_ami_id, encryptor_image.id,
+            'Test updated AMI',
             subnet_id='subnet-1', security_group_ids=['sg-1', 'sg-2'],
             enc_svc_class=DummyEncryptorService
         )
 
         self.assertEqual(2, self.call_count)
         self.assertIsNotNone(ami_id)
-
-    def test_brkt_env_update(self):
-        """ Test that the Bracket environment is through to metavisor user
-        data.
-        """
-        aws_svc, encryptor_image, guest_image = _build_aws_service()
-        encrypted_ami_id = encrypt_ami.encrypt(
-            aws_svc=aws_svc,
-            enc_svc_cls=DummyEncryptorService,
-            image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
-        )
-
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        brkt_env = brkt_cli._parse_brkt_env(
-            api_host_port + ',' + hsmproxy_host_port)
-
-        def run_instance_callback(args):
-            if args.image_id == encryptor_image.id:
-                d = json.loads(args.user_data)
-                self.assertEquals(
-                    api_host_port,
-                    d['brkt']['api_host']
-                )
-                self.assertEquals(
-                    hsmproxy_host_port,
-                    d['brkt']['hsmproxy_host']
-                )
-                self.assertEquals(
-                    'updater',
-                    d['brkt']['solo_mode']
-                )
-
-        aws_svc.run_instance_callback = run_instance_callback
-        update_ami(
-            aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
-            enc_svc_class=DummyEncryptorService,
-            brkt_env=brkt_env
-        )
 
     def test_guest_instance_type(self):
         """ Test that the guest instance type is passed through
@@ -895,7 +902,7 @@ class TestRunUpdate(unittest.TestCase):
                 self.fail('Unexpected image: ' + args.image_id)
 
         aws_svc.run_instance_callback = run_instance_callback
-        ami_id = update_ami(
+        update_ami(
             aws_svc, encrypted_ami_id, encryptor_image.id, 'Test updated AMI',
             subnet_id='subnet-1', security_group_ids=['sg-1', 'sg-2'],
             enc_svc_class=DummyEncryptorService, guest_instance_type='t2.micro'
@@ -1056,6 +1063,8 @@ class DummyValues(object):
         self.validate = True
         self.ami = None
         self.encryptor_ami = None
+        self.proxies = []
+        self.proxy_config_file = None
 
 
 class TestValidation(unittest.TestCase):
@@ -1438,6 +1447,35 @@ class TestUserData(unittest.TestCase):
         mime = udc.to_mime_text()
         self.assertTrue('test.txt: {contents: 1 2 3}' in mime)
 
+    def test_combine_user_data(self):
+        """ Test combining Bracket config data with HTTP proxy config data.
+        """
+        brkt_config = {'foo': 'bar'}
+        p = Proxy(host='proxy1.example.com', port=8001)
+        proxy_config = proxy.generate_proxy_config(p)
+        compressed_mime_data = user_data.combine_user_data(
+            brkt_config,
+            proxy_config
+        )
+        mime_data = zlib.decompress(compressed_mime_data, 16 + zlib.MAX_WBITS)
+
+        msg = email.message_from_string(mime_data)
+        found_brkt_config = False
+        found_brkt_files = False
+
+        for part in msg.walk():
+            if part.get_content_type() == BRKT_CONFIG_CONTENT_TYPE:
+                found_brkt_config = True
+                content = part.get_payload(decode=True)
+                self.assertEqual('{"foo": "bar"}', content)
+            if part.get_content_type() == BRKT_FILES_CONTENT_TYPE:
+                found_brkt_files = True
+                content = part.get_payload(decode=True)
+                self.assertTrue('/var/brkt/ami_config/proxy.yaml:' in content)
+
+        self.assertTrue(found_brkt_config)
+        self.assertTrue(found_brkt_files)
+
 
 class TestCommandLineOptions(unittest.TestCase):
     """ Test handling of command line options."""
@@ -1498,3 +1536,32 @@ class TestCommandLineOptions(unittest.TestCase):
         with self.assertRaises(ValidationError):
             brkt_cli._parse_brkt_env('a:7,b?:8')
 
+    def test_get_proxy_config(self):
+        """ Test reading proxy config from the --proxy and --proxy-config-file
+        command line options.
+        """
+        # No proxy.
+        values = DummyValues()
+        self.assertIsNone(brkt_cli._get_proxy_config(values))
+
+        # --proxy specified.
+        values.proxies = ['proxy.example.com:8000']
+        proxy_yaml = brkt_cli._get_proxy_config(values)
+        d = yaml.load(proxy_yaml)
+        self.assertEquals('proxy.example.com', d['proxies'][0]['host'])
+
+        # --proxy-config-file references a file that doesn't exist.
+        values.proxy = None
+        values.proxy_config_file = 'bogus.yaml'
+        with self.assertRaises(ValidationError):
+            brkt_cli._get_proxy_config(values)
+
+        # --proxy-config-file references a valid file.
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(proxy_yaml)
+            f.flush()
+            values.proxy_config_file = f.name
+            proxy_yaml = brkt_cli._get_proxy_config(values)
+
+        d = yaml.load(proxy_yaml)
+        self.assertEquals('proxy.example.com', d['proxies'][0]['host'])

--- a/test_gce.py
+++ b/test_gce.py
@@ -305,7 +305,7 @@ class TestBrktEnv(unittest.TestCase):
         expected_userdata = {'brkt':{'api_host': api_host_port, 'hsmproxy_host': hsmproxy_host_port}}
         brkt_env = brkt_cli._parse_brkt_env(
             api_host_port + ',' + hsmproxy_host_port)
-        util.add_brkt_env_to_user_data(brkt_env, userdata)
+        util.add_brkt_env_to_brkt_config(brkt_env, userdata)
         self.assertEqual(userdata, expected_userdata)
 
 


### PR DESCRIPTION
Add --proxy and --proxy-config-file options to the update-encrypted-ami
subcommand.

Add a _get_proxy_config() utility function for loading proxy.yaml
content.  This function is called during encryption and update.

Add a combine_user_data() function, which generates the gzipped MIME
blob that is passed to the metavisor.  This allows us to write dedicated
unit tests for this logic.

Minor terminology changes:
* user data: the actual user data bytes that are sent to the instance
* brkt env: host/port of the api service and HSM proxy
* brkt config: the dictionary that stores brkt env, ntp servers, etc.