### PR TITLE
Consolidate instance config arg handling

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -27,10 +27,10 @@ import requests
 from brkt_cli import (
     util
 )
-from brkt_cli.proxy import Proxy
+from brkt_cli.proxy import Proxy, generate_proxy_config, validate_proxy_config
 from brkt_cli.util import validate_dns_name_ip_address
 from brkt_cli.validation import ValidationError
-from encryptor_service import BracketEnvironment
+from brkt_cli.encryptor_service import BracketEnvironment
 
 VERSION = '1.0.2pre1'
 BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
@@ -185,12 +185,12 @@ def get_proxy_config(values):
             with open(path) as f:
                 proxy_config = f.read()
         except IOError as e:
-            log.debug('Unable to read %s', path, e)
+            log.debug('Unable to read %s: %s', path, e)
             raise ValidationError('Unable to read %s' % path)
-        proxy.validate_proxy_config(proxy_config)
+        validate_proxy_config(proxy_config)
     elif values.proxies:
         proxies = _parse_proxies(*values.proxies)
-        proxy_config = proxy.generate_proxy_config(*proxies)
+        proxy_config = generate_proxy_config(*proxies)
         log.debug('Using proxy configuration:\n%s', proxy_config)
 
     return proxy_config

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -50,10 +50,11 @@ from boto.ec2.blockdevicemapping import (
 from boto.ec2.instance import InstanceAttribute
 from boto.exception import EC2ResponseError
 
-from brkt_cli import encryptor_service, user_data
+from brkt_cli import encryptor_service
 from brkt_cli.aws import aws_service
+from brkt_cli.instance_config import InstanceConfig
+from brkt_cli.user_data import gzip_user_data
 from brkt_cli.util import (
-    add_brkt_env_to_brkt_config,
     BracketError,
     Deadline,
     make_nonce,
@@ -307,22 +308,16 @@ def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
 
 
 def run_encryptor_instance(
-        aws_svc, encryptor_image_id,
-        snapshot, root_size,
-        guest_image_id, brkt_env=None, security_group_ids=None,
-        subnet_id=None, zone=None, ntp_servers=None, proxy_config=None,
-        ca_cert=None, jwt=None,
+        aws_svc, encryptor_image_id, snapshot, root_size, guest_image_id,
+        security_group_ids=None, subnet_id=None, zone=None,
+        instance_config=None,
         status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     bdm = BlockDeviceMapping()
-    brkt_config = {}
-    add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 
-    if ntp_servers:
-        brkt_config['ntp-servers'] = ntp_servers
+    if instance_config is None:
+        instance_config = InstanceConfig()
 
-    if 'brkt' not in brkt_config:
-        brkt_config['brkt'] = {}
-    brkt_config['brkt']['status_port'] = status_port
+    instance_config.brkt_config['status_port'] = status_port
 
     image = aws_svc.get_image(encryptor_image_id)
     virtualization_type = image.virtualization_type
@@ -352,14 +347,8 @@ def run_encryptor_instance(
         bdm['/dev/sdf'] = guest_unencrypted_root
         bdm['/dev/sdg'] = guest_encrypted_root
 
-    mime_user_data = user_data.combine_user_data(
-        brkt_config,
-        proxy_config=proxy_config,
-        ca_cert=ca_cert,
-        jwt=jwt
-    )
-    compressed_user_data = user_data.gzip_user_data(mime_user_data)
-
+    user_data = instance_config.make_userdata()
+    compressed_user_data = gzip_user_data(user_data)
     instance = aws_svc.run_instance(encryptor_image_id,
                                     security_group_ids=security_group_ids,
                                     user_data=compressed_user_data,
@@ -857,10 +846,9 @@ def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
     return ami_info
 
 
-def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
+def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami,
             encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            ntp_servers=None, proxy_config=None, ca_cert=None,
-            guest_instance_type='m3.medium', jwt=None,
+            guest_instance_type='m3.medium', instance_config=None,
             status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     log.info('Starting encryptor session %s', aws_svc.session_id)
 
@@ -930,14 +918,10 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, brkt_env=None,
             snapshot=snapshot_id,
             root_size=size,
             guest_image_id=image_id,
-            brkt_env=brkt_env,
             security_group_ids=security_group_ids,
             subnet_id=subnet_id,
             zone=guest_instance.placement,
-            ntp_servers=ntp_servers,
-            proxy_config=proxy_config,
-            ca_cert=ca_cert,
-            jwt=jwt,
+            instance_config=instance_config,
             status_port=status_port
         )
 

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -53,35 +53,6 @@ def setup_encrypt_ami_args(parser):
         help="Don't validate AMIs, subnet, and security groups"
     )
     parser.add_argument(
-        '--ntp-server',
-        metavar='DNS Name',
-        dest='ntp_servers',
-        action='append',
-        help=(
-            'Optional NTP server to sync Metavisor clock. '
-            'May be specified multiple times.'
-        )
-    )
-
-    proxy_group = parser.add_mutually_exclusive_group()
-    proxy_group.add_argument(
-        '--proxy',
-        metavar='HOST:PORT',
-        help=(
-            'Use this HTTPS proxy during encryption.  '
-            'May be specified multiple times.'
-        ),
-        dest='proxies',
-        action='append'
-    )
-    proxy_group.add_argument(
-        '--proxy-config-file',
-        metavar='PATH',
-        help='Path to proxy.yaml file that will be used during encryption',
-        dest='proxy_config_file'
-    )
-
-    parser.add_argument(
         '--region',
         metavar='NAME',
         help='AWS region (e.g. us-west-2)',
@@ -131,25 +102,6 @@ def setup_encrypt_ami_args(parser):
         action='store_true',
         help='Print status information to the console'
     )
-
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    # If you're using this option, it should be passed as a comma separated
-    # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
-    # endpoints must also be in order: api_host,hsmproxy_host
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
-    # Optional CA cert file for Brkt MCP. When an on-prem MCP is used
-    # (and thus, the MCP endpoints are provided in the --brkt-env arg), the
-    # CA cert for the MCP root CA must be 'baked into' the encrypted AMI.
-    parser.add_argument(
-        '--ca-cert',
-        metavar='CERT_FILE',
-        dest='ca_cert',
-        help=argparse.SUPPRESS
-    )
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(
@@ -158,7 +110,6 @@ def setup_encrypt_ami_args(parser):
         dest='encryptor_ami',
         help=argparse.SUPPRESS
     )
-
     # Optional EC2 SSH key pair name to use for launching the guest
     # and encryptor instances.  This argument is hidden because it's only
     # used for development.
@@ -168,7 +119,6 @@ def setup_encrypt_ami_args(parser):
         help=argparse.SUPPRESS,
         dest='key_name'
     )
-
     # Optional arguments for changing the behavior of our retry logic.  We
     # use these options internally, to avoid intermittent AWS service failures
     # when running concurrent encryption processes in integration tests.
@@ -179,24 +129,10 @@ def setup_encrypt_ami_args(parser):
         help=argparse.SUPPRESS,
         default=10.0
     )
-
     parser.add_argument(
         '--retry-initial-sleep-seconds',
         metavar='SECONDS',
         type=float,
         help=argparse.SUPPRESS,
         default=0.25
-    )
-
-    # This option is still in development.
-    """
-    help=(
-        'JSON Web Token that the encrypted instance will use to '
-        'authenticate with the Bracket service.  Use the make-jwt '
-        'subcommand to generate a JWT.'
-    )
-    """
-    parser.add_argument(
-        '--jwt',
-        help=argparse.SUPPRESS
     )

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -516,4 +516,3 @@ class TestVolume(unittest.TestCase):
         aws_svc.get_volume_callback = transition_to_available
         result = aws_service.wait_for_volume(aws_svc, volume.id)
         self.assertEqual(volume, result)
-

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -36,7 +36,6 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env=None,
             encryptor_ami=encryptor_image.id
         )
 
@@ -68,7 +67,6 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            brkt_env=None,
             encryptor_ami=encryptor_image.id
         )
 

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -52,25 +52,6 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
-
-    proxy_group = parser.add_mutually_exclusive_group()
-    proxy_group.add_argument(
-        '--proxy',
-        metavar='HOST:PORT',
-        help=(
-            'Use this HTTPS proxy during encryption.  '
-            'May be specified multiple times.'
-        ),
-        dest='proxies',
-        action='append'
-    )
-    proxy_group.add_argument(
-        '--proxy-config-file',
-        metavar='PATH',
-        help='Path to proxy.yaml file that will be used during encryption',
-        dest='proxy_config_file'
-    )
-
     parser.add_argument(
         '--region',
         metavar='REGION',
@@ -105,22 +86,6 @@ def setup_update_encrypted_ami(parser):
         dest='subnet_id',
         help='Launch instances in this subnet'
     )
-    parser.add_argument(
-        '--ntp-server',
-        metavar='DNS Name',
-        dest='ntp_servers',
-        action='append',
-        help=(
-            'Optional NTP server to sync Metavisor clock. '
-            'May be specified multiple times.'
-        )
-    )
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
     # Optional EC2 SSH key pair name to use for launching the guest
     # and encryptor instances.  This argument is hidden because it's only
     # used for development.
@@ -147,7 +112,6 @@ def setup_update_encrypted_ami(parser):
         action='store_true',
         help='Print status information to the console'
     )
-
     # Optional hidden argument for specifying the metavisor AMI.  This
     # argument is hidden because it's only used for development.  It can
     # also be used to override the default AMI if it's determined to be
@@ -158,7 +122,6 @@ def setup_update_encrypted_ami(parser):
         help=argparse.SUPPRESS,
         dest='encryptor_ami'
     )
-
     # Optional arguments for changing the behavior of our retry logic.  We
     # use these options internally, to avoid intermittent AWS service failures
     # when running concurrent encryption processes in integration tests.
@@ -169,24 +132,10 @@ def setup_update_encrypted_ami(parser):
         help=argparse.SUPPRESS,
         default=10.0
     )
-
     parser.add_argument(
         '--retry-initial-sleep-seconds',
         metavar='SECONDS',
         type=float,
         help=argparse.SUPPRESS,
         default=0.25
-    )
-
-    # This option is still in development.
-    """
-    help=(
-        'JSON Web Token that the encrypted instance will use to '
-        'authenticate with the Bracket service.  Use the make-jwt '
-        'subcommand to generate a JWT.'
-    )
-    """
-    parser.add_argument(
-        '--jwt',
-        help=argparse.SUPPRESS
     )

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -28,20 +28,23 @@ def setup_encrypt_gce_image_args(parser):
         default='prod',
         required=False
     )
+
+    # The email and password options will be deprecated soon (per Grant).
     parser.add_argument(
          '--brkt-email',
          metavar='EMAIL',
          dest='api_email',
          help='Bracket user email',
-         required=True
-     )
+         required=False  # arg is optional because the --jwt arg may be used instead
+    )
     parser.add_argument(
          '--brkt-password',
          metavar='PASSWORD',
          dest='api_password',
          help='Bracket user password',
-         required=True
-     )
+         required=False  # arg is optional because the --jwt arg may be used instead
+    )
+
     parser.add_argument(
         '--project',
         help='GCE project name',
@@ -66,16 +69,8 @@ def setup_encrypt_gce_image_args(parser):
         default='default',
         required=False
     )
-
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    # If you're using this option, it should be passed as a comma separated
-    # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
-    # endpoints must also be in order: api_host,hsmproxy_host
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
+    # Optional Image Name that's used to launch the encryptor instance. This
+    # argument is hidden because it's only used for development.
     parser.add_argument(
         '--encryptor-image-file',
         dest='image_file',
@@ -88,6 +83,3 @@ def setup_encrypt_gce_image_args(parser):
         action='store_true',
         help=argparse.SUPPRESS
     )
-
-    # Optional Image Name that's used to launch the encryptor instance. This
-    # argument is hidden because it's only used for development.

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -219,7 +219,6 @@ class GCEService(BaseGCEService):
         except:
             log.exception('Cleanup failed')
 
-
     def list_zones(self):
         zones = []
         zones_resp = self.compute.zones().list(project=self.project).execute()
@@ -353,7 +352,7 @@ class GCEService(BaseGCEService):
 
     def create_snapshot(self, zone, disk, snapshot_name):
         disk_url = "projects/%s/zones/%s/disks/%s" % (self.project, zone, disk)
-        body = {'sourceDisk':disk_url, 'name':snapshot_name}
+        body = {'sourceDisk': disk_url, 'name': snapshot_name}
         self.compute.disks().createSnapshot(project=self.project, disk=disk, body=body, zone=zone).execute()
 
     def delete_snapshot(self, snapshot_name):
@@ -570,11 +569,12 @@ class GCEService(BaseGCEService):
         }
 
 
-def gce_metadata_from_userdata(brkt_data):
-    gce_metadata = {}
-    gce_metadata['items']= [{'key': 'brkt',
-                                  'value': json.dumps(brkt_data)}]
-    return gce_metadata
+def gce_metadata_from_userdata(brkt_data, extra_items=None):
+    """ brkt_data is a JSON blob containing the brkt-config """
+    items_list = [{'key': 'brkt', 'value': brkt_data}]
+    if extra_items:
+        items_list.extend(extra_items)
+    return { 'items': items_list }
 
 
 def get_image_name(encrypted_image_name, name):

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -53,16 +53,3 @@ def setup_launch_gce_image_args(parser):
         metavar='SCRIPT',
         required=False
     )
-
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    # If you're using this option, it should be passed as a comma separated
-    # list of endpoints. ie blb.*.*.brkt.net:7002,blb.*.*.brkt.net:7001 the
-    # endpoints must also be in order: api_host,hsmproxy_host
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
-
-    # Optional Image Name that's used to launch the encryptor instance. This
-    # argument is hidden because it's only used for development.

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -28,20 +28,23 @@ def setup_update_gce_image_args(parser):
         default='prod',
         required=False
     )
+
+    # The email and password options will be deprecated soon (per Grant).
     parser.add_argument(
          '--brkt-email',
          metavar='EMAIL',
          dest='api_email',
          help='Bracket user email',
-         required=True
-     )
+         required=False  # arg is optional because the --jwt arg may be used instead
+    )
     parser.add_argument(
          '--brkt-password',
          metavar='PASSWORD',
          dest='api_password',
          help='Bracket user password',
-         required=True
-     )
+         required=False  # arg is optional because the --jwt arg may be used instead
+    )
+
     parser.add_argument(
         '--project',
         help='GCE project name',
@@ -59,14 +62,6 @@ def setup_update_gce_image_args(parser):
         default='default',
         required=False
     )
-
-    # Optional yeti endpoints. Hidden because it's only used for development.
-    parser.add_argument(
-        '--brkt-env',
-        dest='brkt_env',
-        help=argparse.SUPPRESS
-    )
-
     # Optional arg <image name>.image.tar.gz for specifying metavisor
     # image file if you don't want to use the latest image
     parser.add_argument(
@@ -75,7 +70,6 @@ def setup_update_gce_image_args(parser):
         required=False,
         help=argparse.SUPPRESS
     )
-
     parser.add_argument(
         '--keep-encryptor',
         dest='keep_encryptor',

--- a/brkt_cli/instance_config.py
+++ b/brkt_cli/instance_config.py
@@ -1,0 +1,87 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+
+from brkt_cli.user_data import UserDataContainer
+from brkt_cli.validation import ValidationError
+
+# The directories for files saved on the Metavisor. We require that the dest
+# path for all --brkt-files be within this directory.
+#
+# If the Metavisor is in 'creator' mode, it will only save files
+# to '/var/brkt/ami_config'.
+# If the Metavisor is in 'metavisor' mode, it will only save files
+# to '/var/brkt/instance_config'.
+
+BRKT_FILE_AMI_CONFIG = '/var/brkt/ami_config'
+BRKT_FILE_INSTANCE_CONFIG = '/var/brkt/instance_config'
+
+BRKT_CONFIG_CONTENT_TYPE = 'text/brkt-config'
+BRKT_FILES_CONTENT_TYPE = 'text/brkt-files'
+GUEST_FILES_CONTENT_TYPE = 'text/brkt-guest-files'
+
+# Some instance config args are only supported when the Metavisor instance
+# is running in 'creator' mode.
+INSTANCE_METAVISOR_MODE = 1
+INSTANCE_CREATOR_MODE   = 2
+
+log = logging.getLogger(__name__)
+
+
+class BrktFile(object):
+    def __init__(self, dest_filename, file_contents):
+        self.dest_filename = dest_filename
+        self.file_contents = file_contents
+
+
+class InstanceConfig(object):
+    """ Class containing common settings for Brkt instances """
+
+    def __init__(self, brkt_config=None, mode=INSTANCE_CREATOR_MODE):
+        if brkt_config is None:
+            brkt_config = {}
+
+        self.brkt_config = brkt_config
+        self._brkt_files = []
+        self._mode = mode
+        if mode is INSTANCE_METAVISOR_MODE:
+            self._brkt_files_dest_dir = BRKT_FILE_INSTANCE_CONFIG
+        else:
+            self._brkt_files_dest_dir = BRKT_FILE_AMI_CONFIG
+
+    def brkt_files_dest_dir(self):
+        return self._brkt_files_dest_dir
+
+    def add_brkt_file(self, dest_filename, file_contents):
+        # dest_filename will be relative to self._brkt_files_dest_dir
+        dest_path = os.path.join(self._brkt_files_dest_dir, dest_filename)
+        brkt_file = BrktFile(dest_path, file_contents)
+        self._brkt_files.append(brkt_file)
+
+    def make_brkt_config_json(self):
+        brkt_config_dict = {'brkt': self.brkt_config}
+        return json.dumps(brkt_config_dict, sort_keys=True)
+
+    def make_userdata(self):
+        udc = UserDataContainer()
+
+        udc.add_part(BRKT_CONFIG_CONTENT_TYPE, self.make_brkt_config_json())
+
+        for brkt_file in self._brkt_files:
+            udc.add_file(brkt_file.dest_filename, brkt_file.file_contents,
+                         BRKT_FILES_CONTENT_TYPE)
+        return udc.to_mime_text()

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -15,8 +15,10 @@ import logging
 
 import brkt_cli
 from brkt_cli.subcommand import Subcommand
-from brkt_cli.user_data import combine_user_data
-
+from brkt_cli.instance_config_args import (
+    instance_config_from_values,
+    setup_instance_config_args
+)
 log = logging.getLogger(__name__)
 
 
@@ -36,16 +38,9 @@ class MakeUserDataSubcommand(Subcommand):
                 'Metavisor and cloud-init when running an instance.'
             )
         )
-        parser.add_argument(
-            '--jwt',
-            required=True,
-            metavar="JWT-STRING",
-            help=(
-                'JSON Web Token that the encrypted instance will use to '
-                'authenticate with the Bracket service.  Use the make-jwt '
-                'subcommand to generate a JWT.'
-            )
-        )
+
+        setup_instance_config_args(parser)
+
         parser.add_argument(
             '-v',
             '--verbose',
@@ -58,7 +53,8 @@ class MakeUserDataSubcommand(Subcommand):
         return values.make_user_data_verbose
 
     def run(self, values):
-        print combine_user_data(brkt_config={}, jwt=values.jwt)
+        instance_cfg = instance_config_from_values(values)
+        print instance_cfg.make_userdata()
         return 0
 
 

--- a/brkt_cli/oauth_requests.py
+++ b/brkt_cli/oauth_requests.py
@@ -129,7 +129,6 @@ class APISession(object):
         if resp.status_code == 401:
             if not self._requests_auth.client.refresh_token:
                 raise APISessionError('Access token expired, no refresh token')
-            self._refresh()
             resp = self.session.request(
                 method, url, headers=headers, auth=self._requests_auth,
                 **kwargs)

--- a/brkt_cli/test_instance_config.py
+++ b/brkt_cli/test_instance_config.py
@@ -1,0 +1,237 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import json
+import os
+import sys
+import tempfile
+import unittest
+import yaml
+
+from brkt_cli import (
+    generate_proxy_config,
+    proxy,
+    parse_brkt_env,
+    _parse_proxies,
+    user_data
+)
+from brkt_cli.instance_config import (
+    BRKT_CONFIG_CONTENT_TYPE,
+    BRKT_FILES_CONTENT_TYPE,
+    InstanceConfig,
+    INSTANCE_CREATOR_MODE,
+    INSTANCE_METAVISOR_MODE
+)
+from brkt_cli.instance_config_args import (
+    instance_config_args_to_values,
+    instance_config_from_values
+)
+from brkt_cli.proxy import Proxy
+from brkt_cli.util import add_brkt_env_to_brkt_config
+from brkt_cli.user_data import get_mime_part_payload
+from brkt_cli.validation import ValidationError
+
+test_jwt = (
+    'eyJhbGciOiAiRVMzODQiLCAidHlwIjogIkpXVCJ9.eyJpc3MiOiAiYnJrdC1jb'
+    'GktMC45LjE3cHJlMSIsICJpYXQiOiAxNDYzNDI5MDg1LCAianRpIjogImJlN2J'
+    'mYzYwIiwgImtpZCI6ICJhYmMifQ.U2lnbmVkLCBzZWFsZWQsIGRlbGl2ZXJlZA'
+)
+
+# Some test constants
+api_host_port = 'api.example.com:777'
+hsmproxy_host_port = 'hsmproxy.example.com:888'
+ntp_server1 = '10.4.5.6'
+ntp_server2 = '199.55.32.1'
+proxy_host = '10.22.33.44'
+proxy_port = 3128
+proxy_host_port = '%s:%d' % (proxy_host, proxy_port)
+
+
+def _get_ca_cert_filename():
+    # Find the "ca_cert.pem" file in brkt_cli/assets
+    my_dir = os.path.dirname(inspect.getfile(inspect.currentframe()))
+    return os.path.join(my_dir, 'assets', 'ca_cert.pem')
+
+
+def _verify_proxy_config_in_userdata(ut, userdata):
+    brkt_config_json = get_mime_part_payload(userdata,
+                                             BRKT_CONFIG_CONTENT_TYPE)
+    ut.assertEqual(brkt_config_json, '{"brkt": {}}')
+
+    brkt_files = get_mime_part_payload(userdata, BRKT_FILES_CONTENT_TYPE)
+    ut.assertTrue('/var/brkt/ami_config/proxy.yaml: ' +
+                    '{contents: "version: 2.0' in brkt_files)
+    ut.assertTrue('host: %s' % proxy_host in brkt_files)
+    ut.assertTrue('port: %d' % proxy_port in brkt_files)
+
+
+class TestInstanceConfig(unittest.TestCase):
+
+    def test_brkt_env(self):
+        brkt_config_in = {
+            'api_host': api_host_port,
+            'hsmproxy_host': hsmproxy_host_port
+        }
+        ic = InstanceConfig(brkt_config_in)
+        config_json = ic.make_brkt_config_json()
+        expected_json = '{"brkt": {"api_host": "%s", "hsmproxy_host": "%s"}}' % \
+                        (api_host_port, hsmproxy_host_port)
+        self.assertEqual(config_json, expected_json)
+
+    def test_ntp_servers(self):
+        # First with just one server
+        ic = InstanceConfig({'ntp_servers': [ntp_server1]})
+
+        config_json = ic.make_brkt_config_json()
+        expected_json = '{"brkt": {"ntp_servers": ["%s"]}}' % ntp_server1
+        self.assertEqual(config_json, expected_json)
+
+        # Now try two servers
+        ic = InstanceConfig({'ntp_servers': [ntp_server1, ntp_server2]})
+
+        config_json = ic.make_brkt_config_json()
+        expected_json = '{"brkt": {"ntp_servers": ["%s", "%s"]}}' % \
+                        (ntp_server1, ntp_server2)
+        self.assertEqual(config_json, expected_json)
+
+    def test_jwt(self):
+        ic = InstanceConfig({'identity_token': test_jwt})
+        config_json = ic.make_brkt_config_json()
+        expected_json = '{"brkt": {"identity_token": "%s"}}' % test_jwt
+        self.assertEqual(config_json, expected_json)
+
+    def test_proxy_config(self):
+        # The proxy file goes in a brkt-file part,
+        # so the brkt config should be empty
+        ic = InstanceConfig({})
+        p = Proxy(host=proxy_host, port=proxy_port)
+        proxy_config = proxy.generate_proxy_config(p)
+        ic.add_brkt_file('proxy.yaml', proxy_config)
+        _verify_proxy_config_in_userdata(self, ic.make_userdata())
+
+    def test_multiple_options(self):
+        brkt_config_in = {
+            'api_host': api_host_port,
+            'hsmproxy_host': hsmproxy_host_port,
+            'ntp_servers': [ntp_server1],
+            'identity_token': test_jwt
+        }
+        ic = InstanceConfig(brkt_config_in)
+        ic.add_brkt_file('ca_cert.pem.example.com', 'DUMMY CERT')
+        ud = ic.make_userdata()
+        brkt_config_json = get_mime_part_payload(ud, BRKT_CONFIG_CONTENT_TYPE)
+        brkt_config = json.loads(brkt_config_json)['brkt']
+
+        self.assertEqual(brkt_config['identity_token'], test_jwt)
+        self.assertEqual(brkt_config['ntp_servers'], [ntp_server1])
+        self.assertEqual(brkt_config['api_host'], api_host_port)
+        self.assertEqual(brkt_config['hsmproxy_host'], hsmproxy_host_port)
+
+        brkt_files = get_mime_part_payload(ud, BRKT_FILES_CONTENT_TYPE)
+        self.assertEqual(brkt_files,
+                        "/var/brkt/ami_config/ca_cert.pem.example.com: " +
+                        "{contents: DUMMY CERT}\n")
+
+        """
+        gce_metadata = ic.make_gce_metadata()
+        item_list = gce_metadata['items']
+        self.assertEqual(len(item_list), 1)
+        brkt_item = item_list[0]
+        self.assertEqual(brkt_item['key'], 'brkt')
+        brkt_userdata = brkt_item['value']
+        """
+
+
+def _get_brkt_config_for_cli_args(cli_args, mode=INSTANCE_CREATOR_MODE):
+    values = instance_config_args_to_values(cli_args)
+    ic = instance_config_from_values(values, mode=mode)
+    ud = ic.make_userdata()
+    brkt_config_json = get_mime_part_payload(ud, BRKT_CONFIG_CONTENT_TYPE)
+    brkt_config = json.loads(brkt_config_json)['brkt']
+    return brkt_config
+
+
+class TestInstanceConfigFromCliArgs(unittest.TestCase):
+
+    def test_brkt_env(self):
+        cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
+        brkt_config = _get_brkt_config_for_cli_args(cli_args)
+        self.assertEqual(brkt_config['api_host'], api_host_port)
+        self.assertEqual(brkt_config['hsmproxy_host'], hsmproxy_host_port)
+
+    def test_ntp_servers(self):
+        cli_args = '--ntp-server %s' % ntp_server1
+        brkt_config = _get_brkt_config_for_cli_args(cli_args)
+        server_list = brkt_config['ntp_servers']
+        self.assertEqual(server_list, [ntp_server1])
+
+        cli_args = '--ntp-server %s --ntp-server %s' % \
+                   (ntp_server1, ntp_server2)
+        brkt_config = _get_brkt_config_for_cli_args(cli_args)
+        server_list = brkt_config['ntp_servers']
+        self.assertEqual(server_list, [ntp_server1, ntp_server2])
+
+    def test_jwt(self):
+        cli_args = '--jwt %s' % test_jwt
+        brkt_config = _get_brkt_config_for_cli_args(cli_args)
+        self.assertEqual(brkt_config['identity_token'], test_jwt)
+
+    def test_proxy_config(self):
+        cli_args = '--proxy %s' % (proxy_host_port)
+        values = instance_config_args_to_values(cli_args)
+        ic = instance_config_from_values(values)
+        _verify_proxy_config_in_userdata(self, ic.make_userdata())
+
+    def test_ca_cert(self):
+        domain = 'dummy.foo.com'
+        # First make sure that you can't use --ca-cert without specifying endpoints
+        cli_args = '--ca-cert dummy.crt'
+        values = instance_config_args_to_values(cli_args)
+        with self.assertRaises(ValidationError):
+            ic = instance_config_from_values(values)
+
+        # Now specify endpoint args but use a bogus cert
+        endpoint_args = '--brkt-env api.%s:7777,hsmproxy.%s:8888' % (domain, domain)
+        dummy_ca_cert = 'THIS IS NOT A CERTIFICATE'
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(dummy_ca_cert)
+            f.flush()
+            cli_args = endpoint_args + ' --ca-cert %s' % f.name
+            values = instance_config_args_to_values(cli_args)
+            with self.assertRaises(ValidationError):
+                ic = instance_config_from_values(values)
+
+        # Now use endpoint args and a valid cert
+        cli_args = endpoint_args + ' --ca-cert %s' % _get_ca_cert_filename()
+        values = instance_config_args_to_values(cli_args)
+        ic = instance_config_from_values(values)
+        ud = ic.make_userdata()
+        brkt_files = get_mime_part_payload(ud, BRKT_FILES_CONTENT_TYPE)
+        self.assertTrue(brkt_files.startswith(
+                        "/var/brkt/ami_config/ca_cert.pem.dummy.foo.com: " +
+                        "{contents: '-----BEGIN CERTIFICATE-----"))
+
+        # Make sure the --ca-cert arg is only recognized in 'creator' mode
+        # prevent stderr message from parse_args
+        sys.stderr = open(os.devnull, 'w')
+        try:
+            values = instance_config_args_to_values(cli_args,
+                                                    mode=INSTANCE_METAVISOR_MODE)
+        except SystemExit:
+            pass
+        else:
+            self.assertTrue(False, 'Did not get expected exception')
+        sys.stderr.close()
+        sys.stderr = sys.__stderr__

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import unittest
-
 import time
 
-from brkt_cli import util
+from brkt_cli import parse_brkt_env, util
 from brkt_cli.validation import ValidationError
 
 
@@ -46,6 +45,18 @@ class TestUtil(unittest.TestCase):
         )
         with self.assertRaises(ValidationError):
             util.parse_name_value('abc')
+
+
+class TestBrktEnv(unittest.TestCase):
+
+    def test_add_brkt_env_to_user_data(self):
+        userdata = {}
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        expected_userdata = {'api_host': api_host_port, 'hsmproxy_host': hsmproxy_host_port}
+        brkt_env = parse_brkt_env(api_host_port + ',' + hsmproxy_host_port)
+        util.add_brkt_env_to_brkt_config(brkt_env, userdata)
+        self.assertEqual(userdata, expected_userdata)
 
 
 class TestBase64(unittest.TestCase):

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -114,40 +114,24 @@ def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
     :param brkt_config a dictionary that contains configuration data
     """
     if brkt_env:
-        if 'brkt' not in brkt_config:
-            brkt_config['brkt'] = {}
         api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
         hsmproxy_host_port = '%s:%d' % (
             brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
-        brkt_config['brkt']['api_host'] = api_host_port
-        brkt_config['brkt']['hsmproxy_host'] = hsmproxy_host_port
+        brkt_config['api_host'] = api_host_port
+        brkt_config['hsmproxy_host'] = hsmproxy_host_port
 
 
-def get_domain_from_brkt_config(brkt_config):
-    """Return the domain string from the api_host in the brkt_config.
+def get_domain_from_brkt_env(brkt_env):
+    """Return the domain string from the api_host in the brkt_env. """
 
-    Raises ValidationError if it doesn't like brkt_config.
-    """
-
-    if not brkt_config or 'brkt' not in brkt_config:
-        raise ValidationError('Invalid brkt_config: %s' % brkt_config)
-    brkt_env = brkt_config['brkt']
-
-    if 'api_host' not in brkt_env:
+    api_host = brkt_env.api_host
+    if not api_host:
         raise ValidationError('api_host endpoint not in brkt_env: %s' %
                               brkt_env)
-    # Remove the port string from api_host
-    api_host = brkt_env['api_host'].split(':')[0]
 
     # Consider the domain to be everything after the first '.' in
     # the api_host.
     return api_host.split('.', 1)[1]
-
-
-def add_token_to_brkt_config(identity_token, user_data):
-    if 'brkt' not in user_data:
-        user_data['brkt'] = {}
-    user_data['brkt']['identity_token'] = identity_token
 
 
 def make_nonce():

--- a/test_gce.py
+++ b/test_gce.py
@@ -11,6 +11,7 @@ from brkt_cli import util
 from brkt_cli.gce import encrypt_gce_image
 from brkt_cli.gce import update_gce_image
 from brkt_cli.gce import gce_service
+from brkt_cli.instance_config import InstanceConfig
 from brkt_cli.test_encryptor_service import (
     DummyEncryptorService,
     FailedEncryptionService
@@ -88,7 +89,6 @@ class DummyGCEService(gce_service.BaseGCEService):
             self.disks.remove(disk)
             return
         raise test.TestException('disk doesnt exist')
-
 
     def wait_instance(self, name, zone):
         return
@@ -236,8 +236,7 @@ class TestRunEncryption(unittest.TestCase):
             encryptor_image='encryptor-image',
             encrypted_image_name='ubuntu-encrypted',
             zone='us-central1-a',
-            brkt_env=None,
-            token=TOKEN,
+            instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertIsNotNone(encrypted_image)
         self.assertEqual(len(gce_svc.disks), 0)
@@ -252,8 +251,7 @@ class TestRunEncryption(unittest.TestCase):
             encryptor_image='encryptor-image',
             encrypted_image_name='ubuntu-encrypted',
             zone='us-central1-a',
-            brkt_env=None,
-            token=TOKEN,
+            instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertEqual(len(gce_svc.disks), 0)
         self.assertEqual(len(gce_svc.instances), 0)
@@ -268,8 +266,7 @@ class TestRunEncryption(unittest.TestCase):
                 encryptor_image='encryptor-image',
                 encrypted_image_name='ubuntu-encrypted',
                 zone='us-central1-a',
-                brkt_env=None,
-                token=TOKEN,
+                instance_config=InstanceConfig({'identity_token': TOKEN})
             )
         self.assertEqual(len(gce_svc.disks), 0)
         self.assertEqual(len(gce_svc.instances), 0)
@@ -326,22 +323,6 @@ class TestImageValidation(unittest.TestCase):
              )
 
 
-class TestBrktEnv(unittest.TestCase):
-
-    def setUp(self):
-        util.SLEEP_ENABLED = False
-
-    def test_add_brkt_env_to_user_data(self):
-        userdata = {}
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        expected_userdata = {'brkt':{'api_host': api_host_port, 'hsmproxy_host': hsmproxy_host_port}}
-        brkt_env = brkt_cli.parse_brkt_env(
-            api_host_port + ',' + hsmproxy_host_port)
-        util.add_brkt_env_to_brkt_config(brkt_env, userdata)
-        self.assertEqual(userdata, expected_userdata)
-
-
 class TestRunUpdate(unittest.TestCase):
 
     def setUp(self):
@@ -357,8 +338,7 @@ class TestRunUpdate(unittest.TestCase):
                 encryptor_image='encryptor-image',
                 encrypted_image_name='ubuntu-encrypted',
                 zone='us-central1-a',
-                brkt_env=None,
-                token=TOKEN
+                instance_config=InstanceConfig({'identity_token': TOKEN})
             )
         self.assertEqual(len(gce_svc.disks), 0)
         self.assertEqual(len(gce_svc.instances), 0)
@@ -372,8 +352,7 @@ class TestRunUpdate(unittest.TestCase):
             encryptor_image='encryptor-image',
             encrypted_image_name='centos-encrypted',
             zone='us-central1-a',
-            brkt_env=None,
-            token=TOKEN
+            instance_config=InstanceConfig({'identity_token': TOKEN})
         )
 
         self.assertIsNotNone(encrypted_image)


### PR DESCRIPTION
* Created InstanceConfig class with methods to generate userdata and gce_userdata.  Its ctor takes a 'values' list, as returnd by argparse.parse_args().

* Reduced the input args to the 'encrypt' and 'update' functions for aws and gce (substituting an InstanceConfig arg).

* Added helper functions in instance_config_args to be used by commands that launch Metavisor instances.

* This has the effect of making all instance-launching commands (encrypt-ami, update-encrypted-ami, encrypt-gce-image, update-encrypted-gce-image, launch-gce-image) now consistently support these args:
  --brkt-env, --proxy, --proxy-config-file, --ntp-server, --jwt.
  Also, all the 'creator' mode commands (all the above except launch-gce-image) now support the --ca-cert arg as well.

* Added unit tests for the new instance_config stuff.

* Fixed a number of glitches flagged by pep8 and pylint.