### PR TITLE
Put JWT in brkt_config, not as file

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -391,11 +391,13 @@ def run_encryptor_instance(
         bdm['/dev/sdf'] = guest_unencrypted_root
         bdm['/dev/sdg'] = guest_encrypted_root
 
-    compressed_user_data = user_data.combine_user_data(
+    mime_user_data = user_data.combine_user_data(
         brkt_config,
         proxy_config=proxy_config,
         jwt=jwt
     )
+    compressed_user_data = user_data.gzip_user_data(mime_user_data)
+
     instance = aws_svc.run_instance(encryptor_image_id,
                                     security_group_ids=security_group_ids,
                                     user_data=compressed_user_data,

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -103,11 +103,12 @@ def update_ami(aws_svc, encrypted_ami, updater_ami,
             description=DESCRIPTION_GUEST_CREATOR % {'image_id': encrypted_ami}
         )
         # Run updater in same zone as guest so we can swap volumes
-        compressed_user_data = user_data.combine_user_data(
+        mime_user_data = user_data.combine_user_data(
             brkt_config,
             proxy_config=proxy_config,
             jwt=jwt
         )
+        compressed_user_data = user_data.gzip_user_data(mime_user_data)
         updater = aws_svc.run_instance(
             updater_ami,
             instance_type="c3.large",

--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -6,7 +6,7 @@ import socket
 
 from brkt_cli.util import (
     add_brkt_env_to_brkt_config,
-    add_token_to_user_data,
+    add_token_to_brkt_config,
     Deadline,
     retry,
 )
@@ -122,7 +122,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
         validate_images(gce_svc, encrypted_image_name, encryptor_image, image_id, image_project)
 
         add_brkt_env_to_brkt_config(brkt_env, brkt_data)
-        add_token_to_user_data(token, brkt_data)
+        add_token_to_brkt_config(token, brkt_data)
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gce_svc.get_session_id()

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -17,7 +17,7 @@ import logging
 from brkt_cli.gce import encrypt_gce_image
 from brkt_cli.util import (
     add_brkt_env_to_brkt_config,
-    add_token_to_user_data,
+    add_token_to_brkt_config,
     Deadline,
 )
 from brkt_cli.encryptor_service import wait_for_encryption
@@ -63,7 +63,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
         log.info("Launching encrypted updater")
         brkt_data = {'brkt': {'solo_mode': 'updater'}}
         add_brkt_env_to_brkt_config(brkt_env, brkt_data)
-        add_token_to_user_data(token, brkt_data)
+        add_token_to_brkt_config(token, brkt_data)
         user_data = gce_metadata_from_userdata(brkt_data)
         gce_svc.run_instance(zone,
                              updater,

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -59,7 +59,7 @@ class MakeUserDataSubcommand(Subcommand):
         with open(values.jwt, 'r') as f:
             token_val = f.read().rstrip()
 
-        print combine_user_data(brkt_config={}, jwt=token_val, do_gzip=False)
+        print combine_user_data(brkt_config={}, jwt=token_val)
         return 0
 
 

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -15,7 +15,7 @@ import logging
 
 import brkt_cli
 from brkt_cli.subcommand import Subcommand
-from brkt_cli.user_data import UserDataContainer, BRKT_FILES_CONTENT_TYPE
+from brkt_cli.user_data import combine_user_data
 
 log = logging.getLogger(__name__)
 
@@ -56,17 +56,10 @@ class MakeUserDataSubcommand(Subcommand):
         return values.make_user_data_verbose
 
     def run(self, values):
-        udc = UserDataContainer()
+        with open(values.jwt, 'r') as f:
+            token_val = f.read().rstrip()
 
-        if values.jwt:
-            jwt = brkt_cli.validate_jwt(values.jwt)
-            udc.add_file(
-                '/var/brkt/instance_config/token.jwt',
-                jwt,
-                BRKT_FILES_CONTENT_TYPE
-            )
-
-        print udc.to_mime_text()
+        print combine_user_data(brkt_config={}, jwt=token_val, do_gzip=False)
         return 0
 
 

--- a/brkt_cli/test_user_data.py
+++ b/brkt_cli/test_user_data.py
@@ -58,12 +58,14 @@ class TestUserData(unittest.TestCase):
             if part.get_content_type() == BRKT_CONFIG_CONTENT_TYPE:
                 found_brkt_config = True
                 content = part.get_payload(decode=True)
-                self.assertEqual('{"foo": "bar"}', content)
+                self.assertEqual(
+                    '{"foo": "bar", "brkt": {"identity_token": "%s"}}' % jwt,
+                    content)
             if part.get_content_type() == BRKT_FILES_CONTENT_TYPE:
                 found_brkt_files = True
                 content = part.get_payload(decode=True)
                 self.assertTrue('/var/brkt/ami_config/proxy.yaml:' in content)
-                self.assertTrue('/var/brkt/ami_config/token.jwt:' in content)
+                self.assertFalse('/var/brkt/ami_config/token.jwt:' in content)
 
         self.assertTrue(found_brkt_config)
         self.assertTrue(found_brkt_files)

--- a/brkt_cli/test_user_data.py
+++ b/brkt_cli/test_user_data.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import email
 import unittest
-import zlib
 
 from brkt_cli import proxy, user_data
 from brkt_cli.proxy import Proxy
@@ -43,12 +42,11 @@ class TestUserData(unittest.TestCase):
             'GktMC45LjE3cHJlMSIsICJpYXQiOiAxNDYzNDI5MDg1LCAianRpIjogImJlN2J'
             'mYzYwIiwgImtpZCI6ICJhYmMifQ.U2lnbmVkLCBzZWFsZWQsIGRlbGl2ZXJlZA'
         )
-        compressed_mime_data = user_data.combine_user_data(
+        mime_data = user_data.combine_user_data(
             brkt_config,
             proxy_config=proxy_config,
             jwt=jwt
         )
-        mime_data = zlib.decompress(compressed_mime_data, 16 + zlib.MAX_WBITS)
 
         msg = email.message_from_string(mime_data)
         found_brkt_config = False
@@ -65,7 +63,6 @@ class TestUserData(unittest.TestCase):
                 found_brkt_files = True
                 content = part.get_payload(decode=True)
                 self.assertTrue('/var/brkt/ami_config/proxy.yaml:' in content)
-                self.assertFalse('/var/brkt/ami_config/token.jwt:' in content)
 
         self.assertTrue(found_brkt_config)
         self.assertTrue(found_brkt_files)

--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -157,8 +157,7 @@ class UserDataContainer(object):
         return str(container)
 
 
-def combine_user_data(brkt_config=None, proxy_config=None, jwt=None,
-                      do_gzip=True):
+def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
     """ Combine the user data dictionary with the given proxy configuration
     into the gzipped multipart MIME binary that will be sent to the
     metavisor instance.
@@ -186,9 +185,10 @@ def combine_user_data(brkt_config=None, proxy_config=None, jwt=None,
         )
 
     user_data_string = udc.to_mime_text()
-    if not do_gzip:
-        return user_data_string
+    return user_data_string
 
+
+def gzip_user_data(user_data_string):
     out = StringIO()
     with gzip.GzipFile(fileobj=out, mode="w") as f:
         f.write(user_data_string)

--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -20,7 +20,7 @@ from email.mime.text import MIMEText
 
 import yaml
 
-from brkt_cli.util import add_token_to_user_data
+from brkt_cli.util import add_token_to_brkt_config
 
 # The directory for files saved on the Metavisor. We require that the dest
 # path for all --brkt-files be within this directory.
@@ -172,7 +172,7 @@ def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
 
     brkt_config = brkt_config or {}
     if jwt:
-        add_token_to_user_data(jwt, brkt_config)
+        add_token_to_brkt_config(jwt, brkt_config)
 
     brkt_config_string = json.dumps(brkt_config)
     udc.add_part(BRKT_CONFIG_CONTENT_TYPE, brkt_config_string)

--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -20,6 +20,8 @@ from email.mime.text import MIMEText
 
 import yaml
 
+from brkt_cli.util import add_token_to_user_data
+
 # The directory for files saved on the Metavisor. We require that the dest
 # path for all --brkt-files be within this directory.
 from StringIO import StringIO
@@ -155,19 +157,24 @@ class UserDataContainer(object):
         return str(container)
 
 
-def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
+def combine_user_data(brkt_config=None, proxy_config=None, jwt=None,
+                      do_gzip=True):
     """ Combine the user data dictionary with the given proxy configuration
     into the gzipped multipart MIME binary that will be sent to the
     metavisor instance.
 
     :param brkt_config: dictionary of Bracket config values
     :param proxy_config: proxy.yaml contents
-    :param jwt: JSON Web Token that metavisor uses to auth with Yeti
+    :param jwt: JSON Web Token (string) that metavisor uses to auth with Yeti
+    :param do_gzip: boolean specifying whether output is gzipped
     :return: a gzipped multipart MIME binary
     """
     udc = UserDataContainer()
 
     brkt_config = brkt_config or {}
+    if jwt:
+        add_token_to_user_data(jwt, brkt_config)
+
     brkt_config_string = json.dumps(brkt_config)
     udc.add_part(BRKT_CONFIG_CONTENT_TYPE, brkt_config_string)
 
@@ -178,14 +185,10 @@ def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
             BRKT_FILES_CONTENT_TYPE
         )
 
-    if jwt:
-        udc.add_file(
-            '/var/brkt/ami_config/token.jwt',
-            jwt,
-            BRKT_FILES_CONTENT_TYPE
-        )
-
     user_data_string = udc.to_mime_text()
+    if not do_gzip:
+        return user_data_string
+
     out = StringIO()
     with gzip.GzipFile(fileobj=out, mode="w") as f:
         f.write(user_data_string)

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -123,7 +123,7 @@ def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
         brkt_config['brkt']['hsmproxy_host'] = hsmproxy_host_port
 
 
-def add_token_to_user_data(identity_token, user_data):
+def add_token_to_brkt_config(identity_token, user_data):
     if 'brkt' not in user_data:
         user_data['brkt'] = {}
     user_data['brkt']['identity_token'] = identity_token


### PR DESCRIPTION
* Instead of putting the JWT in a brkt-file with dest path /var/brkt/ami_config/token.jwt, put the JWT in the brkt_config dictionary with key 'identity_token'.

Testing:
* Ran unit tests
* Ran 'brkt make-user-data -jwt <file_with_jwt>'
