### PR TITLE
Adds arg for updater instance type

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -537,7 +537,7 @@ def command_update_encrypted_ami(values, log):
             aws_svc, encrypted_image.id, encryptor_ami)
         brkt_cli.validate_ntp_servers(values.ntp_servers)
         _validate(aws_svc, values, encryptor_ami)
-        guest_image = _validate_guest_encrypted_ami(
+        _validate_guest_encrypted_ami(
             aws_svc, encrypted_image.id, encryptor_ami)
     else:
         log.info('Skipping AMI validation.')
@@ -579,6 +579,7 @@ def command_update_encrypted_ami(values, log):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
+        updater_instance_type=values.updater_instance_type,
         instance_config=instance_config_from_values(values),
         status_port=values.status_port,
     )

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -78,7 +78,7 @@ class TestRunUpdate(unittest.TestCase):
             if args.image_id == encrypted_ami_id:
                 self.assertEqual('t2.micro', args.instance_type)
             elif args.image_id == encryptor_image.id:
-                self.assertEqual('c3.large', args.instance_type)
+                self.assertEqual('m3.medium', args.instance_type)
             else:
                 self.fail('Unexpected image: ' + args.image_id)
 

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -60,7 +60,9 @@ log = logging.getLogger(__name__)
 def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
                subnet_id=None, security_group_ids=None,
                enc_svc_class=encryptor_service.EncryptorService,
-               guest_instance_type='m3.medium', instance_config=None,
+               guest_instance_type='m3.medium',
+               updater_instance_type='m3.medium',
+               instance_config=None,
                status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     encrypted_guest = None
     updater = None
@@ -119,7 +121,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
 
         updater = run_instance(
             updater_ami,
-            instance_type="c3.large",
+            instance_type=updater_instance_type,
             user_data=compressed_user_data,
             ebs_optimized=False,
             subnet_id=subnet_id,

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -35,8 +35,17 @@ def setup_update_encrypted_ami(parser):
         metavar='TYPE',
         dest='guest_instance_type',
         help=(
-            'The instance type to use when running the unencrypted guest '
-            'instance'),
+            'The instance type to use when running the encrypted guest '
+            'instance. Default: m3.medium'),
+        default='m3.medium'
+    )
+    parser.add_argument(
+        '--updater-instance-type',
+        metavar='TYPE',
+        dest='updater_instance_type',
+        help=(
+            'The instance type to use when running the updater '
+            'instance. Default: m3.medium'),
         default='m3.medium'
     )
     parser.add_argument(


### PR DESCRIPTION
I ran into an issue when updating an AMI on behalf of a customer
where AWS did not have the the capacity to launch c3.large
instances for more than an hour. As a workaround I had to hack
the brkt cli to use an m3.medium instead. We should add an
instance type arg for anywhere we launch an instance so we
aren't beholden to AWS capacity issues.

Makes the default updater type to m3.medium. The previous was
c3.large to match the encryptor instance type. However, we
don't need a beefy instance type for updating since we don't
do any resource intensive operations during updating.