### PR TITLE
Add "kid" field to the generated JWT

### DIFF
--- a/brkt_cli/jwt/__init__.py
+++ b/brkt_cli/jwt/__init__.py
@@ -23,6 +23,7 @@ import time
 
 import brkt_cli
 from brkt_cli import util
+from brkt_cli.jwt import jwk
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.validation import ValidationError
 
@@ -142,7 +143,8 @@ def generate_jwt(signing_key, exp=None, nbf=None, cnc=None):
     payload_dict = {
         'jti': util.make_nonce(),
         'iss': 'brkt-cli-' + brkt_cli.VERSION,
-        'iat': int(time.time())
+        'iat': int(time.time()),
+        'kid': jwk.get_thumbprint(signing_key.get_verifying_key())
     }
     if exp:
         payload_dict['exp'] = _datetime_to_timestamp(exp)

--- a/brkt_cli/jwt/jwk.py
+++ b/brkt_cli/jwt/jwk.py
@@ -1,0 +1,57 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import hashlib
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _long_to_byte_array(long_int):
+    bys = bytearray()
+    while long_int:
+        long_int, r = divmod(long_int, 256)
+        bys.insert(0, r)
+    return bys
+
+
+def _long_to_base64(n):
+    bys = _long_to_byte_array(n)
+    if not bys:
+        bys.append(0)
+    s = base64.urlsafe_b64encode(bys).rstrip(b'=')
+    return s.decode("ascii")
+
+
+def ecdsa_to_jwk(verifying_key):
+    """ Convert an ecdsa.VerifyingKey to the equivalent JWK. """
+    x = _long_to_base64(verifying_key.pubkey.point.x())
+    y = _long_to_base64(verifying_key.pubkey.point.y())
+    return {
+        'alg': 'ES384',
+        'kty': 'EC',
+        'crv': 'P-384',
+        'x': x,
+        'y': y
+    }
+
+
+def get_thumbprint(verifying_key):
+    """ Get the thumbprint of an ecdsa.VerifyingKey. """
+    jwk = ecdsa_to_jwk(verifying_key)
+    thumbprint_json = \
+        '{"crv":"%(crv)s","kty":"%(kty)s","x":"%(x)s","y":"%(y)s"}' % jwk
+    log.debug('Thumbprint JSON: %s', thumbprint_json)
+    return hashlib.sha256(thumbprint_json).hexdigest()

--- a/brkt_cli/jwt/test_jwt.py
+++ b/brkt_cli/jwt/test_jwt.py
@@ -11,7 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import base64
 import json
 from datetime import datetime, timedelta
 
@@ -24,6 +23,7 @@ import time
 import unittest
 
 import brkt_cli.jwt
+import brkt_cli.jwt.jwk
 
 
 class TestTimestamp(unittest.TestCase):
@@ -109,6 +109,8 @@ class TestGenerateJWT(unittest.TestCase):
         exp_result = brkt_cli.jwt._timestamp_to_datetime(payload['exp'])
         self.assertEqual(exp, exp_result)
 
+        self.assertTrue('kid' in payload)
+
         # Check signature.
         verifying_key = signing_key.get_verifying_key()
         verifying_key.verify(signature, '%s.%s' % (header_b64, payload_b64))
@@ -127,3 +129,11 @@ class TestBase64(unittest.TestCase):
             self.assertFalse('=' in encoded)
             self.assertEqual(
                 content, brkt_cli.jwt._urlsafe_b64decode(encoded))
+
+
+class TestJWK(unittest.TestCase):
+
+    def test_long_to_byte_array(self):
+        l = long('deadbeef', 16)
+        ba = brkt_cli.jwt.jwk._long_to_byte_array(l)
+        self.assertEqual(bytearray.fromhex('deadbeef'), ba)


### PR DESCRIPTION
Add a key id field ("kid") to the generated JWT.  To calculate the key
id, we:

1) Load the public key that's associated with the signing key.
2) Convert the public key to a JWK.
3) Calculate the thumbprint of the JWK, as specified in RFC 7638.