### PR TITLE
Consolidate the retry logic

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -339,7 +339,7 @@ class AWSService(BaseAWSService):
         return get_all_snapshots(snapshot_ids)
 
     def get_snapshot(self, snapshot_id):
-        snapshots = self.get_snapshots([snapshot_id])
+        snapshots = self.get_snapshots(snapshot_id)
         return _get_first_element(snapshots, 'InvalidSnapshot.NotFound')
 
     def create_snapshot(self, volume_id, name=None, description=None):

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -5,15 +5,16 @@ import datetime
 import logging
 import json
 import re
+import socket
 import time
 
+import brkt_cli.util
 from brkt_cli.util import (
     append_suffix,
     BracketError,
-    make_nonce,
-    retry
+    make_nonce
 )
-from googleapiclient import discovery
+from googleapiclient import discovery, errors
 from oauth2client.client import GoogleCredentials
 
 from brkt_cli.validation import ValidationError
@@ -29,6 +30,11 @@ brkt_image_buckets = {
     'stage': 'brkt-stage-images',
     'shared': 'brkt-shared-images'
 }
+
+
+def retry(function):
+    return brkt_cli.util.retry(function, on=[socket.error, errors.HttpError])
+
 
 def execute_gce_api_call(gce_object):
     return gce_object.execute()


### PR DESCRIPTION
Update aws_service so that it uses the retry() function in the util
module.  Add the ability to use a RetryExceptionChecker to determine
whether we should retry.  We need this in order to check
EC2ResponseError.error_code.  Change the retry interval to a time period
instead of counting the number of attempts, so that the caller doesn't
have to do math to determine the timeout.

Remove the retry_boto decorator and replace it with a retry_boto()
function.  This gives us the flexibility of retrying either in
AWSService or in the higher-level application code.  Add unit tests for
util.retry().