### PR TITLE
Handle edge case errors when calling the AWS API

### DIFF
--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -89,13 +89,13 @@ def retry(function, on=None, exception_checker=None, timeout=15.0,
                     expected = True
 
                 if not expected:
-                    raise e
+                    raise
                 if now - start_time > timeout:
                     log.error(
                         'Exceeded timeout of %s seconds for %s',
                         timeout,
                         function.__name__)
-                    raise e
+                    raise
                 else:
                     time.sleep(initial_sleep_seconds * float(attempt))
     return _wrapped


### PR DESCRIPTION
Handle two obscure errors that occasionally pop up in the field.  I
believe that the AWS service returns 503 when the request rate limit has
been exceeded for a given account.  I'm not sure what causes
ssl.SSLError, but it has been reported a couple of times.

To handle these errors, we:

* Check for these cases in BotoRetryExceptionChecker.
* Wrap every AWS call with retry_boto()

Also, make BotoRetryExceptionChecker.error_code_regexp an optional
argument.  If the regexp isn't specified, we check for the two cases
above.

Change "raise e" to "raise" in util.retry(), so that the original
traceback is preserved.