### PR TITLE
Don't read --brkt-env inside make_instance_config()

### DIFF
--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -145,10 +145,12 @@ def make_instance_config(values=None, brkt_env=None,
             raise ValidationError(
                 'Can only specify ca-cert for instance in Creator mode'
             )
-        if not values.brkt_env:
+        if not brkt_env:
             raise ValidationError(
-                'Must specify brkt-env when specifying ca-cert.'
+                'Must specify --brkt-env or --service-domain when '
+                'specifying --ca-cert.'
             )
+
         try:
             with open(values.ca_cert, 'r') as f:
                 ca_cert_data = f.read()


### PR DESCRIPTION
The BracketEnvironment object is now passed in by the caller.  Don't
attempt to read it from values when building the InstanceConfig object.