### PR TITLE
Add support for specifying options in a config file

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -66,7 +66,7 @@ class DiagSubcommand(Subcommand):
     def verbose(self, values):
         return values.diag_verbose
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         diag_parser = subparsers.add_parser(
             'diag',
             description=(
@@ -93,7 +93,7 @@ class ShareLogsSubcommand(Subcommand):
     def verbose(self, values):
         return values.share_logs_verbose
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         share_logs_parser = subparsers.add_parser(
             'share-logs',
             description='Share logs from an existing encrypted instance.',
@@ -118,7 +118,7 @@ class EncryptAMISubcommand(Subcommand):
     def verbose(self, values):
         return values.encrypt_ami_verbose
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         encrypt_ami_parser = subparsers.add_parser(
             'encrypt-ami',
             description='Create an encrypted AMI from an existing AMI.',
@@ -144,7 +144,7 @@ class UpdateAMISubcommand(Subcommand):
     def verbose(self, values):
         return values.update_encrypted_ami_verbose
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         update_encrypted_ami_parser = subparsers.add_parser(
             'update-encrypted-ami',
             description=(

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -40,7 +40,7 @@ class MakeTokenSubcommand(Subcommand):
     def name(self):
         return SUBCOMMAND_NAME
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         setup_make_jwt_args(subparsers)
 
     def verbose(self, values):

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -1,0 +1,299 @@
+# Copyright 2015 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import collections
+import errno
+import logging
+import os
+import os.path
+import sys
+import tempfile
+import yaml
+
+from brkt_cli.subcommand import Subcommand
+from brkt_cli.util import render_table_rows
+from brkt_cli.validation import ValidationError
+
+log = logging.getLogger(__name__)
+
+CONFIG_DIR = os.path.expanduser('~/.brkt')
+CONFIG_PATH = os.path.join(CONFIG_DIR, 'config')
+
+VERSION = 1
+
+
+class InvalidOptionError(Exception):
+    def __init__(self, option):
+        self.option = option
+
+
+class CLIConfig(object):
+    """CLIConfig exposes an interface that subcommands can use to retrive
+    persistent configuration options.
+    """
+
+    def __init__(self):
+        self._config = {
+            'version': VERSION,
+            'options': {}
+        }
+        self._registered_options = collections.defaultdict(dict)
+
+    def _check_option(self, option):
+        if option not in self._registered_options:
+            raise InvalidOptionError(option)
+
+    def register_option(self, option, desc):
+        self._registered_options[option] = desc
+
+    def registered_options(self):
+        return self._registered_options
+
+    def set_option(self, option, value):
+        """Set the value for the supplied option.
+
+        :param option a dot-delimited option string
+        :param value the option value
+        """
+        self._check_option(option)
+        levels = option.split('.')
+        attr = levels.pop()
+        cur = self._config['options']
+        for level in levels:
+            if level not in cur:
+                cur[level] = {}
+            cur = cur[level]
+        cur[attr] = value
+
+    def get_option(self, option, default=None):
+        """Fetch the value for the supplied option.
+
+        :param option a dot-delimited option string
+        :param default the value to be returned if option is not present
+
+        :return the option value
+        """
+        self._check_option(option)
+        levels = option.split('.')
+        attr = levels.pop()
+        cur = self._config['options']
+        for level in levels:
+            if level not in cur:
+                return default
+            cur = cur[level]
+        return cur.get(attr, default)
+
+    def _remove_empty_dicts(self, h):
+        to_remove = []
+        for k in h:
+            if isinstance(h[k], dict):
+                self._remove_empty_dicts(h[k])
+                if len(h[k]) == 0:
+                    to_remove.append(k)
+        for k in to_remove:
+            del h[k]
+
+    def unset_option(self, option):
+        """Unset the value for the supplied option.
+        :param option A dot-delimited option string
+        """
+        self._check_option(option)
+        levels = option.split('.')
+        attr = levels.pop()
+        cur = self._config['options']
+        for level in levels:
+            if level not in cur:
+                return
+            cur = cur[level]
+        if attr in cur:
+            del cur[attr]
+        # Clean up any empty sub-sections
+        self._remove_empty_dicts(self._config['options'])
+
+    def read(self):
+        """Read the config from disk"""
+        try:
+            with open(CONFIG_PATH) as f:
+                config = yaml.safe_load(f)
+            self._config = config
+        except IOError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    def write(self, f):
+        """Write the config to disk.
+        :param f A file-like object
+        """
+        yaml.dump(self._config, f)
+
+
+class ConfigSubcommand(Subcommand):
+    def __init__(self, stdout=sys.stdout):
+        self.stdout = stdout
+
+    def name(self):
+        return 'config'
+
+    def register(self, subparsers, parsed_config):
+        self.parsed_config = parsed_config
+        config_parser = subparsers.add_parser(
+            self.name(),
+            description=(
+                'Display or update brkt-cli options stored in'
+                ' ~/.brkt/config')
+        )
+
+        config_subparsers = config_parser.add_subparsers(
+            dest='config_subcommand'
+        )
+
+        # List all options
+        config_subparsers.add_parser(
+            'list',
+            help='display the values of all options set in the config file',
+            description='Display the values of all options set in the config file')
+
+        # All the options available for retrieval/mutation
+        rows = []
+        descs = self.parsed_config.registered_options()
+        opts = sorted(descs.keys())
+        for opt in opts:
+            rows.append([opt, descs[opt]])
+        opts_table = render_table_rows(rows, row_prefix='  ')
+        epilog = "\n".join([
+            'supported options:',
+            '',
+            opts_table
+        ])
+
+        # Set an option
+        set_parser = config_subparsers.add_parser(
+            'set',
+            help='set the value for an option',
+            description='Set the value for an option',
+            epilog=epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        set_parser.add_argument(
+            'option',
+            help='the option name (e.g. encrypt-gce-image.project)')
+        set_parser.add_argument(
+            'value',
+            help='the option value')
+
+        # Get the value for an option
+        get_parser = config_subparsers.add_parser(
+            'get',
+            help='get the value for an option',
+            description='Get the value for an option',
+            epilog=epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        get_parser.add_argument(
+            'option',
+            help='the option name (e.g. encrypt-gce-image.project)')
+
+        # Unset the value for an option
+        unset_parser = config_subparsers.add_parser(
+            'unset',
+            help='unset the value for an option',
+            description='Unset the value for an option',
+            epilog=epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        unset_parser.add_argument(
+            'option',
+            help='the option name (e.g. encrypt-gce-image.project)')
+
+    def _unlink_noraise(self, path):
+        try:
+            os.unlink(path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                pass
+            else:
+                log.exception("Failed unlinking %s", path)
+        except:
+            log.exception("Failed unlinking %s", path)
+
+    def _write_config(self):
+        """Create ~/.brkt if it doesn't exist and safely write out a
+        new config.
+        """
+        try:
+            os.mkdir(CONFIG_DIR, 0755)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+        f = tempfile.NamedTemporaryFile(delete=False, prefix='brkt_cli')
+        try:
+            self.parsed_config.write(f)
+            f.close()
+        except:
+            self._unlink_noraise(f.name)
+            raise
+        try:
+            os.rename(f.name, CONFIG_PATH)
+        except:
+            self._unlink_noraise(f.name)
+            raise
+
+    def _list_options(self):
+        """Display the contents of the config"""
+        for opt in sorted(self.parsed_config.registered_options().keys()):
+            val = self.parsed_config.get_option(opt)
+            if val is not None:
+                line = "%s=%s\n" % (opt, val)
+                self.stdout.write(line)
+        return 0
+
+    def _get_option(self, opt):
+        try:
+            val = self.parsed_config.get_option(opt)
+        except InvalidOptionError:
+            raise ValidationError('Error: unknown option "%s".' % (opt,))
+        if val:
+            self.stdout.write("%s\n" % (val,))
+        return 0
+
+    def _set_option(self, opt, val):
+        """Set the specified option"""
+        try:
+            self.parsed_config.set_option(opt, val)
+        except InvalidOptionError:
+            raise ValidationError('Error: unknown option "%s".' % (opt,))
+        self._write_config()
+        return 0
+
+    def _unset_option(self, opt):
+        """Unset the specified option"""
+        try:
+            self.parsed_config.unset_option(opt)
+        except InvalidOptionError:
+            raise ValidationError('Error: unknown option "%s".' % (opt,))
+        self._write_config()
+        return 0
+
+    def run(self, values):
+        subcommand = values.config_subcommand
+        if subcommand == 'list':
+            self._list_options()
+        elif subcommand == 'set':
+            self._set_option(values.option, values.value)
+        elif subcommand == 'get':
+            self._get_option(values.option)
+        elif subcommand == 'unset':
+            self._unset_option(values.option)
+        return 0
+
+
+def get_subcommands():
+    return [ConfigSubcommand()]

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -1,0 +1,105 @@
+import argparse
+import StringIO
+import unittest
+
+from brkt_cli.config import CLIConfig, ConfigSubcommand
+from brkt_cli.validation import ValidationError
+
+
+class GetValues(object):
+    def __init__(self, option):
+        self.config_subcommand = 'get'
+        self.option = option
+
+
+class SetValues(object):
+    def __init__(self, option, value):
+        self.config_subcommand = 'set'
+        self.option = option
+        self.value = value
+
+
+class UnsetValues(object):
+    def __init__(self, option):
+        self.config_subcommand = 'unset'
+        self.option = option
+
+
+class ListValues(object):
+    def __init__(self):
+        self.config_subcommand = 'list'
+
+
+def noop():
+    pass
+
+
+class ConfigCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO.StringIO()
+        self.cfg = CLIConfig()
+        self.cfg.register_option('test-section.test-option', 'A test')
+        self.cmd = ConfigSubcommand(stdout=self.out)
+        parser = argparse.ArgumentParser()
+        self.cmd.register(parser.add_subparsers(), self.cfg)
+        self.cmd._write_config = noop
+
+    def test_get_unknown_option(self):
+        """Verify that we raise an error if the user attempts to fetch an
+        unknown option.
+        """
+        options = ['no-section', 'test-section.no-option']
+        for option in options:
+            with self.assertRaises(ValidationError):
+                self.cmd.run(GetValues(option))
+
+    def test_set_unknown_option(self):
+        """Verify that we raise an error if the user attempts to set an
+        unknown option.
+        """
+        args = (('no-section.no-option', 'foo'),
+                ('test-section.no-option', 'foo'))
+        for opt, val in args:
+            with self.assertRaises(ValidationError):
+                self.cmd.run(SetValues(opt, val))
+
+    def test_unset_unknown_option(self):
+        """Verify that we raise an error if the user attempts to unset an
+        unknown option.
+        """
+        options = ['no-section', 'test-section.no-option']
+        for option in options:
+            with self.assertRaises(ValidationError):
+                self.cmd.run(UnsetValues(option))
+
+    def test_set_list_get_unset(self):
+        """Verify that we can successfully set, get, and unset an existing
+        option.
+        """
+        val = 'test-val'
+        opt = 'test-section.test-option'
+        self.cmd.run(SetValues(opt, val))
+        self.assertEqual(self.cfg.get_option(opt), val)
+
+        self.cmd.run(GetValues(opt))
+        self.assertEqual(self.out.getvalue(), "%s\n" % (val,))
+
+        self.cmd.run(ListValues())
+        self.assertEqual(self.out.getvalue(), "%s\n%s=%s\n" % (val, opt, val))
+
+        self.cmd.run(UnsetValues(opt))
+        self.assertEqual(self.cfg.get_option(opt), None)
+
+    def test_cleanup_empty_subsections(self):
+        """Verify that we clean up empty subsections of the config"""
+        opt1 = 'a.b.c'
+        opt2 = 'a.d.e'
+        for opt in [opt1, opt2]:
+            self.cfg.register_option(opt, 'test')
+            self.cmd.run(SetValues(opt, 'val'))
+
+        self.cmd.run(UnsetValues(opt1))
+        self.assertEquals(self.cfg._config['options'], {'a': {'d': {'e': 'val'}}})
+
+        self.cmd.run(UnsetValues(opt2))
+        self.assertEquals(self.cfg._config['options'], {})

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -1,3 +1,4 @@
+import argparse
 import brkt_cli
 import logging
 
@@ -31,14 +32,26 @@ class EncryptGCEImageSubcommand(Subcommand):
     def name(self):
         return 'encrypt-gce-image'
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         encrypt_gce_image_parser = subparsers.add_parser(
             'encrypt-gce-image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
-        encrypt_gce_image_args.setup_encrypt_gce_image_args(encrypt_gce_image_parser)
+        encrypt_gce_image_args.setup_encrypt_gce_image_args(
+            encrypt_gce_image_parser, parsed_config)
         setup_instance_config_args(encrypt_gce_image_parser,
                                    brkt_env_default=BRKT_ENV_PROD)
+
+    def setup_config(self, config):
+        config.register_option(
+            '%s.project' % (self.name(),),
+            'The GCE project metavisors will be launched into')
+        config.register_option(
+            '%s.network' % (self.name(),),
+            'The GCE network metavisors will be launched into')
+        config.register_option(
+            '%s.zone' % (self.name(),),
+            'The GCE zone metavisors will be launched into')
 
     def run(self, values):
         return _run_subcommand(self.name(), values)
@@ -49,7 +62,7 @@ class UpdateGCEImageSubcommand(Subcommand):
     def name(self):
         return 'update-gce-image'
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         update_gce_image_parser = subparsers.add_parser(
             'update-gce-image',
             formatter_class=brkt_cli.SortingHelpFormatter
@@ -67,7 +80,7 @@ class LaunchGCEImageSubcommand(Subcommand):
     def name(self):
         return 'launch-gce-image'
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         launch_gce_image_parser = subparsers.add_parser(
             'launch-gce-image',
             formatter_class=brkt_cli.SortingHelpFormatter

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -1,7 +1,7 @@
 import argparse
 
 
-def setup_encrypt_gce_image_args(parser):
+def setup_encrypt_gce_image_args(parser, parsed_config):
     parser.add_argument(
         'image',
         metavar='ID',
@@ -18,7 +18,7 @@ def setup_encrypt_gce_image_args(parser):
         '--zone',
         help='GCE zone to operate in',
         dest='zone',
-        default='us-central1-a',
+        default=parsed_config.get_option('encrypt-gce-image.zone', 'us-central1-a'),
         required=True
     )
     parser.add_argument(
@@ -32,6 +32,7 @@ def setup_encrypt_gce_image_args(parser):
         '--project',
         help='GCE project name',
         dest='project',
+        default=parsed_config.get_option('encrypt-gce-image.project'),
         required=True
     )
     parser.add_argument(
@@ -49,7 +50,7 @@ def setup_encrypt_gce_image_args(parser):
     parser.add_argument(
         '--network',
         dest='network',
-        default='default',
+        default=parsed_config.get_option('encrypt-gce-image.network', 'default'),
         required=False
     )
     # Optional Image Name that's used to launch the encryptor instance. This

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -33,7 +33,7 @@ class GetPublicKeySubcommand(Subcommand):
     def exposed(self):
         return False
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         parser = subparsers.add_parser(
             self.name(),
             description=(

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -38,7 +38,7 @@ class MakeKeySubcommand(Subcommand):
     def name(self):
         return 'make-key'
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         parser = subparsers.add_parser(
             self.name(),
             description=(

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -27,7 +27,7 @@ class MakeUserDataSubcommand(Subcommand):
     def name(self):
         return 'make-user-data'
 
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         parser = subparsers.add_parser(
             self.name(),
             description=(

--- a/brkt_cli/subcommand.py
+++ b/brkt_cli/subcommand.py
@@ -47,12 +47,24 @@ class Subcommand(object):
         """
         return False
 
+    def setup_config(self, config):
+        """ Subcommands may add options to the supplied ConfigParser.
+        Option values will be pulled from ~/.brkt/config.
+
+        @param config an instance of brkt_cli.cli_config.CliConfigParser
+        """
+        pass
+
     @abc.abstractmethod
-    def register(self, subparsers):
+    def register(self, subparsers, parsed_config):
         """ Add a subcommand to the top-level command parser.
 
         :param subparsers: the ArgumentParser object returned by
             add_subparsers()
+        :param parsed_config: an instance of
+            brkt_cli.cli_config.CliConfigParser containing values that
+            have been parsed from disk. Use it to initialize any default
+            values for arguments.
         """
         pass
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -217,3 +217,40 @@ def read_private_key(pem_path):
     if crypto.curve != brkt_cli.crypto.SECP384R1:
         raise ValidationError(key_format_err)
     return crypto
+
+
+def render_table_rows(rows, row_prefix=''):
+    """ Render the supplied rows as a table. This computes the maximum width
+    of each column and renders each row such that all columns are left
+    justified. Each value must be formattable as a string.
+
+    An example:
+
+    >>> from brkt_cli.util import render_table_rows
+    >>> rows = [["foo", "bar", "baz"], ["foofoo", "barbarbar", "baz"]]
+    >>> print render_table_rows(rows)
+    foo    bar       baz
+    foofoo barbarbar baz
+    >>>
+
+    :param rows a list of lists that represent the rows that are to be
+    rendered.
+    :param row_prefix an optional string that will be prepended to each
+    row after it has been rendered.
+    :return the rows rendered as a string.
+    """
+    if len(rows) == 0:
+        return ''
+    widths = [0 for _ in rows[0]]
+    for row in rows:
+        for ii, col in enumerate(row):
+            widths[ii] = max(widths[ii], len(col))
+    fmts = []
+    for width in widths:
+        fmts.append('{:' + str(width) + '}')
+    fmt = " ".join(fmts)
+    lines = []
+    for row in rows:
+        lines.append(row_prefix + fmt.format(*row))
+    table = "\n".join(lines)
+    return table

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'brkt_cli',
         'brkt_cli.aws',
         'brkt_cli.brkt_jwt',
+        'brkt_cli.config',
         'brkt_cli.crypto',
         'brkt_cli.gce',
         'brkt_cli.get_public_key',


### PR DESCRIPTION
This commit adds infrastructure to allow subcommands to read default
values from a config file stored in ~/.brkt/config. In order to use
the new infrastructure, subcommands must implement the setup_config()
method. In it, they should register any options they want to pull
from the config.

A new sub-command, "config", has been added to the cli. This lets
users list, set, get, and unset options in the config. It is
modeled after "kubectl config".

Finally, the first consumer of the config infrastructure is the
"encrypt-gce-image" sub-command. The "project", "network", and
"zone" options may be specified via the config.