### PR TITLE
Default don't snapshot failed encryptor log volume

### DIFF
--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -17,13 +17,15 @@ import argparse
 
 def setup_diag_args(parser):
     parser.add_argument(
-        '--snapshot-id',
-        metavar='snapshot_id',
+        '--snapshot',
+        metavar='SNAPSHOT-ID',
+        dest='snapshot_id',
         help='The snapshot with Bracket system logs'
     )
     parser.add_argument(
-        '--instance-id',
-        metavar='instance_id',
+        '--instance',
+        metavar='INSTANCE-ID',
+        dest='instance_id',
         help='The instance with Bracket system logs'
     )
     parser.add_argument(

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -53,13 +53,6 @@ def setup_encrypt_ami_args(parser):
         help="Don't validate AMIs, subnet, and security groups"
     )
     parser.add_argument(
-        '--no-save-encryptor-logs',
-        dest='save_encryptor_logs',
-        action='store_false',
-        default=True,
-        help="Don't save a snapshot of logs from encryptor instance"
-    )
-    parser.add_argument(
         '--region',
         metavar='NAME',
         help='AWS region (e.g. us-west-2)',
@@ -142,4 +135,11 @@ def setup_encrypt_ami_args(parser):
         type=float,
         help=argparse.SUPPRESS,
         default=0.25
+    )
+    parser.add_argument(
+        '--save-encryptor-logs',
+        dest='save_encryptor_logs',
+        action='store_true',
+        help=argparse.SUPPRESS,
+        default=False
     )

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -16,13 +16,15 @@ import argparse
 
 def setup_share_logs_args(parser):
     parser.add_argument(
-        '--snapshot-id',
-        metavar='snapshot_id',
+        '--snapshot',
+        metavar='SNAPSHOT-ID',
+        dest='snapshot_id',
         help='The snapshot with Bracket system logs to be shared'
     )
     parser.add_argument(
-        '--instance-id',
+        '--instance',
         metavar='INSTANCE-ID',
+        dest='instance_id',
         help='The instance with Bracket system logs to be shared'
     )
     parser.add_argument(


### PR DESCRIPTION
Turns --no-save-encryptor-logs to --save-encryptor-logs which is
False by default and hidden.

Cleanup snapshot and instance id flags for the share-logs and
diag commands.