### PR TITLE
Check subcommand result

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -415,7 +415,13 @@ def main():
         supported_versions = None
     try:
         if subcommand:
-            return subcommand.run(values)
+            result = subcommand.run(values)
+            if not isinstance(result, (int, long)):
+                raise Exception(
+                    '%s did not return an integer result' % subcommand.name())
+            log.debug('%s returned %d', subcommand.name(), result)
+            return result
+
         if values.subparser_name == 'launch-gce-image':
             log.info('Warning: GCE support is still in development.')
             return command_launch_gce_image(values, log)


### PR DESCRIPTION
Make sure that the run() method of the subcommand returns the result
status as an integer.  This should help us find problems with status
codes without having to run the integration tests.