### PR TITLE
Don't require brkt-env when launching a GCE instance

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -157,7 +157,7 @@ def brkt_env_from_values(values):
     elif values.brkt_env:
         return parse_brkt_env(values.brkt_env)
     else:
-        return get_prod_brkt_env()
+        return None
 
 
 def _parse_proxies(*proxy_host_ports):

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -29,7 +29,7 @@ from brkt_cli.aws import (
     share_logs
 )
 from brkt_cli.instance_config_args import (
-    instance_config_from_values,
+    make_instance_config,
     setup_instance_config_args
 )
 from brkt_cli.subcommand import Subcommand
@@ -444,12 +444,16 @@ def command_encrypt_ami(values):
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
+    brkt_env = (
+        brkt_cli.brkt_env_from_values(values) or
+        brkt_cli.get_prod_brkt_env()
+    )
+
     if values.validate:
         # Validate the region before connecting.
         _validate_region(aws_svc, values.region)
 
         if values.token:
-            brkt_env = brkt_cli.brkt_env_from_values(values)
             brkt_cli.check_jwt_auth(brkt_env, values.token)
 
     aws_svc.connect(values.region, key_name=values.key_name)
@@ -482,7 +486,7 @@ def command_encrypt_ami(values):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
-        instance_config=instance_config_from_values(values),
+        instance_config=make_instance_config(values, brkt_env),
         status_port=values.status_port,
         save_encryptor_logs=values.save_encryptor_logs
     )
@@ -522,12 +526,16 @@ def command_update_encrypted_ami(values):
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
+    brkt_env = (
+        brkt_cli.brkt_env_from_values(values) or
+        brkt_cli.get_prod_brkt_env()
+    )
+
     if values.validate:
         # Validate the region before connecting.
         _validate_region(aws_svc, values.region)
 
         if values.token:
-            brkt_env = brkt_cli.brkt_env_from_values(values)
             brkt_cli.check_jwt_auth(brkt_env, values.token)
 
     aws_svc.connect(values.region, key_name=values.key_name)
@@ -590,7 +598,7 @@ def command_update_encrypted_ami(values):
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
         updater_instance_type=values.updater_instance_type,
-        instance_config=instance_config_from_values(values),
+        instance_config=make_instance_config(values, brkt_env),
         status_port=values.status_port,
     )
     print(updated_ami_id)

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -32,7 +32,7 @@ from brkt_cli.aws.test_aws_service import build_aws_service
 from brkt_cli.instance_config import BRKT_CONFIG_CONTENT_TYPE
 from brkt_cli.instance_config_args import (
     instance_config_args_to_values,
-    instance_config_from_values
+    make_instance_config
 )
 from brkt_cli.test_encryptor_service import (
     DummyEncryptorService,
@@ -409,7 +409,8 @@ class TestBrktEnv(unittest.TestCase):
 
         cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
         values = instance_config_args_to_values(cli_args)
-        ic = instance_config_from_values(values)
+        brkt_env = brkt_cli.brkt_env_from_values(values)
+        ic = make_instance_config(values, brkt_env)
         aws_svc.run_instance_callback = run_instance_callback
         encrypt_ami.encrypt(
             aws_svc=aws_svc,
@@ -435,7 +436,8 @@ class TestBrktEnv(unittest.TestCase):
         hsmproxy_host_port = 'hsmproxy.example.com:888'
         cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
         values = instance_config_args_to_values(cli_args)
-        ic = instance_config_from_values(values)
+        brkt_env = brkt_cli.brkt_env_from_values(values)
+        ic = make_instance_config(values, brkt_env)
 
         def run_instance_callback(args):
             if args.image_id == encryptor_image.id:

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -116,21 +116,16 @@ def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE,
     )
 
 
-def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE):
+def make_instance_config(values=None, brkt_env=None,
+                         mode=INSTANCE_CREATOR_MODE):
+    log.debug('Creating instance config with %s', brkt_env)
+
     brkt_config = {}
-    if values is None:
+    if not values:
         return InstanceConfig(brkt_config, mode)
 
-    # First handle the args that affect brkt_config
-    if values.service_domain:
-        brkt_env = brkt_cli.brkt_env_from_domain(values.service_domain)
-    elif values.brkt_env:
-        brkt_env = brkt_cli.parse_brkt_env(values.brkt_env)
-    else:
-        brkt_env = brkt_cli.get_prod_brkt_env()
-
-    add_brkt_env_to_brkt_config(brkt_env, brkt_config)
-    log.debug('Using %s', brkt_env)
+    if brkt_env:
+        add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 
     if values.token:
         brkt_config['identity_token'] = values.token

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -16,7 +16,7 @@ import logging
 import brkt_cli
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.instance_config_args import (
-    instance_config_from_values,
+    make_instance_config,
     setup_instance_config_args
 )
 log = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class MakeUserDataSubcommand(Subcommand):
         return values.make_user_data_verbose
 
     def run(self, values):
-        instance_cfg = instance_config_from_values(values)
+        instance_cfg = make_instance_config(values)
         print instance_cfg.make_userdata()
         return 0
 

--- a/test.py
+++ b/test.py
@@ -113,6 +113,8 @@ class DummyValues(object):
         self.proxies = []
         self.proxy_config_file = None
         self.status_port = None
+        self.brkt_env = None
+        self.service_domain = None
 
 
 class TestCommandLineOptions(unittest.TestCase):
@@ -295,3 +297,28 @@ class TestBrktEnv(unittest.TestCase):
             api_host_port + ',' + hsmproxy_host_port)
         brkt_cli.add_brkt_env_to_brkt_config(brkt_env, userdata)
         self.assertEqual(userdata, expected_userdata)
+
+    def test_brkt_env_from_values(self):
+        """ Test parsing BracketEnvironment from the --service-domain and
+        --brkt-env command line options.
+        """
+        # No values are set.
+        self.assertIsNone(brkt_cli.brkt_env_from_values(DummyValues()))
+
+        # Test --service-domain
+        values = DummyValues()
+        values.service_domain = 'example.com'
+        brkt_env = brkt_cli.brkt_env_from_values(values)
+        self.assertEqual(
+            str(brkt_cli.brkt_env_from_domain('example.com')),
+            str(brkt_env)
+        )
+
+        # Test --brkt-env
+        values = DummyValues()
+        values.brkt_env = 'yetiapi.example.com:443,hsmproxy.example.com:443'
+        brkt_env = brkt_cli.brkt_env_from_values(values)
+        self.assertEqual(
+            str(brkt_cli.parse_brkt_env(values.brkt_env)),
+            str(brkt_env)
+        )


### PR DESCRIPTION
Split BracketEnvironment parsing out from the rest of the values passed
when constructing InstanceConfig.  This allows callsites to determine
whether to specify BracketEnvironment or not.

Background: in commit bfe70c372f95730964a0f9c3366aa94a8806cf64 we
started always sending the Yeti environment to Metavisor.  This created
problems when launching a GCE image.  If the user didn't specify the
environment on the command line, we'd send the prod endpoints, which
would inadvertently override the Metavisor defaults.