### PR TITLE
Block project wide ssh keys when we launch guest for encryption

### DIFF
--- a/brkt_cli/encrypt_gce_image.py
+++ b/brkt_cli/encrypt_gce_image.py
@@ -40,7 +40,7 @@ def setup_encryption(gce_svc,
                      image_project):
     try:
         log.info('Launching guest instance')
-        gce_svc.run_instance(zone, instance_name, image_id, image_project=image_project)
+        gce_svc.run_instance(zone, instance_name, image_id, block_project_ssh_keys=True, image_project=image_project)
         gce_svc.delete_instance(zone, instance_name)
         log.info('Guest instance terminated')
         log.info('Waiting for guest root disk to become ready')

--- a/brkt_cli/gce_service.py
+++ b/brkt_cli/gce_service.py
@@ -161,7 +161,9 @@ class BaseGCEService(object):
                      disks,
                      metadata,
                      delete_boot,
-                     instance_type):
+                     block_project_ssh_keys,
+                     instance_type,
+                     image_project):
         pass
 
     @abc.abstractmethod
@@ -430,9 +432,16 @@ class GCEService(BaseGCEService):
                      disks=[],
                      metadata={},
                      delete_boot=False,
+                     block_project_ssh_keys=False,
                      instance_type='n1-standard-4',
                      image_project=None):
         self.instances.append(name)
+
+        if block_project_ssh_keys:
+            if 'items' not in metadata:
+                metadata['items'] = []
+            metadata['items'].append({"key": "block-project-ssh-keys", 'value': 'true'})
+
         # if boot disk doesn't autodelete we need to track it
         if not delete_boot:
             self.disks.append(name)

--- a/test_gce.py
+++ b/test_gce.py
@@ -138,6 +138,7 @@ class DummyGCEService(gce_service.BaseGCEService):
                      disks=[],
                      metadata={},
                      delete_boot=False,
+                     block_project_ssh_keys=False,
                      instance_type='n1-standard-4',
                      image_project=None):
         self.instances.append(name)


### PR DESCRIPTION
This will prevent us from creating an undesirable authorized_keys
file on the guest root disk.