### PR TITLE
Clean up old SLEEP_ENABLED code

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -115,7 +115,6 @@ SUFFIX_ENCRYPTED_IMAGE = (
 DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE = \
     'Based on %(image_id)s, encrypted by Bracket Computing'
 
-SLEEP_ENABLED = True
 AMI_NAME_MAX_LENGTH = 128
 
 log = logging.getLogger(__name__)

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import unittest
 
+from brkt_cli import util
 from brkt_cli.aws import (
     encrypt_ami, test_aws_service, update_ami
 )
@@ -25,7 +26,7 @@ from brkt_cli.test_encryptor_service import (
 class TestRunUpdate(unittest.TestCase):
 
     def setUp(self):
-        encrypt_ami.SLEEP_ENABLED = False
+        util.SLEEP_ENABLED = False
 
     def test_subnet_and_security_groups(self):
         """ Test that the subnet and security group ids are passed through


### PR DESCRIPTION
We moved the SLEEP_ENABLED global from encrypt_ami to util a while back.
This commit removes the original variable and cleans up the remaining
callsite.