### PR TITLE
Display GCE instance name and IP upon successful launch

### DIFF
--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -21,3 +21,5 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_ty
                          delete_boot=delete_boot,
                          instance_type=instance_type)
     gce_svc.wait_instance(instance_name, zone)
+    log.info("Instance %s (%s) launched successfully" % (instance_name,
+             gce_svc.get_instance_ip(instance_name, zone)))


### PR DESCRIPTION
Displays the GCE instance name and public IP which avoids the user from having to lookup the GCE UI (or use other means) to obtain the IP of the launched instance.