### PR TITLE
Add support for subcommand modules

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import argparse
+import importlib
 import logging
 import re
 import sys
@@ -28,7 +29,6 @@ from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
 from brkt_cli import aws_service
 from brkt_cli import encrypt_ami
-from brkt_cli import encrypt_ami_args
 from brkt_cli import encryptor_service
 from brkt_cli import encrypt_gce_image
 from brkt_cli import encrypt_gce_image_args
@@ -36,7 +36,6 @@ from brkt_cli import gce_service
 from brkt_cli import launch_gce_image
 from brkt_cli import launch_gce_image_args
 from brkt_cli import oauth_requests
-from brkt_cli import update_encrypted_ami_args
 from brkt_cli import update_gce_image
 from brkt_cli import update_encrypted_gce_image_args
 from brkt_cli import util
@@ -52,6 +51,10 @@ from update_ami import update_ami
 
 VERSION = '0.9.17pre1'
 BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
+
+# The list of modules that may be loaded.  Modules contain subcommands of
+# the brkt command and CSP-specific code.
+MODULE_NAMES = ['brkt_cli.aws', 'brkt_cli.gce']
 
 log = None
 
@@ -175,6 +178,7 @@ def _parse_tags(tag_strings):
             raise ValidationError('Tag %s is not in the format KEY=VALUE' % s)
         tags[m.group(1)] = m.group(2)
     return tags
+
 
 def _api_login(api_addr, api_email, api_password, https=True):
     scheme = 'https' if https else 'http'
@@ -677,17 +681,50 @@ def main():
         help="Don't check whether this version of brkt-cli is supported"
     )
 
-    # metavar indicates with subparsers will be shown
-    # when the cli is invoked incorrectly or with -h/--help
-    # this hides other subparsers that shouldn't be visible
-    # to users
-    subparsers = parser.add_subparsers(dest='subparser_name', metavar='{encrypt-ami,update-encrypted-ami}')
+    # Batch up messages that are logged while loading modules.  We don't know
+    # whether to log them yet, since we haven't parsed arguments.  argparse
+    # seems to get confused when you parse arguments twice.
+    module_load_messages = []
 
-    encrypt_ami_parser = subparsers.add_parser(
-        'encrypt-ami',
-        description='Create an encrypted AMI from an existing AMI.'
+    # Load subcommand modules dynamically.
+    modules = []
+    subcommand_to_module = {}
+
+    # Load any modules that are installed.
+    for module_name in MODULE_NAMES:
+        try:
+            module = importlib.import_module(module_name)
+            modules.append(module)
+        except ImportError as e:
+                module_load_messages.append(
+                    'Skipping module %s: %s' % (module_name, e))
+
+    # Map each subcommand to the module that contains it.
+    for module in modules:
+        for subcommand in module.INTERFACE.get_subcommands():
+            subcommand_to_module[subcommand] = module
+
+    # Use metavar to hide any subcommands that we don't want to expose.
+    exposed_subcommands = []
+    for module in modules:
+        exposed_subcommands.extend(
+            module.INTERFACE.get_exposed_subcommands()
+        )
+    exposed_subcommands = sorted(exposed_subcommands)
+    metavar = '{%s}' % ','.join(exposed_subcommands)
+
+    subparsers = parser.add_subparsers(
+        dest='subparser_name',
+        metavar=metavar
     )
-    encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
+
+    # Add subcommands to the parser.
+    for subcommand, module in subcommand_to_module.iteritems():
+        module_load_messages.append(
+            'Registering subcommand %s in %s' % (
+                subcommand, module.__package__)
+        )
+        module.INTERFACE.register_subcommand(subparsers, subcommand)
 
     encrypt_gce_image_parser = subparsers.add_parser('encrypt-gce-image')
     encrypt_gce_image_args.setup_encrypt_gce_image_args(encrypt_gce_image_parser)
@@ -697,16 +734,6 @@ def main():
 
     update_gce_image_parser = subparsers.add_parser('update-gce-image')
     update_encrypted_gce_image_args.setup_update_gce_image_args(update_gce_image_parser)
-
-    update_encrypted_ami_parser = \
-        subparsers.add_parser(
-            'update-encrypted-ami',
-            description=(
-                'Update an encrypted AMI with the latest Metavisor release.'
-            )
-        )
-    update_encrypted_ami_args.setup_update_encrypted_ami(
-        update_encrypted_ami_parser)
 
     argv = sys.argv[1:]
     values = parser.parse_args(argv)
@@ -729,6 +756,13 @@ def main():
     log.setLevel(log_level)
     aws_service.log.setLevel(log_level)
     encryptor_service.log.setLevel(log_level)
+
+    for module in modules:
+        for log in module.INTERFACE.get_loggers():
+            log.setLevel(log_level)
+
+    for msg in module_load_messages:
+        log.debug(msg)
 
     if values.check_version:
         supported_versions = None

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -701,14 +701,14 @@ def main():
 
     # Map each subcommand to the module that contains it.
     for module in modules:
-        for subcommand in module.INTERFACE.get_subcommands():
+        for subcommand in module.get_interface().get_subcommands():
             subcommand_to_module[subcommand] = module
 
     # Use metavar to hide any subcommands that we don't want to expose.
     exposed_subcommands = []
     for module in modules:
         exposed_subcommands.extend(
-            module.INTERFACE.get_exposed_subcommands()
+            module.get_interface().get_exposed_subcommands()
         )
     exposed_subcommands = sorted(exposed_subcommands)
     metavar = '{%s}' % ','.join(exposed_subcommands)
@@ -724,7 +724,7 @@ def main():
             'Registering subcommand %s in %s' % (
                 subcommand, module.__package__)
         )
-        module.INTERFACE.register_subcommand(subparsers, subcommand)
+        module.get_interface().register_subcommand(subparsers, subcommand)
 
     encrypt_gce_image_parser = subparsers.add_parser('encrypt-gce-image')
     encrypt_gce_image_args.setup_encrypt_gce_image_args(encrypt_gce_image_parser)
@@ -758,7 +758,7 @@ def main():
     encryptor_service.log.setLevel(log_level)
 
     for module in modules:
-        for log in module.INTERFACE.get_loggers():
+        for log in module.get_interface().get_loggers():
             log.setLevel(log_level)
 
     for msg in module_load_messages:

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -1,0 +1,58 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+from brkt_cli.aws import encrypt_ami_args, update_encrypted_ami_args
+from brkt_cli.module import ModuleInterface
+
+
+class AWSModuleInterface(ModuleInterface):
+
+    def get_subcommands(self):
+        return ['encrypt-ami', 'update-encrypted-ami']
+
+    def get_exposed_subcommands(self):
+        return self.get_subcommands()
+
+    def get_loggers(self):
+        return []
+
+    def register_subcommand(self, subparsers, subcommand):
+        if subcommand == 'encrypt-ami':
+            encrypt_ami_parser = subparsers.add_parser(
+                'encrypt-ami',
+                description='Create an encrypted AMI from an existing AMI.'
+            )
+            encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
+
+        if subcommand == 'update-encrypted-ami':
+            update_encrypted_ami_parser = subparsers.add_parser(
+                'update-encrypted-ami',
+                description=(
+                    'Update an encrypted AMI with the latest Metavisor '
+                    'release.'
+                )
+            )
+            update_encrypted_ami_args.setup_update_encrypted_ami(
+                update_encrypted_ami_parser)
+
+    def run_subcommand(self, subcommand, values):
+        if values.subparser_name == 'encrypt-ami':
+            # return command_encrypt_ami(values, log)
+            print subcommand
+        if values.subparser_name == 'update-encrypted-ami':
+            # return command_update_encrypted_ami(values, log)
+            print subcommand
+
+
+INTERFACE = AWSModuleInterface()

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -55,4 +55,5 @@ class AWSModuleInterface(ModuleInterface):
             print subcommand
 
 
-INTERFACE = AWSModuleInterface()
+def get_interface():
+    return AWSModuleInterface()

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -1,11 +1,25 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 
 
-def setup_update_encrypted_ami(parser):
+def setup_encrypt_ami_args(parser):
     parser.add_argument(
         'ami',
         metavar='ID',
-        help='The encrypted AMI that will be updated'
+        help='The guest AMI that will be encrypted'
     )
     parser.add_argument(
         '--encrypted-ami-name',
@@ -36,6 +50,16 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
+    parser.add_argument(
+        '--ntp-server',
+        metavar='DNS Name',
+        dest='ntp_servers',
+        action='append',
+        help=(
+            'Optional NTP server to sync Metavisor clock. '
+            'May be specified multiple times.'
+        )
+    )
 
     proxy_group = parser.add_mutually_exclusive_group()
     proxy_group.add_argument(
@@ -57,10 +81,9 @@ def setup_update_encrypted_ami(parser):
 
     parser.add_argument(
         '--region',
-        metavar='REGION',
+        metavar='NAME',
         help='AWS region (e.g. us-west-2)',
         dest='region',
-        default='us-west-2',
         required=True
     )
     parser.add_argument(
@@ -80,31 +103,6 @@ def setup_update_encrypted_ami(parser):
         help='Launch instances in this subnet'
     )
     parser.add_argument(
-        '--ntp-server',
-        metavar='DNS Name',
-        dest='ntp_servers',
-        action='append',
-        help=(
-            'Optional NTP server to sync Metavisor clock. '
-            'May be specified multiple times.'
-        )
-    )
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
-    # Optional EC2 SSH key pair name to use for launching the guest
-    # and encryptor instances.  This argument is hidden because it's only
-    # used for development.
-    parser.add_argument(
-        '--key',
-        metavar='KEY',
-        help=argparse.SUPPRESS,
-        dest='key_name'
-    )
-    parser.add_argument(
         '--tag',
         metavar='KEY=VALUE',
         dest='tags',
@@ -115,13 +113,31 @@ def setup_update_encrypted_ami(parser):
         )
     )
 
-    # Optional hidden argument for specifying the metavisor AMI.  This
-    # argument is hidden because it's only used for development.  It can
-    # also be used to override the default AMI if it's determined to be
-    # unstable.
+    # Optional yeti endpoints. Hidden because it's only used for development.
+    # If you're using this option, it should be passed as a comma separated
+    # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
+    # endpoints must also be in order: api_host,hsmproxy_host
+    parser.add_argument(
+        '--brkt-env',
+        dest='brkt_env',
+        help=argparse.SUPPRESS
+    )
+
+    # Optional AMI ID that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
     parser.add_argument(
         '--encryptor-ami',
         metavar='ID',
+        dest='encryptor_ami',
+        help=argparse.SUPPRESS
+    )
+
+    # Optional EC2 SSH key pair name to use for launching the guest
+    # and encryptor instances.  This argument is hidden because it's only
+    # used for development.
+    parser.add_argument(
+        '--key',
+        metavar='NAME',
         help=argparse.SUPPRESS,
-        dest='encryptor_ami'
+        dest='key_name'
     )

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -1,11 +1,25 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 
 
-def setup_encrypt_ami_args(parser):
+def setup_update_encrypted_ami(parser):
     parser.add_argument(
         'ami',
         metavar='ID',
-        help='The guest AMI that will be encrypted'
+        help='The encrypted AMI that will be updated'
     )
     parser.add_argument(
         '--encrypted-ami-name',
@@ -57,9 +71,10 @@ def setup_encrypt_ami_args(parser):
 
     parser.add_argument(
         '--region',
-        metavar='NAME',
+        metavar='REGION',
         help='AWS region (e.g. us-west-2)',
         dest='region',
+        default='us-west-2',
         required=True
     )
     parser.add_argument(
@@ -79,16 +94,6 @@ def setup_encrypt_ami_args(parser):
         help='Launch instances in this subnet'
     )
     parser.add_argument(
-        '--tag',
-        metavar='KEY=VALUE',
-        dest='tags',
-        action='append',
-        help=(
-            'Custom tag for resources created during encryption. '
-            'May be specified multiple times.'
-        )
-    )
-    parser.add_argument(
         '--ntp-server',
         metavar='DNS Name',
         dest='ntp_servers',
@@ -98,32 +103,39 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
-
     # Optional yeti endpoints. Hidden because it's only used for development.
-    # If you're using this option, it should be passed as a comma separated
-    # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
-    # endpoints must also be in order: api_host,hsmproxy_host
     parser.add_argument(
         '--brkt-env',
         dest='brkt_env',
         help=argparse.SUPPRESS
     )
-
-    # Optional AMI ID that's used to launch the encryptor instance.  This
-    # argument is hidden because it's only used for development.
-    parser.add_argument(
-        '--encryptor-ami',
-        metavar='ID',
-        dest='encryptor_ami',
-        help=argparse.SUPPRESS
-    )
-
     # Optional EC2 SSH key pair name to use for launching the guest
     # and encryptor instances.  This argument is hidden because it's only
     # used for development.
     parser.add_argument(
         '--key',
-        metavar='NAME',
+        metavar='KEY',
         help=argparse.SUPPRESS,
         dest='key_name'
+    )
+    parser.add_argument(
+        '--tag',
+        metavar='KEY=VALUE',
+        dest='tags',
+        action='append',
+        help=(
+            'Custom tag for resources created during encryption. '
+            'May be specified multiple times.'
+        )
+    )
+
+    # Optional hidden argument for specifying the metavisor AMI.  This
+    # argument is hidden because it's only used for development.  It can
+    # also be used to override the default AMI if it's determined to be
+    # unstable.
+    parser.add_argument(
+        '--encryptor-ami',
+        metavar='ID',
+        help=argparse.SUPPRESS,
+        dest='encryptor_ami'
     )

--- a/brkt_cli/module.py
+++ b/brkt_cli/module.py
@@ -1,0 +1,60 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import abc
+
+
+class ModuleInterface(object):
+    """ brkt-cli modules need to implement this interface in order to
+    be initialized.  Each module must have a variable called INTERFACE
+    in its __init__.py which implements this interface.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def get_subcommands(self):
+        """ Return the list of subcommands that are implemented by the module.
+        @return a list of strings
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_exposed_subcommands(self):
+        """ Return the list of subcommands that are shown in brkt command
+        usage.
+        @return a list of strings
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_loggers(self):
+        """ Return a list of Logger objects.  brkt_cli sets the log level
+        to INFO or DEBUG, depending on whether the user specifies -v.
+        """
+        pass
+
+    @abc.abstractmethod
+    def register_subcommand(self, subparsers, subcommand):
+        """ Modules implement this callback in order to add subcommands to the
+        command parser.
+
+        :param subparsers: the ArgumentParser object returned by
+            add_subparsers()
+        :param subcommand: the subcommand name
+        """
+        pass
+
+    @abc.abstractmethod
+    def run_subcommand(self, subcommand, values):
+        """ Modules implement this callback to run a subcommand. """
+        pass

--- a/brkt_cli/module.py
+++ b/brkt_cli/module.py
@@ -16,8 +16,8 @@ import abc
 
 class ModuleInterface(object):
     """ brkt-cli modules need to implement this interface in order to
-    be initialized.  Each module must have a variable called INTERFACE
-    in its __init__.py which implements this interface.
+    be initialized.  Each module must have a function called get_interface()
+    in its __init__.py which returns an instance of this interface.
     """
     __metaclass__ = abc.ABCMeta
 


### PR DESCRIPTION
Move AWS argument parsing into a new brkt_cli.aws module.  Load the
module by name and call its interface to initialize command line
arguments.  The next step will be to move all of the AWS-specific code
into brkt_cli.aws so that it isn't intermingled with other CLI and GCE
logic.