### PR TITLE
Improve error message when signing key can't be parsed

### DIFF
--- a/brkt_cli/jwt/__init__.py
+++ b/brkt_cli/jwt/__init__.py
@@ -93,7 +93,11 @@ def read_signing_key(pem_path):
     except IOError as e:
         raise ValidationError(e)
     except ValueError:
-        raise ValidationError('%s must be a PEM private key' % pem_path)
+        if log.isEnabledFor(logging.DEBUG):
+            log.exception('Unable to load signing key %s', pem_path)
+        raise ValidationError(
+            'Signing key must be a 384-bit ECDSA private key (NIST P-384) in '
+            'PEM format')
 
     if signing_key.curve != NIST384p:
         raise ValidationError(


### PR DESCRIPTION
When the signing key can't be parsed, give more specifics about the type
of key that we support.