### PR TITLE
Add generate-jwt command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python: "2.7"
-install: pip install boto requests google-api-python-client PyYAML oauthlib
-script: python -m unittest test test_gce
+install: pip install boto requests google-api-python-client PyYAML oauthlib iso8601 ecdsa
+script: python -m unittest discover

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -45,7 +45,7 @@ BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
 
 # The list of modules that may be loaded.  Modules contain subcommands of
 # the brkt command and CSP-specific code.
-MODULE_NAMES = ['brkt_cli.aws', 'brkt_cli.gce']
+MODULE_NAMES = ['brkt_cli.aws', 'brkt_cli.gce', 'brkt_cli.jwt']
 
 log = logging.getLogger(__name__)
 
@@ -356,8 +356,8 @@ def main():
             module = importlib.import_module(module_name)
             modules.append(module)
         except ImportError as e:
-                module_load_messages.append(
-                    'Skipping module %s: %s' % (module_name, e))
+            module_load_messages.append(
+                'Skipping module %s: %s' % (module_name, e))
 
     # Map each subcommand to the module that contains it.
     for module in modules:

--- a/brkt_cli/jwt/__init__.py
+++ b/brkt_cli/jwt/__init__.py
@@ -1,0 +1,179 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import json
+import re
+
+from datetime import datetime
+from ecdsa import SigningKey, NIST384p
+import base64
+import iso8601
+import time
+
+import brkt_cli
+from brkt_cli import util
+from brkt_cli.module import ModuleInterface
+from brkt_cli.validation import ValidationError
+
+
+class JWTModuleInterface(ModuleInterface):
+
+    def get_subcommands(self):
+        return ['generate-jwt']
+
+    def get_exposed_subcommands(self):
+        return self.get_subcommands()
+
+    def register_subcommand(self, subparsers, subcommand):
+        if subcommand == 'generate-jwt':
+            parser = subparsers.add_parser(
+                'generate-jwt',
+                description=(
+                    'Generate a JSON Web Token for launching an encrypted '
+                    'instance. A timestamp can be either a Unix timestamp in '
+                    'seconds or ISO 8601 (2016-05-10T19:15:36Z).'
+                )
+            )
+            setup_generate_jwt_args(parser)
+
+    def run_subcommand(self, subcommand, values):
+        signing_key = read_signing_key(values.signing_key)
+        exp = None
+        if values.exp:
+            exp = parse_timestamp(values.exp)
+        nbf = None
+        if values.nbf:
+            nbf = parse_timestamp(values.nbf)
+        print generate_jwt(signing_key, exp=exp, nbf=nbf)
+        return 0
+
+
+def _timestamp_to_datetime(ts):
+    """ Convert a Unix timestamp to a datetime with timezone set to UTC. """
+    return datetime.fromtimestamp(ts, tz=iso8601.UTC)
+
+
+def _datetime_to_timestamp(dt):
+    """ Convert a datetime to a Unix timestamp in seconds. """
+    time_zero = _timestamp_to_datetime(0)
+    return (dt - time_zero).total_seconds()
+
+
+def get_interface():
+    return JWTModuleInterface()
+
+
+def read_signing_key(path):
+    with open(path) as f:
+        key_string = f.read()
+    signing_key = SigningKey.from_pem(key_string)
+    if signing_key.curve != NIST384p:
+        raise ValidationError(
+            'Signing key uses the %s. %s is required.' % (
+                signing_key.curve.name, NIST384p.name)
+        )
+    return signing_key
+
+
+def parse_timestamp(ts_string):
+    """ Return a datetime that represents the given timestamp
+    string.  The string can be a Unix timestamp in seconds or an ISO 8601
+    timestamp. """
+    now = int(time.time())
+
+    # Parse integer timestamp.
+    m = re.match('\d+(\.\d+)?$', ts_string)
+    if m:
+        t = float(ts_string)
+        if t < now:
+            raise ValidationError(
+                '%s is earlier than the current timestamp (%s).' % (
+                    ts_string, now))
+        return _timestamp_to_datetime(t)
+
+    # Parse ISO 8601 timestamp.
+    dt_now = _timestamp_to_datetime(now)
+    dt = iso8601.parse_date(ts_string)
+    if dt < dt_now:
+        raise ValidationError(
+            '%s is earlier than the current timestamp (%s).' % (
+                ts_string, dt_now))
+    return dt
+
+
+def generate_jwt(signing_key, exp=None, nbf=None, cnc=None):
+    """ Generate a JWT.
+
+    :param exp expiration time as a datetime
+    :param nbf not before as a datetime
+    :param cnc maximum number of concurrent instances as an integer
+    :return the JWT as a string
+    """
+
+    header_dict = {'typ': 'JWT', 'alg': 'ES384'}
+    payload_dict = {
+        'jti': util.make_nonce(),
+        'iss': 'brkt-cli-' + brkt_cli.VERSION,
+        'iat': int(time.time())
+    }
+    if exp:
+        payload_dict['exp'] = _datetime_to_timestamp(exp)
+    if nbf:
+        payload_dict['nbf'] = _datetime_to_timestamp(nbf)
+    if cnc is not None:
+        payload_dict['cnc'] = cnc
+
+    def encode(content):
+        return base64.urlsafe_b64encode(content).replace(b'=', b'')
+
+    header_json = json.dumps(header_dict, sort_keys=True)
+    header_b64 = encode(header_json)
+    payload_json = json.dumps(payload_dict, sort_keys=True)
+    payload_b64 = encode(payload_json)
+    signature = signing_key.sign('%s.%s' % (header_b64, payload_b64))
+
+    return '%s.%s.%s' % (header_b64, payload_b64, encode(signature))
+
+
+def setup_generate_jwt_args(parser):
+    parser.add_argument(
+        '--cnc',
+        metavar='N',
+        type=int,
+        help='Maximum number of concurrent instances'
+    )
+    parser.add_argument(
+        '--exp',
+        metavar='TIMESTAMP',
+        help='Token expiration time'
+    )
+    parser.add_argument(
+        '--nbf',
+        metavar='TIMESTAMP',
+        help='Token is not valid before this time'
+    )
+    parser.add_argument(
+        '--signing-key',
+        metavar='PATH',
+        help=(
+            'The private key that is used to sign the JWT. The key must be '
+            'in PEM format.'),
+        required=True
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='update_encrypted_ami_verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )

--- a/brkt_cli/jwt/__init__.py
+++ b/brkt_cli/jwt/__init__.py
@@ -32,7 +32,7 @@ class JWTModuleInterface(ModuleInterface):
         return ['generate-jwt']
 
     def get_exposed_subcommands(self):
-        return self.get_subcommands()
+        return []
 
     def register_subcommand(self, subparsers, subcommand):
         if subcommand == 'generate-jwt':

--- a/brkt_cli/jwt/test_jwt.py
+++ b/brkt_cli/jwt/test_jwt.py
@@ -1,0 +1,69 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+
+import iso8601
+
+from brkt_cli.validation import ValidationError
+from ecdsa import SigningKey, NIST192p, NIST384p
+import tempfile
+import time
+import unittest
+
+from brkt_cli import jwt
+
+
+class TestTimestamp(unittest.TestCase):
+
+    def test_datetime_to_timestamp(self):
+        now = time.time()
+        dt = datetime.fromtimestamp(now, tz=iso8601.UTC)
+        self.assertEqual(now, jwt._datetime_to_timestamp(dt))
+
+    def test_parse_timestamp(self):
+        ts = int(time.time())
+        dt = datetime.fromtimestamp(ts, tz=iso8601.UTC)
+
+        self.assertEqual(dt, jwt.parse_timestamp(str(ts)))
+        self.assertEqual(dt, jwt.parse_timestamp(dt.isoformat()))
+
+
+class TestSigningKey(unittest.TestCase):
+
+    def test_read_signing_key(self):
+        """ Test reading the signing key from a file. """
+        # Write private key to a temp file.
+        signing_key = SigningKey.generate(curve=NIST384p)
+        pem = signing_key.to_pem()
+        key_file = tempfile.NamedTemporaryFile()
+        key_file.write(pem)
+        key_file.flush()
+
+        signing_key = jwt.read_signing_key(key_file.name)
+        self.assertEqual(pem, signing_key.to_pem())
+        key_file.close()
+
+    def test_read_signing_key_invalid_curve(self):
+        """ Test that we require NIST384p for the signing key. """
+        # Write private key to a temp file.
+        signing_key = SigningKey.generate(curve=NIST192p)
+        pem = signing_key.to_pem()
+        key_file = tempfile.NamedTemporaryFile()
+        key_file.write(pem)
+        key_file.flush()
+
+        with self.assertRaises(ValidationError):
+            jwt.read_signing_key(key_file.name)
+        key_file.close()

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description='Bracket Computing command line interface',
     url='http://brkt.com',
     license='Apache 2.0',
-    packages=['brkt_cli', 'brkt_cli.aws'],
+    packages=['brkt_cli', 'brkt_cli.aws', 'brkt_cli.jwt'],
     install_requires=[
         'boto>=2.38.0',
         'requests>=2.7.0',
@@ -45,7 +45,10 @@ setup(
         'oauth2client>=2.0.0',
         'pyasn1>=0.1.9',
         'google-api-python-client>=1.5.0',
-        'PyYaml>=3.11'],
+        'PyYaml>=3.11',
+        'iso8601>=0.1.11',
+        'ecdsa>=0.13'
+    ],
     zip_safe=False,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Add a generate-jwt command for generating a JWT that is used to launch
an encrypted instance.

$ ./brkt generate-jwt -h
usage: brkt generate-jwt [-h] [--cnc N] [--exp TIMESTAMP] [--nbf
TIMESTAMP]
                         --signing-key PATH [-v]

Generate a JSON Web Token for launching an encrypted instance.
Timestamps can
be either a Unix timestamp in seconds or ISO 8601
(2016-05-10T19:15:36Z).

optional arguments:
-h, --help          show this help message and exit
--cnc N             Maximum number of concurrent instances
--exp TIMESTAMP     Token expiration time
--nbf TIMESTAMP     Token is not valid before this time
--signing-key PATH  The private key that is used to sign the JWT. The
key
                      must be in PEM format.
-v, --verbose       Print status information to the console

$ ./brkt generate-jwt --cnc 12 --exp 2016-06-01 --nbf
2016-05-14T14:00:00Z --signing-key /tmp/openssl.pem
eyJhbGciOiAiRVMzODQiLCAidHlwIjogIkpXVCJ9.eyJleHAiOiAxNDY0NzM5MjAwLjAsICJpYXQiOiAxNDYyOTEzMDE2LCAiaXNzIjogImJya3QtY2xpLTAuOS4xN3ByZTEiLCAianRpIjogIjc4M2NkY2M0IiwgIm5iZiI6IDE0NjMyMzQ0MDAuMH0
=.eRzvC2t9mzu-
69rxRP4I11kxMz4bPaJSMlh1XHw0geKu_io5qWOPhSRMbWtX4SZnnZLrHF7XaHE5ueAHAOhyzd3RHQSxVtkvey0Z3Q2GtkoyRbqT8iaQXvaC46tT6_yI