### PR TITLE
Shorten metavar for diag and share-logs

### DIFF
--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -18,13 +18,13 @@ import argparse
 def setup_diag_args(parser):
     parser.add_argument(
         '--snapshot',
-        metavar='SNAPSHOT-ID',
+        metavar='ID',
         dest='snapshot_id',
         help='The snapshot with Bracket system logs'
     )
     parser.add_argument(
         '--instance',
-        metavar='INSTANCE-ID',
+        metavar='ID',
         dest='instance_id',
         help='The instance with Bracket system logs'
     )

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -17,13 +17,13 @@ import argparse
 def setup_share_logs_args(parser):
     parser.add_argument(
         '--snapshot',
-        metavar='SNAPSHOT-ID',
+        metavar='ID',
         dest='snapshot_id',
         help='The snapshot with Bracket system logs to be shared'
     )
     parser.add_argument(
         '--instance',
-        metavar='INSTANCE-ID',
+        metavar='ID',
         dest='instance_id',
         help='The instance with Bracket system logs to be shared'
     )


### PR DESCRIPTION
Change the metavar name from SNAPSHOT-ID and INSTANCE-ID to ID, to
follow convention and make the usage output a little more concise.

-------------

```
$ ./brkt share-logs -h
usage: brkt share-logs [-h] [--snapshot ID] [--instance ID] [--no-
validate]
                       --region NAME [-v]

Share logs from an existing encrypted instance.

optional arguments:
--instance ID  The instance with Bracket system logs to be shared
--no-validate  Don't validate instance has AMI with Bracket tags
--region NAME  AWS region (e.g. us-west-2)
--snapshot ID  The snapshot with Bracket system logs to be shared
-h, --help     show this help message and exit
-v, --verbose  Print status information to the console
```