### PR TITLE
Support specifying a domain for --brkt-env

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -23,6 +23,9 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
+BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
+
+
 class EncryptGCEImageSubcommand(Subcommand):
 
     def name(self):
@@ -35,7 +38,7 @@ class EncryptGCEImageSubcommand(Subcommand):
         )
         encrypt_gce_image_args.setup_encrypt_gce_image_args(encrypt_gce_image_parser)
         setup_instance_config_args(encrypt_gce_image_parser,
-                                   brkt_env_default=brkt_cli.BRKT_ENV_PROD)
+                                   brkt_env_default=BRKT_ENV_PROD)
 
     def run(self, values):
         return _run_subcommand(self.name(), values)
@@ -53,7 +56,7 @@ class UpdateGCEImageSubcommand(Subcommand):
         )
         update_encrypted_gce_image_args.setup_update_gce_image_args(update_gce_image_parser)
         setup_instance_config_args(update_gce_image_parser,
-                                   brkt_env_default=brkt_cli.BRKT_ENV_PROD)
+                                   brkt_env_default=BRKT_ENV_PROD)
 
     def run(self, values):
         return _run_subcommand(self.name(), values)

--- a/test.py
+++ b/test.py
@@ -168,11 +168,18 @@ class TestCommandLineOptions(unittest.TestCase):
         self.assertEqual(888, be.hsmproxy_port)
 
         with self.assertRaises(ValidationError):
-            brkt_cli.parse_brkt_env('a')
-        with self.assertRaises(ValidationError):
             brkt_cli.parse_brkt_env('a:7,b:8:9')
         with self.assertRaises(ValidationError):
             brkt_cli.parse_brkt_env('a:7,b?:8')
+
+    def test_brkt_env_from_domain(self):
+        be = brkt_cli.brkt_env_from_domain('example.com')
+        self.assertEqual('yetiapi.example.com', be.api_host)
+        self.assertEqual(443, be.api_port)
+        self.assertEqual('hsmproxy.example.com', be.hsmproxy_host)
+        self.assertEqual(443, be.hsmproxy_port)
+        self.assertEqual('api.example.com', be.public_api_host)
+        self.assertEqual(80, be.public_api_port)
 
     def test_get_proxy_config(self):
         """ Test reading proxy config from the --proxy and --proxy-config-file


### PR DESCRIPTION
    Support specifying the Yeti environment by its domain

    Add a new hidden --service-domain option that specifies the Yeti
    environment that the metavisor (and soon, the CLI) will talk to.
    When a domain is specified (e.g. stage.mgmt.brkt.com), we infer the
    following hosts and ports:

    * internal API (RPC): yetiapi.<domain>:443
    * HSM proxy: hsmproxy.<domain>:443
    * external API: api.<domain>:80

    Always send the Yeti environment to metavisor, so that behavior is
    clearly defined and does not differ between CSPs.