### PR TITLE
Remove unused status port validation cruft

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -277,12 +277,6 @@ def _connect_and_validate(aws_svc, values, encryptor_ami_id):
     if values.encrypted_ami_name:
         aws_service.validate_image_name(values.encrypted_ami_name)
 
-    if values.status_port:
-        values.status_port = \
-            aws_service.validate_status_port(values.status_port)
-    else:
-        values.status_port = encryptor_service.ENCRYPTOR_STATUS_PORT
-
     aws_svc.connect(values.region, key_name=values.key_name)
 
     try:

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -550,23 +550,6 @@ def validate_image_name(name):
     return name
 
 
-def validate_status_port(status_port):
-    """ Verify that the status port is valid.
-
-    :return: the status port if it's valid
-    :raises ValidationError if the status port is invalid
-    """
-    if status_port == 81:
-        raise ValidationError(
-            'Port 81 cannot be used for status port.'
-        )
-    if (status_port <= 0) or (status_port > 65535):
-        raise ValidationError(
-            'Port must be in the range 1-65535'
-        )
-    return status_port
-
-
 def validate_tag_key(key):
     """ Verify that the key is a valid EC2 tag key.
 


### PR DESCRIPTION
This code is no longer used since validation is done with
argparse.