### PR TITLE
Update ca-certificates when building the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.4
 MAINTAINER Bracket Computing Inc.
 
 RUN apk -U upgrade && \
-    apk add --no-cache -U py-pip build-base libffi-dev openssl-dev python-dev
+    apk add --no-cache -U py-pip build-base libffi-dev openssl-dev python-dev ca-certificates
 
 COPY . /brkt-cli
 RUN pip install /brkt-cli

--- a/README.md
+++ b/README.md
@@ -265,12 +265,12 @@ command.  Note that you must pass any required environment variables or
 files into the container.  Some examples:
 
 ```
-$ docker run -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+$ docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-brkt encrypt-ami --region us-west-2 ami-4133cb21
+brkt encrypt-ami --region us-west-2 ami-9025e1f0
 ```
 
 ```
-$ docker run -v ~/keys:/keys brkt make-jwt --signing-key /keys/secret.pem
+$ docker run --rm -v ~/keys:/keys brkt make-jwt --signing-key /keys/secret.pem
 eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImU2MTNhYzI0YzRkN2ExY...
 ```


### PR DESCRIPTION
Update ca-certificates when building a Docker container.  This avoids
cert verification issues when getting the AMI list from S3 via https.

Add --rm docker run samples, so that people who copy/paste don't end up
with container cruft from every run.

Update the sample AMI ID to be an HVM AMI, since that's now the default.