### PR TITLE
Use https for getting amis from s3

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -119,9 +119,9 @@ SLEEP_ENABLED = True
 AMI_NAME_MAX_LENGTH = 128
 
 BRACKET_ENVIRONMENT = "prod"
-ENCRYPTOR_AMIS_URL = "http://solo-brkt-%s-net.s3.amazonaws.com/amis.json"
+ENCRYPTOR_AMIS_URL = "https://solo-brkt-%s-net.s3.amazonaws.com/amis.json"
 HVM_ENCRYPTOR_AMIS_URL = \
-    "http://solo-brkt-%s-net.s3.amazonaws.com/hvm_amis.json"
+    "https://solo-brkt-%s-net.s3.amazonaws.com/hvm_amis.json"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
http is liable to be cached by an internet proxy without the
right headers.

https is also the right thing to do from a security perspective.
Note that now, this verifies the s3 server certificate so your
python version should support this.

Testing done:
- ran locally on my Mac and virtualenv