### PR TITLE
Add -v option to subcommands

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -46,6 +46,14 @@ class AWSModuleInterface(ModuleInterface):
         # at ERROR level.
         boto.log.setLevel(logging.FATAL)
 
+    def verbose(self, subcommand, values):
+        if subcommand == 'encrypt-ami':
+            return values.encrypt_ami_verbose
+        elif subcommand == 'update-encrypted-ami':
+            return values.update_encrypted_ami_verbose
+        else:
+            raise Exception('Unexpected subcommand: %s' % subcommand)
+
     def register_subcommand(self, subparsers, subcommand):
         if subcommand == 'encrypt-ami':
             encrypt_ami_parser = subparsers.add_parser(

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -112,6 +112,13 @@ def setup_encrypt_ami_args(parser):
             'May be specified multiple times.'
         )
     )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='encrypt_ami_verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -128,6 +128,13 @@ def setup_update_encrypted_ami(parser):
             'May be specified multiple times.'
         )
     )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='update_encrypted_ami_verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
 
     # Optional hidden argument for specifying the metavisor AMI.  This
     # argument is hidden because it's only used for development.  It can

--- a/brkt_cli/module.py
+++ b/brkt_cli/module.py
@@ -44,6 +44,15 @@ class ModuleInterface(object):
         """
         pass
 
+    def verbose(self, subcommand, values):
+        """ Modules can optionally implement this callback to specify
+        whether the verbose flag was specified for the given subcommand.
+
+        @param subcommand the subcommand to check
+        @param values the parsed arguments object
+        """
+        return False
+
     @abc.abstractmethod
     def register_subcommand(self, subparsers, subcommand):
         """ Modules implement this callback in order to add subcommands to the


### PR DESCRIPTION
Add -v and --verbose to the encrypt-ami and update-encrypted-ami
subcommands.  Several users have gotten confused because -v was
specified as an option to the top-level brkt command.