### PR TITLE
Move BracketEnvironment and TestEncryptAMIBackwardsCompatibility

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -31,7 +31,6 @@ from brkt_cli import (
 from brkt_cli.proxy import Proxy, generate_proxy_config, validate_proxy_config
 from brkt_cli.util import validate_dns_name_ip_address
 from brkt_cli.validation import ValidationError
-from brkt_cli.encryptor_service import BracketEnvironment
 
 VERSION = '1.0.3pre1'
 BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
@@ -48,6 +47,22 @@ SUBCOMMAND_MODULE_PATHS = [
 ]
 
 log = logging.getLogger(__name__)
+
+
+class BracketEnvironment(object):
+    def __init__(self):
+        self.api_host = None
+        self.api_port = None
+        self.hsmproxy_host = None
+        self.hsmproxy_port = None
+
+    def __repr__(self):
+        return '<BracketEnvironment api=%s:%d, hsmproxy=%s:%d>' % (
+            self.api_host,
+            self.api_port,
+            self.hsmproxy_host,
+            self.hsmproxy_port
+        )
 
 
 def validate_ntp_servers(ntp_servers):
@@ -281,6 +296,21 @@ def validate_jwt(jwt):
         )
 
     return jwt
+
+
+def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
+    """ Add BracketEnvironment values to the config dictionary
+    that will be passed to the metavisor via userdata.
+
+    :param brkt_env a BracketEnvironment object
+    :param brkt_config a dictionary that contains configuration data
+    """
+    if brkt_env:
+        api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
+        hsmproxy_host_port = '%s:%d' % (
+            brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
+        brkt_config['api_host'] = api_host_port
+        brkt_config['hsmproxy_host'] = hsmproxy_host_port
 
 
 class SortingHelpFormatter(argparse.HelpFormatter):

--- a/brkt_cli/aws/test_aws.py
+++ b/brkt_cli/aws/test_aws.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 import email
+import inspect
 import unittest
 
 from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
@@ -295,3 +296,52 @@ class TestVirtualizationType(unittest.TestCase):
         values.pv = True
         guest_image.virtualizaiton_type = 'hvm'
         self.assertTrue(brkt_cli.aws._use_pv_metavisor(values, guest_image))
+
+
+class TestEncryptAMIBackwardsCompatibility(unittest.TestCase):
+
+    def test_attributes(self):
+        required_attributes = (
+            'AMI_NAME_MAX_LENGTH',
+            'DESCRIPTION_SNAPSHOT',
+            'NAME_ENCRYPTOR',
+            'NAME_METAVISOR_ROOT_VOLUME',
+            'NAME_METAVISOR_GRUB_VOLUME',
+            'NAME_METAVISOR_LOG_VOLUME'
+        )
+        for attr in required_attributes:
+            self.assertTrue(
+                hasattr(encrypt_ami, attr),
+                'Did not find attribute encrypt_ami.%s' % attr
+            )
+
+    def test_method_signatures(self):
+        required_method_signatures = (
+            ('append_suffix',
+             ['name', 'suffix', 'max_length']),
+            ('clean_up',
+             ['aws_svc', 'instance_ids', 'security_group_ids']),
+            ('get_encrypted_suffix', []),
+            ('snapshot_encrypted_instance',
+             ['aws_svc', 'enc_svc_cls', 'encryptor_instance',
+              'encryptor_image', 'legacy']),
+            ('register_ami',
+             ['aws_svc', 'encryptor_instance', 'encryptor_image', 'name',
+              'description', 'mv_bdm', 'legacy', 'mv_root_id']),
+            ('wait_for_instance',
+             ['aws_svc', 'instance_id']),
+            ('create_encryptor_security_group', ['aws_svc'])
+        )
+        for mthd, args in required_method_signatures:
+            self.assertTrue(
+                hasattr(encrypt_ami, mthd),
+                'Did not find method encrypt_ami.%s' % mthd
+            )
+            method_ref = encrypt_ami.__dict__[mthd]
+            method_args = inspect.getargspec(method_ref)[0]
+            for arg in args:
+                self.assertIn(
+                    arg, method_args,
+                    'Did not find argument "%s" for method encrypt_ami.%s' % (
+                        arg, mthd)
+                )

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -18,13 +18,12 @@ import logging
 import time
 import urllib2
 
-
+from brkt_cli import validation
 from brkt_cli.util import (
         BracketError,
         Deadline,
         sleep
 )
-from brkt_cli import validation
 
 ENCRYPT_INITIALIZING = 'initial'
 ENCRYPT_DOWNLOADING = 'downloading'
@@ -39,22 +38,6 @@ FAILURE_CODE_AWS_PERMISSIONS = 'insufficient_aws_permissions'
 FAILURE_CODE_INVALID_NTP_SERVERS = 'invalid_ntp_servers'
 
 log = logging.getLogger(__name__)
-
-
-class BracketEnvironment(object):
-    def __init__(self):
-        self.api_host = None
-        self.api_port = None
-        self.hsmproxy_host = None
-        self.hsmproxy_port = None
-
-    def __repr__(self):
-        return '<BracketEnvironment api=%s:%d, hsmproxy=%s:%d>' % (
-            self.api_host,
-            self.api_port,
-            self.hsmproxy_host,
-            self.hsmproxy_port
-        )
 
 
 class EncryptionError(BracketError):

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -16,7 +16,8 @@ import logging
 
 from brkt_cli.gce import encrypt_gce_image
 from brkt_cli.gce.gce_service import gce_metadata_from_userdata
-from brkt_cli.util import add_brkt_env_to_brkt_config, Deadline
+from brkt_cli.util import Deadline
+from brkt_cli import add_brkt_env_to_brkt_config
 
 from brkt_cli.encryptor_service import wait_for_encryption
 from brkt_cli.encryptor_service import wait_for_encryptor_up

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -20,13 +20,12 @@ from cryptography.hazmat.backends import default_backend
 from brkt_cli import (
     get_proxy_config,
     parse_brkt_env,
-)
+    add_brkt_env_to_brkt_config)
 from brkt_cli.instance_config import (
     InstanceConfig,
     INSTANCE_CREATOR_MODE
 )
 from brkt_cli.util import (
-    add_brkt_env_to_brkt_config,
     get_domain_from_brkt_env
 )
 from brkt_cli.validation import ValidationError

--- a/brkt_cli/test_instance_config.py
+++ b/brkt_cli/test_instance_config.py
@@ -18,15 +18,9 @@ import os
 import sys
 import tempfile
 import unittest
-import yaml
 
 from brkt_cli import (
-    generate_proxy_config,
-    proxy,
-    parse_brkt_env,
-    _parse_proxies,
-    user_data
-)
+    proxy)
 from brkt_cli.instance_config import (
     BRKT_CONFIG_CONTENT_TYPE,
     BRKT_FILES_CONTENT_TYPE,
@@ -39,7 +33,6 @@ from brkt_cli.instance_config_args import (
     instance_config_from_values
 )
 from brkt_cli.proxy import Proxy
-from brkt_cli.util import add_brkt_env_to_brkt_config
 from brkt_cli.user_data import get_mime_part_payload
 from brkt_cli.validation import ValidationError
 

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -48,18 +48,6 @@ class TestUtil(unittest.TestCase):
             util.parse_name_value('abc')
 
 
-class TestBrktEnv(unittest.TestCase):
-
-    def test_add_brkt_env_to_user_data(self):
-        userdata = {}
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        expected_userdata = {'api_host': api_host_port, 'hsmproxy_host': hsmproxy_host_port}
-        brkt_env = parse_brkt_env(api_host_port + ',' + hsmproxy_host_port)
-        util.add_brkt_env_to_brkt_config(brkt_env, userdata)
-        self.assertEqual(userdata, expected_userdata)
-
-
 class TestBase64(unittest.TestCase):
     """ Test that our encoding code follows the spec used by JWT.  The
     encoded string must be URL-safe and not use padding. """

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -109,21 +109,6 @@ def retry(function, on=None, exception_checker=None, timeout=15.0,
     return _wrapped
 
 
-def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
-    """ Add BracketEnvironment values to the config dictionary
-    that will be passed to the metavisor via userdata.
-
-    :param brkt_env a BracketEnvironment object
-    :param brkt_config a dictionary that contains configuration data
-    """
-    if brkt_env:
-        api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
-        hsmproxy_host_port = '%s:%d' % (
-            brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
-        brkt_config['api_host'] = api_host_port
-        brkt_config['hsmproxy_host'] = hsmproxy_host_port
-
-
 def get_domain_from_brkt_env(brkt_env):
     """Return the domain string from the api_host in the brkt_env. """
 

--- a/test.py
+++ b/test.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-import inspect
 import json
 import tempfile
 import time
@@ -21,63 +20,10 @@ import unittest
 import yaml
 
 import brkt_cli
-import brkt_cli.aws
 import brkt_cli.util
 from brkt_cli import proxy
-from brkt_cli.aws import (
-    encrypt_ami
-)
 from brkt_cli.proxy import Proxy
 from brkt_cli.validation import ValidationError
-
-
-class TestEncryptAMIBackwardsCompatibility(unittest.TestCase):
-
-    def test_attributes(self):
-        required_attributes = (
-            'AMI_NAME_MAX_LENGTH',
-            'DESCRIPTION_SNAPSHOT',
-            'NAME_ENCRYPTOR',
-            'NAME_METAVISOR_ROOT_VOLUME',
-            'NAME_METAVISOR_GRUB_VOLUME',
-            'NAME_METAVISOR_LOG_VOLUME'
-        )
-        for attr in required_attributes:
-            self.assertTrue(
-                hasattr(encrypt_ami, attr),
-                'Did not find attribute encrypt_ami.%s' % attr
-            )
-
-    def test_method_signatures(self):
-        required_method_signatures = (
-            ('append_suffix',
-             ['name', 'suffix', 'max_length']),
-            ('clean_up',
-             ['aws_svc', 'instance_ids', 'security_group_ids']),
-            ('get_encrypted_suffix', []),
-            ('snapshot_encrypted_instance',
-             ['aws_svc', 'enc_svc_cls', 'encryptor_instance',
-              'encryptor_image', 'legacy']),
-            ('register_ami',
-             ['aws_svc', 'encryptor_instance', 'encryptor_image', 'name',
-              'description', 'mv_bdm', 'legacy', 'mv_root_id']),
-            ('wait_for_instance',
-             ['aws_svc', 'instance_id']),
-            ('create_encryptor_security_group', ['aws_svc'])
-        )
-        for mthd, args in required_method_signatures:
-            self.assertTrue(
-                hasattr(encrypt_ami, mthd),
-                'Did not find method encrypt_ami.%s' % mthd
-            )
-            method_ref = encrypt_ami.__dict__[mthd]
-            method_args = inspect.getargspec(method_ref)[0]
-            for arg in args:
-                self.assertIn(
-                    arg, method_args,
-                    'Did not find argument "%s" for method encrypt_ami.%s' % (
-                        arg, mthd)
-                )
 
 
 class TestVersionCheck(unittest.TestCase):
@@ -326,3 +272,19 @@ class TestJWT(unittest.TestCase):
                 base64_malformed_payload, base64_payload, base64_signature)
             with self.assertRaises(ValidationError):
                 brkt_cli.validate_jwt(jwt)
+
+
+class TestBrktEnv(unittest.TestCase):
+
+    def test_add_brkt_env_to_user_data(self):
+        userdata = {}
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        expected_userdata = {
+            'api_host': api_host_port,
+            'hsmproxy_host': hsmproxy_host_port
+        }
+        brkt_env = brkt_cli.parse_brkt_env(
+            api_host_port + ',' + hsmproxy_host_port)
+        brkt_cli.add_brkt_env_to_brkt_config(brkt_env, userdata)
+        self.assertEqual(userdata, expected_userdata)


### PR DESCRIPTION
Address some refactoring issues that came up as a result of work on
BracketEnvironment.  Commit these changes separately, so that they don't
muddy up the followup commmit.

Move the BracketEnvironment from the encryptor_service package into the
brkt_cli package.  It's a higher-level system configuration construct
and doesn't apply to the encryptor instance.

Move add_brkt_env_to_brkt_config() from util to brkt_cli, also because
it's a higher-level concept.  util should be for lower-level code.

Move TestEncryptAMIBackwardsCompatibility into the AWS codebase, since
it is AWS-specific.