### PR TITLE
Made JWT input be string for make-user-data

### DIFF
--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -38,6 +38,8 @@ class MakeUserDataSubcommand(Subcommand):
         )
         parser.add_argument(
             '--jwt',
+            required=True,
+            metavar="JWT-STRING",
             help=(
                 'JSON Web Token that the encrypted instance will use to '
                 'authenticate with the Bracket service.  Use the make-jwt '
@@ -56,10 +58,7 @@ class MakeUserDataSubcommand(Subcommand):
         return values.make_user_data_verbose
 
     def run(self, values):
-        with open(values.jwt, 'r') as f:
-            token_val = f.read().rstrip()
-
-        print combine_user_data(brkt_config={}, jwt=token_val)
+        print combine_user_data(brkt_config={}, jwt=values.jwt)
         return 0
 
 


### PR DESCRIPTION
[squashed version of #329]
* In #321, I switched the '--jwt' input to make-user-data be  a filename instead of a string.  But other commands use JWTs as strings, so make-user-data should follow that convention.