### PR TITLE
Fix verbose logging check when printing exceptions

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -388,16 +388,6 @@ def main():
     argv = sys.argv[1:]
     values = parser.parse_args(argv)
 
-    # Initialize logging.  Verbose logging can be specified for either
-    # the top-level "brkt" command or one of the subcommands.  We support
-    # both because users got confused when "brkt encrypt-ami -v" didn't work.
-    log_level = logging.INFO
-    if values.verbose:
-        log_level = logging.DEBUG
-
-    # Turn off logging for categories that we don't care about.
-    logging.getLogger('requests').setLevel(logging.ERROR)
-
     # Find the matching subcommand.
     subcommand = None
     for s in subcommands:
@@ -407,7 +397,13 @@ def main():
     if not subcommand:
         raise Exception('Could not find subcommand ' + values.subparser_name)
 
-    # Initialize logging.
+    # Turn off logging for categories that we don't care about.
+    logging.getLogger('requests').setLevel(logging.ERROR)
+
+    # Initialize logging.  Verbose logging can be specified for either
+    # the top-level "brkt" command or one of the subcommands.  We support
+    # both because users got confused when "brkt encrypt-ami -v" didn't work.
+    log_level = logging.INFO
     verbose = values.verbose
     if subcommand.verbose(values):
         verbose = True

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -103,14 +103,14 @@ def _run_subcommand(subcommand, values):
             'Unable to connect to AWS.  Are your AWS_ACCESS_KEY_ID and '
             'AWS_SECRET_ACCESS_KEY environment variables set?'
         )
-        if values.verbose:
+        if log.isEnabledFor(logging.DEBUG):
             log.exception(msg)
         else:
             log.error(msg)
     except EC2ResponseError as e:
         if e.error_code == 'AuthFailure':
             msg = 'Check your AWS login credentials and permissions'
-            if values.verbose:
+            if log.isEnabledFor(logging.DEBUG):
                 log.exception(msg)
             else:
                 log.error(msg + ': ' + e.error_message)
@@ -119,12 +119,12 @@ def _run_subcommand(subcommand, values):
             'InvalidSubnetID.NotFound',
             'InvalidGroup.NotFound'
         ):
-            if values.verbose:
+            if log.isEnabledFor(logging.DEBUG):
                 log.exception(e.error_message)
             else:
                 log.error(e.error_message)
         elif e.error_code == 'UnauthorizedOperation':
-            if values.verbose:
+            if log.isEnabledFor(logging.DEBUG):
                 log.exception(e.error_message)
             else:
                 log.error(e.error_message)


### PR DESCRIPTION
Check for debug logging on the Logger object instead of using
values.verbose.  values.verbose only works when -v is specified at the
top level, not at the subcommand level.

Clean up duplicate logging initialization code.