### PR TITLE
Add --claim option to generate-jwt

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -65,10 +65,9 @@ def parse_tags(tag_strings):
 
     tags = {}
     for s in tag_strings:
-        m = re.match(r'([^=]+)=(.+)', s)
-        if not m:
-            raise ValidationError('Tag %s is not in the format KEY=VALUE' % s)
-        tags[m.group(1)] = m.group(2)
+        key, value = util.parse_name_value(s)
+        tags[key] = value
+
     return tags
 
 

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -14,7 +14,8 @@
 
 import unittest
 
-import brkt_cli
+from brkt_cli import util
+from brkt_cli.validation import ValidationError
 
 
 class TestUtil(unittest.TestCase):
@@ -24,17 +25,25 @@ class TestUtil(unittest.TestCase):
         """
         name = 'Boogie nights are always the best in town'
         suffix = ' (except Tuesday)'
-        encrypted_name = brkt_cli.util.append_suffix(
+        encrypted_name = util.append_suffix(
             name, suffix, max_length=128)
         self.assertTrue(encrypted_name.startswith(name))
         self.assertTrue(encrypted_name.endswith(suffix))
 
         # Make sure we truncate the original name when it's too long.
         name += ('X' * 100)
-        encrypted_name = brkt_cli.util.append_suffix(
+        encrypted_name = util.append_suffix(
             name, suffix, max_length=128)
         self.assertEqual(128, len(encrypted_name))
         self.assertTrue(encrypted_name.startswith('Boogie nights'))
+
+    def test_parse_name_value(self):
+        self.assertEqual(
+            ('foo', 'bar'),
+            util.parse_name_value('foo=bar')
+        )
+        with self.assertRaises(ValidationError):
+            util.parse_name_value('abc')
 
 
 class TestBase64(unittest.TestCase):
@@ -44,9 +53,9 @@ class TestBase64(unittest.TestCase):
     def test_encode_and_decode(self):
         for length in xrange(0, 1000):
             content = 'x' * length
-            encoded = brkt_cli.util.urlsafe_b64encode(content)
+            encoded = util.urlsafe_b64encode(content)
             self.assertFalse('/' in encoded)
             self.assertFalse('_' in encoded)
             self.assertFalse('=' in encoded)
             self.assertEqual(
-                content, brkt_cli.util.urlsafe_b64decode(encoded))
+                content, util.urlsafe_b64decode(encoded))

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -20,6 +20,7 @@ import uuid
 
 from googleapiclient import errors
 
+from brkt_cli.validation import ValidationError
 
 SLEEP_ENABLED = True
 MAX_BACKOFF_SECS = 10
@@ -156,3 +157,16 @@ def urlsafe_b64decode(base64_string):
         base64_string += b'=' * (4 - removed)
 
     return base64.urlsafe_b64decode(base64_string)
+
+
+def parse_name_value(name_value):
+    """ Parse a string in NAME=VALUE format.
+
+    :return: a tuple of name, value
+    :raise: ValidationError if name_value is malformed
+    """
+    m = re.match(r'([^=]+)=(.+)', name_value)
+    if not m:
+        raise ValidationError(
+            '%s is not in the format NAME=VALUE' % name_value)
+    return m.group(1), m.group(2)


### PR DESCRIPTION
Add a --claim option, which allows the user to add JWT claims as
name/value pairs.  Refactor the name/value parsing code, so that the
same code is used for claims and tags.