### PR TITLE
Initialize logging in submodules

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -14,6 +14,7 @@
 import logging
 import re
 
+import boto
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
 import brkt_cli
@@ -40,8 +41,10 @@ class AWSModuleInterface(ModuleInterface):
     def get_exposed_subcommands(self):
         return self.get_subcommands()
 
-    def get_loggers(self):
-        return [log]
+    def init_logging(self, verbose):
+        # Set boto logging to FATAL, since boto logs auth errors and 401s
+        # at ERROR level.
+        boto.log.setLevel(logging.FATAL)
 
     def register_subcommand(self, subparsers, subcommand):
         if subcommand == 'encrypt-ami':

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -18,6 +18,7 @@ import tempfile
 
 import boto
 import boto.sts
+import boto.vpc
 import logging
 from boto.exception import EC2ResponseError
 import time

--- a/brkt_cli/module.py
+++ b/brkt_cli/module.py
@@ -36,10 +36,11 @@ class ModuleInterface(object):
         """
         pass
 
-    @abc.abstractmethod
-    def get_loggers(self):
-        """ Return a list of Logger objects.  brkt_cli sets the log level
-        to INFO or DEBUG, depending on whether the user specifies -v.
+    def init_logging(self, verbose):
+        """ Modules can optionally implement this callback to initialize
+        loggers.
+
+        :param verbose: True if the user specified verbose logging
         """
         pass
 


### PR DESCRIPTION
Add an init_logging() method to ModuleInterface, which allows submodules
to configure logging.  Move boto logging setup into the aws submodule.
Set the default log level on the root logger, per the usual convention,
and suppress boto logging explicitly.

Import boto.vpc in aws_service.  Somehow an unrelated code change caused
boto.vpc.regions() to start failing.