### PR TITLE
Add internal options for retry behavior

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -323,7 +323,14 @@ def _validate_region(aws_svc, values):
 def command_encrypt_ami(values, log):
     session_id = util.make_nonce()
 
-    aws_svc = aws_service.AWSService(session_id)
+    aws_svc = aws_service.AWSService(
+        session_id,
+        retry_timeout=values.retry_timeout,
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
+    )
+    log.debug(
+        'Retry timeout=%.02f, initial sleep seconds=%.02f',
+        aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
     # Validate the specified region.
     if values.validate:
@@ -392,7 +399,15 @@ def _get_updated_image_name(image_name, session_id):
 def command_update_encrypted_ami(values, log):
     nonce = util.make_nonce()
 
-    aws_svc = aws_service.AWSService(nonce)
+    aws_svc = aws_service.AWSService(
+        nonce,
+        retry_timeout=values.retry_timeout,
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
+    )
+    log.debug(
+        'Retry timeout=%.02f, initial sleep seconds=%.02f',
+        aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
+
     _validate_region(aws_svc, values)
     encryptor_ami = (
         values.encryptor_ami or

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -149,6 +149,25 @@ def setup_encrypt_ami_args(parser):
         dest='key_name'
     )
 
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    parser.add_argument(
+        '--retry-timeout',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=10.0
+    )
+
+    parser.add_argument(
+        '--retry-initial-sleep-seconds',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=0.25
+    )
+
     # This option is still in development.
     """
     help=(

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -147,6 +147,25 @@ def setup_update_encrypted_ami(parser):
         dest='encryptor_ami'
     )
 
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    parser.add_argument(
+        '--retry-timeout',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=10.0
+    )
+
+    parser.add_argument(
+        '--retry-initial-sleep-seconds',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=0.25
+    )
+
     # This option is still in development.
     """
     help=(


### PR DESCRIPTION
Add two new options to the encrypt-ami and update-encrypted-ami
subcommands that allow the caller to change the default timeout and
initial sleep time when retrying AWS operations:

--retry-timeout
--retry-initial-sleep-seconds

We use these options internally, to avoid intermittent AWS service
failures when running concurrent encryption processes in integration
tests.