### PR TITLE
Moved 'kid' field from payload to header of JWT

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -301,7 +301,7 @@ def validate_jwt(jwt):
         raise ValidationError('Unable to decode signature ' + parts[2])
 
     # Validate header.
-    expected_fields = ['typ', 'alg']
+    expected_fields = ['typ', 'alg', 'kid']
     missing_fields = [f for f in expected_fields if f not in header]
     if missing_fields:
         raise ValidationError(
@@ -309,7 +309,7 @@ def validate_jwt(jwt):
         )
 
     # Validate payload.
-    expected_fields = ['jti', 'iss', 'iat', 'kid']
+    expected_fields = ['jti', 'iss', 'iat']
     missing_fields = [f for f in expected_fields if f not in payload]
     if missing_fields:
         raise ValidationError(

--- a/test.py
+++ b/test.py
@@ -273,12 +273,11 @@ class TestJWT(unittest.TestCase):
 
         # Valid(ish) JWT.  The validation code doesn't currently go as far
         # as to validate the signature.
-        header = {'typ': 'JWT', 'alg': 'ES384'}
+        header = {'typ': 'JWT', 'alg': 'ES384', 'kid': 'abc'}
         payload = {
             'jti': brkt_cli.util.make_nonce(),
             'iss': 'brkt-cli-' + brkt_cli.VERSION,
-            'iat': int(time.time()),
-            'kid': 'abc'
+            'iat': int(time.time())
         }
         signature = 'Signed, sealed, delivered'
 
@@ -306,7 +305,7 @@ class TestJWT(unittest.TestCase):
             brkt_cli.validate_jwt(jwt)
 
         # Missing header field.
-        for missing_field in ['typ', 'alg']:
+        for missing_field in ['typ', 'alg', 'kid']:
             malformed_header = dict(header)
             del(malformed_header[missing_field])
             base64_malformed_header = brkt_cli.util.urlsafe_b64encode(
@@ -317,7 +316,7 @@ class TestJWT(unittest.TestCase):
                 brkt_cli.validate_jwt(jwt)
 
         # Missing payload field.
-        for missing_field in ['jti', 'iss', 'iat', 'kid']:
+        for missing_field in ['jti', 'iss', 'iat']:
             malformed_payload = dict(payload)
             del(malformed_payload[missing_field])
             base64_malformed_payload = brkt_cli.util.urlsafe_b64encode(


### PR DESCRIPTION
* Per Grant, the 'kid' field should be in the header and not in the payload.  The JWTs created by 'brkt make-jwt' already put the 'kid' in the header.

Testing:
* Ran unit tests.
* Ran "make-user-data --jwt <data output by 'brkt make-jwt'>"