### PR TITLE
Return exit status from run_subcommand()

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -450,7 +450,7 @@ def main():
         subcommand = values.subparser_name
         if subcommand in subcommand_to_module:
             module = subcommand_to_module[subcommand]
-            module.get_interface().run_subcommand(subcommand, values)
+            return module.get_interface().run_subcommand(subcommand, values)
         if subcommand == 'launch-gce-image':
             log.info('Warning: GCE support is still in development.')
             return command_launch_gce_image(values, log)

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -65,9 +65,9 @@ class AWSModuleInterface(ModuleInterface):
     def run_subcommand(self, subcommand, values):
         try:
             if values.subparser_name == 'encrypt-ami':
-                command_encrypt_ami(values, log)
+                return command_encrypt_ami(values, log)
             if values.subparser_name == 'update-encrypted-ami':
-                command_update_encrypted_ami(values, log)
+                return command_update_encrypted_ami(values, log)
         except NoAuthHandlerFound:
             msg = (
                 'Unable to connect to AWS.  Are your AWS_ACCESS_KEY_ID and '
@@ -104,6 +104,8 @@ class AWSModuleInterface(ModuleInterface):
                 )
             else:
                 raise
+
+        return 1
 
 
 def get_interface():

--- a/brkt_cli/module.py
+++ b/brkt_cli/module.py
@@ -56,5 +56,8 @@ class ModuleInterface(object):
 
     @abc.abstractmethod
     def run_subcommand(self, subcommand, values):
-        """ Modules implement this callback to run a subcommand. """
+        """ Modules implement this callback to run a subcommand.
+
+        :return the exit status as an integer (0 means success)
+        """
         pass


### PR DESCRIPTION
Update AWSModuleInterface.run_subcommand() and the callsite to return
the exit status.  Failing to do this caused the function to return None,
which resulted in an exit status of 1.