### PR TITLE
Sort command line options

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -21,6 +21,7 @@ import logging
 import re
 import sys
 from distutils.version import LooseVersion
+from operator import attrgetter
 
 import requests
 
@@ -280,6 +281,12 @@ def validate_jwt(jwt):
         )
 
     return jwt
+
+
+class SortingHelpFormatter(argparse.HelpFormatter):
+    def add_arguments(self, actions):
+        actions = sorted(actions, key=attrgetter('option_strings'))
+        super(SortingHelpFormatter, self).add_arguments(actions)
 
 
 def main():

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -70,8 +70,10 @@ class DiagSubcommand(Subcommand):
     def register(self, subparsers):
         diag_parser = subparsers.add_parser(
             'diag',
-            description='Create instance to diagnose an existing encrypted ' \
-            'instance.'
+            description=(
+                'Create instance to diagnose an existing encrypted instance.'
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         diag_args.setup_diag_args(diag_parser)
 
@@ -95,7 +97,8 @@ class ShareLogsSubcommand(Subcommand):
     def register(self, subparsers):
         share_logs_parser = subparsers.add_parser(
             'share-logs',
-            description='Share logs from an existing encrypted instance.'
+            description='Share logs from an existing encrypted instance.',
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         share_logs_args.setup_share_logs_args(share_logs_parser)
 
@@ -119,7 +122,8 @@ class EncryptAMISubcommand(Subcommand):
     def register(self, subparsers):
         encrypt_ami_parser = subparsers.add_parser(
             'encrypt-ami',
-            description='Create an encrypted AMI from an existing AMI.'
+            description='Create an encrypted AMI from an existing AMI.',
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
         setup_instance_config_args(encrypt_ami_parser)
@@ -147,7 +151,8 @@ class UpdateAMISubcommand(Subcommand):
             description=(
                 'Update an encrypted AMI with the latest Metavisor '
                 'release.'
-            )
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         update_encrypted_ami_args.setup_update_encrypted_ami(
             update_encrypted_ami_parser)

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -17,7 +17,7 @@ import argparse
 def setup_share_logs_args(parser):
     parser.add_argument(
         'instance_id',
-        metavar='instance-id',
+        metavar='INSTANCE-ID',
         help='The instance with Bracket system logs to be shared'
     )
     parser.add_argument(

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -176,7 +176,8 @@ def setup_make_jwt_args(subparsers):
             'instance. A timestamp can be either a Unix timestamp in '
             'seconds or ISO 8601 (2016-05-10T19:15:36Z).  Timezone offset '
             'defaults to UTC if not specified.'
-        )
+        ),
+        formatter_class=brkt_cli.SortingHelpFormatter
     )
     parser.add_argument(
         '--claim',

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -29,7 +29,10 @@ class EncryptGCEImageSubcommand(Subcommand):
         return 'encrypt-gce-image'
 
     def register(self, subparsers):
-        encrypt_gce_image_parser = subparsers.add_parser('encrypt-gce-image')
+        encrypt_gce_image_parser = subparsers.add_parser(
+            'encrypt-gce-image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
         encrypt_gce_image_args.setup_encrypt_gce_image_args(encrypt_gce_image_parser)
         setup_instance_config_args(encrypt_gce_image_parser,
                                    brkt_env_default=brkt_cli.BRKT_ENV_PROD)
@@ -44,7 +47,10 @@ class UpdateGCEImageSubcommand(Subcommand):
         return 'update-gce-image'
 
     def register(self, subparsers):
-        update_gce_image_parser = subparsers.add_parser('update-gce-image')
+        update_gce_image_parser = subparsers.add_parser(
+            'update-gce-image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
         update_encrypted_gce_image_args.setup_update_gce_image_args(update_gce_image_parser)
         setup_instance_config_args(update_gce_image_parser,
                                    brkt_env_default=brkt_cli.BRKT_ENV_PROD)
@@ -59,7 +65,10 @@ class LaunchGCEImageSubcommand(Subcommand):
         return 'launch-gce-image'
 
     def register(self, subparsers):
-        launch_gce_image_parser = subparsers.add_parser('launch-gce-image')
+        launch_gce_image_parser = subparsers.add_parser(
+            'launch-gce-image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
         launch_gce_image_args.setup_launch_gce_image_args(launch_gce_image_parser)
         setup_instance_config_args(launch_gce_image_parser,
                                    mode=INSTANCE_METAVISOR_MODE)

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -36,7 +36,8 @@ class GetPublicKeySubcommand(Subcommand):
             description=(
                 'Print the public part of a private key.  If the private key '
                 'is encrypted, prompt for a password and decrypt the key.'
-            )
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         parser.add_argument(
             'private_key_path',

--- a/brkt_cli/make_key_pair/__init__.py
+++ b/brkt_cli/make_key_pair/__init__.py
@@ -45,7 +45,8 @@ class MakeKeyPairSubcommand(Subcommand):
                 'Generate a 384-bit ECDSA public and private key pair '
                 '(NIST P-384) in OpenSSL PEM format.  The keys are written '
                 'to stdout by default.'
-            )
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
         parser.add_argument(
             '--no-passphrase',

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -36,7 +36,8 @@ class MakeUserDataSubcommand(Subcommand):
             description=(
                 'Generate MIME multipart user-data that is passed to '
                 'Metavisor and cloud-init when running an instance.'
-            )
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
         )
 
         setup_instance_config_args(parser)


### PR DESCRIPTION
Use a custom HelpFormatter to sort options for all commands in
alphabetical order.  Rename share-logs' positional argument to be in all
caps, to follow convention.