### PR TITLE
Pass the entire values object into _validation_region()

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -393,7 +393,7 @@ def command_update_encrypted_ami(values, log):
     nonce = util.make_nonce()
 
     aws_svc = aws_service.AWSService(nonce)
-    _validate_region(aws_svc, values.region)
+    _validate_region(aws_svc, values)
     encryptor_ami = (
         values.encryptor_ami or
         encrypt_ami.get_encryptor_ami(values.region, hvm=values.hvm)


### PR DESCRIPTION
Commit f63b1e1eaaf0afcc6590d0635adaf3a8313a6105 changed the signature of
_validation_region() and broke update-encrypted-ami.  Fix
command_update_encrypted_ami() so that it passes the entire values
object instead of the region name.