### PR TITLE
Add --network option to update and encrypt gce

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -94,9 +94,10 @@ def command_launch_gce_image(values, log):
 
 
 def command_update_encrypted_gce_image(values, log):
-    check_args(values)
     session_id = util.make_nonce()
     gce_svc = gce_service.GCEService(values.project, session_id, log)
+    check_args(values, gce_svc)
+
     encrypted_image_name = gce_service.get_image_name(values.encrypted_image_name, values.image)
 
     brkt_env = None
@@ -120,7 +121,8 @@ def command_update_encrypted_gce_image(values, log):
         token=token,
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,
-        image_bucket=values.bucket
+        image_bucket=values.bucket,
+        network=values.network
     )
 
     print(updated_image_id)
@@ -128,9 +130,9 @@ def command_update_encrypted_gce_image(values, log):
 
 
 def command_encrypt_gce_image(values, log):
-    check_args(values)
     session_id = util.make_nonce()
     gce_svc = gce_service.GCEService(values.project, session_id, log)
+    check_args(values, gce_svc)
 
     brkt_env = None
     if values.brkt_env:
@@ -156,7 +158,8 @@ def command_encrypt_gce_image(values, log):
         image_project=values.image_project,
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,
-        image_bucket=values.bucket
+        image_bucket=values.bucket,
+        network=values.network
     )
     # Print the image name to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
@@ -164,7 +167,9 @@ def command_encrypt_gce_image(values, log):
     return 0
 
 
-def check_args(values):
+def check_args(values, gce_svc):
+    if not gce_svc.network_exists(values.network):
+        raise ValidationError("Network provided does not exist")
     if values.encryptor_image:
         if values.bucket != 'prod':
             raise ValidationError("Please provided either an encryptor image or an image bucket")

--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -66,12 +66,14 @@ def do_encryption(gce_svc,
                    encryptor_image,
                    instance_name,
                    encrypted_image_disk,
-                   brkt_data):
+                   brkt_data,
+                   network):
     try:
         log.info('Launching encryptor instance')
         gce_svc.run_instance(zone=zone,
                              name=encryptor,
                              image=encryptor_image,
+                             network=network,
                              disks=[gce_svc.get_disk(zone, instance_name),
                                     gce_svc.get_disk(zone, encrypted_image_disk)],
                              metadata=gce_metadata_from_userdata(brkt_data))
@@ -108,7 +110,7 @@ def create_image(gce_svc, zone, encrypted_image_disk, encrypted_image_name, encr
 
 def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, brkt_env, token, image_project=None,
-            keep_encryptor=False, image_file=None, image_bucket=None):
+            keep_encryptor=False, image_file=None, image_bucket=None, network=None):
     brkt_data = {}
     try:
         # create metavisor image from file in GCS bucket
@@ -133,7 +135,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
 
         # run encryptor instance with avatar_creator as root,
         # customer image and blank disk
-        do_encryption(gce_svc, enc_svc_cls, zone, encryptor, encryptor_image, instance_name, encrypted_image_disk, brkt_data)
+        do_encryption(gce_svc, enc_svc_cls, zone, encryptor, encryptor_image, instance_name, encrypted_image_disk, brkt_data, network)
 
         # create image
         create_image(gce_svc, zone, encrypted_image_disk, encrypted_image_name, encryptor)

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -60,6 +60,12 @@ def setup_encrypt_gce_image_args(parser):
         dest='encryptor_image',
         required=False
     )
+    parser.add_argument(
+        '--network',
+        dest='network',
+        default='default',
+        required=False
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     # If you're using this option, it should be passed as a comma separated

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -53,6 +53,12 @@ def setup_update_gce_image_args(parser):
         dest='encryptor_image',
         required=False
     )
+    parser.add_argument(
+        '--network',
+        dest='network',
+        default='default',
+        required=False
+    )
 
     # Optional yeti endpoints. Hidden because it's only used for development.
     parser.add_argument(

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 
 def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, brkt_env, token, keep_encryptor=False,
-            image_file=None, image_bucket=None):
+            image_file=None, image_bucket=None, network=None):
     snap_created = None
     try:
         # create image from file in GCS bucket
@@ -68,6 +68,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
         gce_svc.run_instance(zone,
                              updater,
                              encryptor_image,
+                             network=network,
                              disks=[],
                              metadata=user_data)
         enc_svc = enc_svc_cls([gce_svc.get_instance_ip(updater, zone)])

--- a/test_gce.py
+++ b/test_gce.py
@@ -57,6 +57,11 @@ class DummyGCEService(gce_service.BaseGCEService):
                 return
             time.sleep(5)
 
+    def get_network(self, nw):
+        if nw == 'test-nw' or nw == 'default':
+            return True
+        return False
+
     def get_image(self, image, image_project):
         if image == NONEXISTANT_IMAGE:
             raise
@@ -157,6 +162,7 @@ class DummyGCEService(gce_service.BaseGCEService):
                      zone,
                      name,
                      image,
+                     network=None,
                      disks=[],
                      metadata={},
                      delete_boot=False,


### PR DESCRIPTION
Allows user to specify a non-default network
to launch encryptor instances in

Testing: encrypted and updated gce images