### PR TITLE
Remove support for BRACKET_ENVIRONMENT

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -49,9 +49,8 @@ from brkt_cli.aws.update_ami import update_ami
 log = logging.getLogger(__name__)
 
 
-BRACKET_ENVIRONMENT = "prod"
-PV_ENCRYPTOR_AMIS_URL = "https://solo-brkt-%s-net.s3.amazonaws.com/amis.json"
-ENCRYPTOR_AMIS_URL = "https://solo-brkt-%s-net.s3.amazonaws.com/hvm_amis.json"
+PV_ENCRYPTOR_AMIS_URL = "https://solo-brkt-prod-net.s3.amazonaws.com/amis.json"
+ENCRYPTOR_AMIS_URL = "https://solo-brkt-prod-net.s3.amazonaws.com/hvm_amis.json"
 
 
 class DiagSubcommand(Subcommand):
@@ -409,14 +408,11 @@ def _get_encryptor_ami(region_name, pv=False):
     :raise ValidationError if the region is not supported
     :raise BracketError if the list of AMIs cannot be read
     """
-    bracket_env = os.getenv('BRACKET_ENVIRONMENT',
-                            BRACKET_ENVIRONMENT)
-    if not bracket_env:
-        raise BracketError('No bracket environment found')
     if pv:
-        bucket_url = PV_ENCRYPTOR_AMIS_URL % bracket_env
+        bucket_url = PV_ENCRYPTOR_AMIS_URL
     else:
-        bucket_url = ENCRYPTOR_AMIS_URL % bracket_env
+        bucket_url = ENCRYPTOR_AMIS_URL
+
     log.debug('Getting encryptor AMI list from %s', bucket_url)
     r = urllib2.urlopen(bucket_url)
     if r.getcode() not in (200, 201):


### PR DESCRIPTION
Remove support for the BRACKET_ENVIRONMENT environment variable.  This
variable was a switch that would tell brkt-cli whether to use the
staging or production build of Metavisor.  This is no longer being used.
Developers who want to use a specific Metavisor AMI can use the hidden
--encryptor-ami option.