### PR TITLE
Remove dependencies from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ In order to use the Bracket service, you must be a
 registered Bracket customer.  Email support@brkt.com for
 more information.
 
-**brkt-cli** has the following dependencies:
-* Python 2.7
-* [boto](https://github.com/boto/boto) 2.38.0+ (Python interface to AWS)
-* [requests](http://www.python-requests.org/en/latest/) 2.7.0+ (Python HTTP library)
+**brkt-cli** requires Python 2.7.
 
 ## Process
 


### PR DESCRIPTION
The list of dependencies has become stale.  Removing it, so that we
don't have to keep it current.  It's no longer necessary, now that we're
using pip/setuptools to automatically install dependencies.