### PR TITLE
Adds `brkt share-logs`, `brkt diag` 

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -22,7 +22,11 @@ from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
 import brkt_cli
 from brkt_cli import encryptor_service, util
-from brkt_cli.aws import aws_service, encrypt_ami, share_logs
+from brkt_cli.aws import (
+    aws_service,
+    encrypt_ami,
+    share_logs
+)
 from brkt_cli.instance_config_args import (
     instance_config_from_values,
     setup_instance_config_args
@@ -35,8 +39,8 @@ from brkt_cli.aws.encrypt_ami import (
     TAG_ENCRYPTOR_AMI,
     TAG_ENCRYPTOR_SESSION_ID)
 
-import brkt_cli.aws.share_logs_args
 import brkt_cli.aws.encrypt_ami_args
+import brkt_cli.aws.share_logs_args
 import brkt_cli.aws.update_encrypted_ami_args
 from brkt_cli.aws.update_ami import update_ami
 

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -24,6 +24,7 @@ import brkt_cli
 from brkt_cli import encryptor_service, util
 from brkt_cli.aws import (
     aws_service,
+    diag,
     encrypt_ami,
     share_logs
 )
@@ -39,6 +40,7 @@ from brkt_cli.aws.encrypt_ami import (
     TAG_ENCRYPTOR_AMI,
     TAG_ENCRYPTOR_SESSION_ID)
 
+import brkt_cli.aws.diag_args
 import brkt_cli.aws.encrypt_ami_args
 import brkt_cli.aws.share_logs_args
 import brkt_cli.aws.update_encrypted_ami_args
@@ -51,6 +53,30 @@ METAVISOR_AMI_REGION_NAMES = ['us-east-1', 'us-west-1', 'us-west-2']
 BRACKET_ENVIRONMENT = "prod"
 PV_ENCRYPTOR_AMIS_URL = "https://solo-brkt-%s-net.s3.amazonaws.com/amis.json"
 ENCRYPTOR_AMIS_URL = "https://solo-brkt-%s-net.s3.amazonaws.com/hvm_amis.json"
+
+
+class DiagSubcommand(Subcommand):
+    def name(self):
+        return 'diag'
+
+    def init_logging(self, verbose):
+        # Set boto logging to FATAL, since boto logs auth errors and 401s
+        # at ERROR level.
+        boto.log.setLevel(logging.FATAL)
+
+    def verbose(self, values):
+        return values.diag_verbose
+
+    def register(self, subparsers):
+        diag_parser = subparsers.add_parser(
+            'diag',
+            description='Create instance to diagnose an existing encrypted ' \
+            'instance.'
+        )
+        diag_args.setup_diag_args(diag_parser)
+
+    def run(self, values):
+        return _run_subcommand(self.name(), values)
 
 
 class ShareLogsSubcommand(Subcommand):
@@ -133,19 +159,23 @@ class UpdateAMISubcommand(Subcommand):
 
 
 def get_subcommands():
-    return [EncryptAMISubcommand(),
-            ShareLogsSubcommand(),
-            UpdateAMISubcommand()]
+    return [
+        DiagSubcommand(),
+        EncryptAMISubcommand(),
+        ShareLogsSubcommand(),
+        UpdateAMISubcommand()]
 
 
 def _run_subcommand(subcommand, values):
     try:
+        if subcommand == 'diag':
+            return command_diag(values, log)
         if subcommand == 'encrypt-ami':
             return command_encrypt_ami(values, log)
-        if subcommand == 'update-encrypted-ami':
-            return command_update_encrypted_ami(values, log)
         if subcommand == 'share-logs':
             return command_share_logs(values, log)
+        if subcommand == 'update-encrypted-ami':
+            return command_update_encrypted_ami(values, log)
     except NoAuthHandlerFound:
         msg = (
             'Unable to connect to AWS.  Are your AWS_ACCESS_KEY_ID and '
@@ -552,6 +582,63 @@ def command_update_encrypted_ami(values, log):
 
 def _validate_log_instance(aws_svc, instance_id):
     pass
+
+
+def _validate_log_snapshot(aws_svc, snapshot_id):
+    pass
+
+
+def command_diag(values, log):
+    nonce = util.make_nonce()
+
+    aws_svc = aws_service.AWSService(
+        nonce,
+        retry_timeout=values.retry_timeout,
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
+    )
+    log.debug(
+        'Retry timeout=%.02f, initial sleep seconds=%.02f',
+        aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
+
+    if values.snapshot_id and values.instance_id:
+        raise ValidationError("Only one of --instance-id or --snapshot-id "
+                              "may be specified")
+
+    if not values.snapshot_id and not values.instance_id:
+        raise ValidationError("--instance-id or --snapshot-id "
+                              "must be specified")
+
+    if values.validate:
+        # Validate the region before connecting.
+        region_names = [r.name for r in aws_svc.get_regions()]
+        if values.region not in region_names:
+            raise ValidationError(
+                'Invalid region %s.  Supported regions: %s.' %
+                (values.region, ', '.join(region_names)))
+
+    aws_svc.connect(values.region, key_name=values.key_name)
+    default_tags = {}
+    default_tags.update(brkt_cli.parse_tags(values.tags))
+    aws_svc.default_tags = default_tags
+
+    if values.validate:
+        if values.key_name:
+            aws_svc.get_key_pair(values.key_name)
+        if values.instance_id:
+            _validate_log_instance(
+                aws_svc, values.instance_id)
+        _validate_subnet_and_security_groups(
+            aws_svc, values.subnet_id, values.security_group_ids)
+    else:
+        log.info('Skipping validation.')
+
+    diag.diag(
+        aws_svc,
+        instance_id=values.instance_id,
+        snapshot_id=values.snapshot_id,
+        ssh_keypair=values.key_name
+    )
+    return 0
 
 
 def command_share_logs(values, log):

--- a/brkt_cli/aws/diag.py
+++ b/brkt_cli/aws/diag.py
@@ -1,0 +1,126 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from brkt_cli.aws.encrypt_ami import (
+    wait_for_instance,
+)
+
+from boto.ec2.blockdevicemapping import (
+    BlockDeviceMapping,
+    EBSBlockDeviceType,
+)
+
+from brkt_cli.aws.share_logs import snapshot_log_volume
+from brkt_cli.util import make_nonce
+
+# Security group names
+NAME_DIAG_SECURITY_GROUP = 'Bracket Diag %(nonce)s'
+DESCRIPTION_DIAG_SECURITY_GROUP = (
+    "Allows ssh access to diag instance.")
+
+# Diag instance names.
+NAME_DIAG_INSTANCE = 'Bracket Diag for snapshot %(snapshot_id)s'
+DESCRIPTION_DIAG_INSTANCE = \
+    'Diag instance with logs from %(snapshot_id)s'
+
+DIAG_IMAGES_BY_REGION = {
+    "us-east-1": "ami-0705e36c",
+    "us-west-1": "ami-053cd641",
+    "us-west-2": "ami-03665533",
+}
+
+
+log = logging.getLogger(__name__)
+
+
+def create_diag_security_group(aws_svc, vpc_id=None):
+    sg_name = NAME_DIAG_SECURITY_GROUP % {'nonce': make_nonce()}
+    sg_desc = DESCRIPTION_DIAG_SECURITY_GROUP
+    sg = aws_svc.create_security_group(sg_name, sg_desc, vpc_id=vpc_id)
+    log.info('Created temporary security group with id %s', sg.id)
+    try:
+        aws_svc.add_security_group_rule(
+            sg.id, ip_protocol='tcp',
+            from_port=22,
+            to_port=22,
+            cidr_ip='0.0.0.0/0')
+    except Exception as e:
+        log.error('Failed adding security group rule to %s: %s', sg.id, e)
+        try:
+            log.info('Cleaning up temporary security group %s', sg.id)
+            aws_svc.delete_security_group(sg.id)
+        except Exception as e2:
+            log.warn('Failed deleting temporary security group: %s', e2)
+        raise
+    if aws_svc.default_tags:
+        aws_svc.create_tags(sg.id)
+    return sg
+
+
+def diag(aws_svc=None, region='us-west-2',
+         instance_id=None, snapshot_id=None,
+         vpc_id=None, subnet_id=None, security_group_ids=None,
+         diag_instance_type='m3.medium', ssh_keypair=None):
+    if instance_id:
+        snapshot_id = snapshot_log_volume(aws_svc, instance_id).id
+        log.info("Waiting for 30 seconds for snapshot to be available")
+        time.sleep(30)
+
+    diag_image = DIAG_IMAGES_BY_REGION[region]
+
+    log.info("Launching diag instance")
+
+    if not security_group_ids:
+        vpc_id = None
+        if subnet_id:
+            subnet = aws_svc.get_subnet(subnet_id)
+            vpc_id = subnet.vpc_id
+        temp_sg_id = create_diag_security_group(aws_svc, vpc_id=vpc_id).id
+        security_group_ids = [temp_sg_id]
+
+    log_volume = EBSBlockDeviceType(
+        delete_on_termination=True,
+        snapshot_id=snapshot_id)
+    bdm = BlockDeviceMapping()
+
+    # Choose sdf since it is the first free mountpoint
+    bdm['/dev/sdf'] = log_volume
+
+    diag_instance = aws_svc.run_instance(
+        diag_image,
+        instance_type=diag_instance_type,
+        ebs_optimized=False,
+        subnet_id=subnet_id,
+        security_group_ids=security_group_ids,
+        block_device_map=bdm)
+
+    aws_svc.create_tags(
+        diag_instance.id,
+        name=NAME_DIAG_INSTANCE % {'snapshot_id': snapshot_id},
+        description=DESCRIPTION_DIAG_INSTANCE % {'snapshot_id': snapshot_id}
+    )
+
+    wait_for_instance(aws_svc, diag_instance.id)
+
+    diag_instance = aws_svc.get_instance(diag_instance.id)
+    print "Diag instance id: %s" % diag_instance.id
+    if diag_instance.ip_address:
+        print "IP address: %s" % diag_instance.ip_address
+    if diag_instance.private_ip_address:
+        print "Private IP address: %s" % diag_instance.private_ip_address
+    print "User: ec2-user"
+    print "SSH Keypair: %s" % ssh_keypair
+    print "Log volume mountpoint: /dev/xbd5 for PV, /dev/xbd5s1 for HVM"

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -1,0 +1,107 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+
+def setup_diag_args(parser):
+    parser.add_argument(
+        '--snapshot-id',
+        metavar='snapshot_id',
+        help='The snapshot with Bracket system logs'
+    )
+    parser.add_argument(
+        '--instance-id',
+        metavar='instance_id',
+        help='The instance with Bracket system logs'
+    )
+    parser.add_argument(
+        '--diag-instance-type',
+        metavar='TYPE',
+        dest='diag_instance_type',
+        help=(
+            'The instance type to use when running the diag instance'),
+        default='m3.medium'
+    )
+    parser.add_argument(
+        '--no-validate',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate instances and snapshots"
+    )
+    parser.add_argument(
+        '--region',
+        metavar='NAME',
+        help='AWS region (e.g. us-west-2)',
+        dest='region',
+        required=True
+    )
+    parser.add_argument(
+        '--security-group',
+        metavar='ID',
+        dest='security_group_ids',
+        action='append',
+        help=(
+            'Use this security group when running the encryptor instance. '
+            'May be specified multiple times.'
+        )
+    )
+    parser.add_argument(
+        '--subnet',
+        metavar='ID',
+        dest='subnet_id',
+        help='Launch instances in this subnet'
+    )
+    parser.add_argument(
+        '--tag',
+        metavar='KEY=VALUE',
+        dest='tags',
+        action='append',
+        help=(
+            'Custom tag for resources created during encryption. '
+            'May be specified multiple times.'
+        )
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='diag_verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
+    parser.add_argument(
+        '--key',
+        metavar='NAME',
+        help='ssh keypair name to be used to connect to diag instance.',
+        required=True,
+        dest='key_name'
+    )
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    parser.add_argument(
+        '--retry-timeout',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=10.0
+    )
+    parser.add_argument(
+        '--retry-initial-sleep-seconds',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=0.25
+    )

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -1,0 +1,80 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from brkt_cli.aws.encrypt_ami import (
+    clean_up,
+    wait_for_snapshots
+)
+
+log = logging.getLogger(__name__)
+
+# Snapshot names.
+NAME_LOG_SNAPSHOT = 'Bracket system log volume'
+DESCRIPTION_LOG_SNAPSHOT = \
+    'Log volume from %(instance_id)s'
+
+
+def _snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
+    """ Snapshot the log volume of the given instance.
+
+    :except SnapshotError if the snapshot goes into an error state
+    """
+
+    # Snapshot root volume.
+    instance = aws_svc.get_instance(instance_id)
+    bdm = instance.block_device_mapping
+
+    image = aws_svc.get_image(instance.image_id)
+    if image.virtualization_type == 'paravirtual':
+        log_vol = bdm["/dev/sda3"]
+    elif image.virtualization_type == 'hvm':
+        log_vol = bdm["/dev/sda1"]
+    else:
+        raise Exception('Unknown virtualization type %s' %
+                        image.virtualization_type)
+
+    vol = aws_svc.get_volume(log_vol.volume_id)
+
+    snapshot = aws_svc.create_snapshot(
+        vol.id,
+        name=NAME_LOG_SNAPSHOT,
+        description=DESCRIPTION_LOG_SNAPSHOT % {'instance_id': instance_id}
+    )
+    log.info(
+        'Creating snapshot %s of log volume for instance %s',
+        snapshot.id, instance_id
+    )
+
+    try:
+        wait_for_snapshots(aws_svc, snapshot.id)
+    except:
+        clean_up(aws_svc, snapshot_ids=[snapshot.id])
+        raise
+
+    log.info(
+        'Sharing snapshot %s with AWS account %s',
+        snapshot.id, bracket_aws_account
+    )
+    snapshot.share(user_ids=[bracket_aws_account])
+    ret_values = snapshot.id
+    log.debug('Returning %s', str(ret_values))
+    return ret_values
+
+
+def share(aws_svc=None, logshare_svc=None, instance_id='',
+          bracket_aws_account=''):
+    snapshot_id = _snapshot_log_volume(aws_svc, instance_id,
+                                       bracket_aws_account)
+    print snapshot_id

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -17,13 +17,15 @@ from brkt_cli.aws.encrypt_ami import (
     clean_up,
     wait_for_snapshots
 )
+from datetime import datetime
 
 log = logging.getLogger(__name__)
 
 # Snapshot names.
-NAME_LOG_SNAPSHOT = 'Bracket system log volume'
+NAME_LOG_SNAPSHOT = 'Bracket logs from %(instance_id)s'
 DESCRIPTION_LOG_SNAPSHOT = \
-    'Log volume from %(instance_id)s'
+    'Bracket logs from %(instance_id)s in AWS account %(aws_account)s '\
+    'taken at %(timestamp)s'
 
 
 def snapshot_log_volume(aws_svc, instance_id):
@@ -49,8 +51,12 @@ def snapshot_log_volume(aws_svc, instance_id):
 
     snapshot = aws_svc.create_snapshot(
         vol.id,
-        name=NAME_LOG_SNAPSHOT,
-        description=DESCRIPTION_LOG_SNAPSHOT % {'instance_id': instance_id}
+        name=NAME_LOG_SNAPSHOT % {'instance_id': instance_id},
+        description=DESCRIPTION_LOG_SNAPSHOT % {
+            'instance_id': instance_id,
+            'aws_account': image.owner_id,
+            'timestamp': datetime.utcnow().strftime('%b %d %Y %I:%M%p UTC')
+        }
     )
     log.info(
         'Creating snapshot %s of log volume for instance %s',

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -26,7 +26,7 @@ DESCRIPTION_LOG_SNAPSHOT = \
     'Log volume from %(instance_id)s'
 
 
-def _snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
+def snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
     """ Snapshot the log volume of the given instance.
 
     :except SnapshotError if the snapshot goes into an error state
@@ -62,18 +62,18 @@ def _snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
     except:
         clean_up(aws_svc, snapshot_ids=[snapshot.id])
         raise
+    return snapshot
 
+
+def _share_snapshot(snapshot, bracket_aws_account):
     log.info(
         'Sharing snapshot %s with AWS account %s',
         snapshot.id, bracket_aws_account
     )
     snapshot.share(user_ids=[bracket_aws_account])
-    ret_values = snapshot.id
-    log.debug('Returning %s', str(ret_values))
-    return ret_values
 
 
 def share(aws_svc=None, instance_id='', bracket_aws_account=''):
-    snapshot_id = _snapshot_log_volume(aws_svc, instance_id,
-                                       bracket_aws_account)
-    print snapshot_id
+    snapshot = snapshot_log_volume(aws_svc, instance_id, bracket_aws_account)
+    _share_snapshot(snapshot, bracket_aws_account)
+    print snapshot.id

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -73,8 +73,7 @@ def _snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
     return ret_values
 
 
-def share(aws_svc=None, logshare_svc=None, instance_id='',
-          bracket_aws_account=''):
+def share(aws_svc=None, instance_id='', bracket_aws_account=''):
     snapshot_id = _snapshot_log_volume(aws_svc, instance_id,
                                        bracket_aws_account)
     print snapshot_id

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -26,7 +26,7 @@ DESCRIPTION_LOG_SNAPSHOT = \
     'Log volume from %(instance_id)s'
 
 
-def snapshot_log_volume(aws_svc, instance_id, bracket_aws_account):
+def snapshot_log_volume(aws_svc, instance_id):
     """ Snapshot the log volume of the given instance.
 
     :except SnapshotError if the snapshot goes into an error state
@@ -74,6 +74,6 @@ def _share_snapshot(snapshot, bracket_aws_account):
 
 
 def share(aws_svc=None, instance_id='', bracket_aws_account=''):
-    snapshot = snapshot_log_volume(aws_svc, instance_id, bracket_aws_account)
+    snapshot = snapshot_log_volume(aws_svc, instance_id)
     _share_snapshot(snapshot, bracket_aws_account)
     print snapshot.id

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -1,0 +1,69 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+
+def setup_share_logs_args(parser):
+    parser.add_argument(
+        'instance_id',
+        metavar='instance-id',
+        help='The instance with Bracket system logs to be shared'
+    )
+    parser.add_argument(
+        '--no-validate',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate instance has AMI with Bracket tags"
+    )
+    parser.add_argument(
+        '--region',
+        metavar='NAME',
+        help='AWS region (e.g. us-west-2)',
+        dest='region',
+        required=True
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='share_logs_verbose',
+        action='store_true',
+        help='Print status information to the console'
+    )
+    # Hidden argument to specify AWS account to share account with - used
+    # for developer testing
+    parser.add_argument(
+        '--bracket-aws-account',
+        metavar='ID',
+        dest='bracket_aws_account',
+        default=164337164081,
+        help=argparse.SUPPRESS
+    )
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    parser.add_argument(
+        '--retry-timeout',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=10.0
+    )
+    parser.add_argument(
+        '--retry-initial-sleep-seconds',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=0.25
+    )


### PR DESCRIPTION
brkt share-logs subcommand allows users to share a snapshot of the Bracket
system log volume from an instance in the customer AWS account
with the Bracket AWS account. This is intended to be used by customers to
aid Bracket debugging in cases where logs are not reaching the Bracket
servers (e.g. cases with network connecitivity issues from an instance).

brkt diag subcommand will launch an instance with the log volume attached
and readable. It can grab the logs from an instance given instance
id or from a snapshot id. The diag instance is launched with
a specified ssh key with a security group that has port 22 open.

Sample developer use case: 
* Run `brkt diag --instance-id`
* SSH to debug instance and view logs

Sample customer user case: 
* Customer runs `brkt share-logs`
* Bracket support gets notified of new snapshot log (mechanism TBD)
* Bracket support runs `brkt diag --snapshot-id`