### PR TITLE
Preserve traceback when re-raising exceptions

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -344,7 +344,7 @@ def create_encryptor_security_group(aws_svc, vpc_id=None):
             aws_svc.delete_security_group(sg.id)
         except Exception as e2:
             log.warn('Failed deleting temporary security group: %s', e2)
-        raise e
+        raise
 
     aws_svc.create_tags(sg.id)
     return sg
@@ -648,7 +648,7 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
         encryptor_service.wait_for_encryption(enc_svc)
     except encryptor_service.EncryptionError as e:
         log_exception_console(aws_svc, e, encryptor_instance.id)
-        raise e
+        raise
 
     log.info('Encrypted root drive is ready.')
     # The encryptor instance may modify its volume attachments while running,

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -151,7 +151,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             wait_for_encryption(enc_svc)
         except Exception as e:
             log_exception_console(aws_svc, e, updater.id)
-            raise e
+            raise
 
         aws_svc.stop_instance(updater.id)
         encrypted_guest = wait_for_instance(


### PR DESCRIPTION
Replace "raise e" with "raise", so that the original traceback is
preserved.  Remove a gratuitous try/except in the GCE codebase.