### PR TITLE
Retain the pip cache between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: python
 python: "2.7"
 install: pip install boto requests google-api-python-client PyYAML oauthlib iso8601 ecdsa
 script: python -m unittest discover
+cache: pip


### PR DESCRIPTION
Retain the pip cache, to speed up Travis builds.  More info at

https://docs.travis-ci.com/user/caching/