### PR TITLE
Add --ca-cert arg to encrypt-ami

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -375,7 +375,7 @@ def command_encrypt_ami(values, log):
             parsed_cert = x509.load_pem_x509_certificate(ca_cert_data,
                                                          default_backend())
         except Exception as e:
-            raise ValidationError('Error validating CA cert: %s', str(e))
+            raise ValidationError('Error validating CA cert: %s' % e)
 
     else:
         ca_cert_data = None

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -17,6 +17,9 @@ import re
 import boto
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
 import brkt_cli
 from brkt_cli import encryptor_service, util
 from brkt_cli.aws import aws_service, encrypt_ami
@@ -358,6 +361,25 @@ def command_encrypt_ami(values, log):
     proxy_config = brkt_cli.get_proxy_config(values)
     jwt = brkt_cli.validate_jwt(values.jwt)
 
+    if values.ca_cert:
+        if not values.brkt_env:
+            raise ValidationError(
+                'Must specify --brkt-env when using --ca-cert.'
+            )
+        try:
+            with open(values.ca_cert, 'r') as f:
+                ca_cert_data = f.read()
+        except IOError as e:
+            raise ValidationError(e)
+        try:
+            parsed_cert = x509.load_pem_x509_certificate(ca_cert_data,
+                                                         default_backend())
+        except Exception as e:
+            raise ValidationError('Error validating CA cert: %s', str(e))
+
+    else:
+        ca_cert_data = None
+
     encrypted_image_id = encrypt_ami.encrypt(
         aws_svc=aws_svc,
         enc_svc_cls=encryptor_service.EncryptorService,
@@ -369,6 +391,7 @@ def command_encrypt_ami(values, log):
         brkt_env=brkt_env,
         ntp_servers=values.ntp_servers,
         proxy_config=proxy_config,
+        ca_cert=ca_cert_data,
         guest_instance_type=values.guest_instance_type,
         jwt=jwt,
         status_port=values.status_port

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -356,7 +356,8 @@ def run_encryptor_instance(
         snapshot, root_size,
         guest_image_id, brkt_env=None, security_group_ids=None,
         subnet_id=None, zone=None, ntp_servers=None, proxy_config=None,
-        jwt=None, status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
+        ca_cert=None, jwt=None,
+        status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     bdm = BlockDeviceMapping()
     brkt_config = {}
     add_brkt_env_to_brkt_config(brkt_env, brkt_config)
@@ -399,6 +400,7 @@ def run_encryptor_instance(
     mime_user_data = user_data.combine_user_data(
         brkt_config,
         proxy_config=proxy_config,
+        ca_cert=ca_cert,
         jwt=jwt
     )
     compressed_user_data = user_data.gzip_user_data(mime_user_data)
@@ -898,7 +900,7 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
 def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            ntp_servers=None, proxy_config=None,
+            ntp_servers=None, proxy_config=None, ca_cert=None,
             guest_instance_type='m3.medium', jwt=None,
             status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     log.info('Starting encryptor session %s', aws_svc.session_id)
@@ -975,6 +977,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             zone=guest_instance.placement,
             ntp_servers=ntp_servers,
             proxy_config=proxy_config,
+            ca_cert=ca_cert,
             jwt=jwt,
             status_port=status_port
         )

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -141,7 +141,15 @@ def setup_encrypt_ami_args(parser):
         dest='brkt_env',
         help=argparse.SUPPRESS
     )
-
+    # Optional CA cert file for Brkt MCP. When an on-prem MCP is used
+    # (and thus, the MCP endpoints are provided in the --brkt-env arg), the
+    # CA cert for the MCP root CA must be 'baked into' the encrypted AMI.
+    parser.add_argument(
+        '--ca-cert',
+        metavar='CERT_FILE',
+        dest='ca_cert',
+        help=argparse.SUPPRESS
+    )
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(

--- a/brkt_cli/user_data.py
+++ b/brkt_cli/user_data.py
@@ -20,7 +20,10 @@ from email.mime.text import MIMEText
 
 import yaml
 
-from brkt_cli.util import add_token_to_brkt_config
+from brkt_cli.util import (
+    add_token_to_brkt_config,
+    get_domain_from_brkt_config
+)
 
 # The directory for files saved on the Metavisor. We require that the dest
 # path for all --brkt-files be within this directory.
@@ -157,7 +160,8 @@ class UserDataContainer(object):
         return str(container)
 
 
-def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
+def combine_user_data(brkt_config=None, proxy_config=None, ca_cert=None,
+                      jwt=None):
     """ Combine the user data dictionary with the given proxy configuration
     into the gzipped multipart MIME binary that will be sent to the
     metavisor instance.
@@ -181,6 +185,14 @@ def combine_user_data(brkt_config=None, proxy_config=None, jwt=None):
         udc.add_file(
             '/var/brkt/ami_config/proxy.yaml',
             proxy_config,
+            BRKT_FILES_CONTENT_TYPE
+        )
+    if ca_cert:
+        domain = get_domain_from_brkt_config(brkt_config)
+        ca_cert_filename = "/var/brkt/ami_config/ca_cert.pem.%s" % (domain)
+        udc.add_file(
+            ca_cert_filename,
+            ca_cert,
             BRKT_FILES_CONTENT_TYPE
         )
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -123,6 +123,27 @@ def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
         brkt_config['brkt']['hsmproxy_host'] = hsmproxy_host_port
 
 
+def get_domain_from_brkt_config(brkt_config):
+    """Return the domain string from the api_host in the brkt_config.
+
+    Raises ValidationError if it doesn't like brkt_config.
+    """
+
+    if not brkt_config or 'brkt' not in brkt_config:
+        raise ValidationError('Invalid brkt_config: %s' % brkt_config)
+    brkt_env = brkt_config['brkt']
+
+    if 'api_host' not in brkt_env:
+        raise ValidationError('api_host endpoint not in brkt_env: %s' %
+                              brkt_env)
+    # Remove the port string from api_host
+    api_host = brkt_env['api_host'].split(':')[0]
+
+    # Consider the domain to be everything after the first '.' in
+    # the api_host.
+    return api_host.split('.', 1)[1]
+
+
 def add_token_to_brkt_config(identity_token, user_data):
     if 'brkt' not in user_data:
         user_data['brkt'] = {}


### PR DESCRIPTION
* Adds --ca-cert arg to 'encrypt-ami' command
  (TODO: add it to update-ami, encrypt-gce-image and update-gce-image)

[rebased and fixed version of #322, which superseded #308]
