### PR TITLE
Add network_host to brkt env passed in

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -50,11 +50,14 @@ log = logging.getLogger(__name__)
 class BracketEnvironment(object):
     def __init__(self, api_host=None, api_port=443,
                  hsmproxy_host=None, hsmproxy_port=443,
+                 network_host=None, network_port=443,
                  public_api_host=None, public_api_port=443):
         self.api_host = api_host
         self.api_port = api_port
         self.hsmproxy_host = hsmproxy_host
         self.hsmproxy_port = hsmproxy_port
+        self.network_host = network_host
+        self.network_port = network_port
         self.public_api_host = public_api_host
         self.public_api_port = public_api_port
 
@@ -62,6 +65,7 @@ class BracketEnvironment(object):
         return (
             '<BracketEnvironment api={be.api_host}:{be.api_port} '
             'hsmproxy={be.hsmproxy_host}:{be.hsmproxy_port} '
+            'network={be.network_host}:{be.network_port} '
             'public_api={be.public_api_host}:{be.public_api_port}>'
         ).format(be=self)
 
@@ -97,17 +101,18 @@ def parse_tags(tag_strings):
 def parse_brkt_env(brkt_env_string):
     """ Parse the --brkt-env value.  The value is in the following format:
 
-    api_host:port,hsmproxy_host:port
+    api_host:port,hsmproxy_host:port,network_host:port
 
     :return: a BracketEnvironment object
     :raise: ValidationError if brkt_env is malformed
     """
     error_msg = (
         '--brkt-env value must be in the following format: '
-        '<api-host>:<api-port>,<hsm-proxy-host>:<hsm-proxy-port>'
+        '<api-host>:<api-port>,<hsm-proxy-host>:<hsm-proxy-port>,'
+        '<network-host>:<network-port>'
     )
     endpoints = brkt_env_string.split(',')
-    if len(endpoints) != 2:
+    if len(endpoints) != 3:
         raise ValidationError(error_msg)
 
     def _parse_endpoint(endpoint):
@@ -129,6 +134,7 @@ def parse_brkt_env(brkt_env_string):
     # soon and we can get rid of it
     be.public_api_host = be.api_host.replace('yetiapi', 'api')
     (be.hsmproxy_host, be.hsmproxy_port) = _parse_endpoint(endpoints[1])
+    (be.network_host, be.network_port) = _parse_endpoint(endpoints[2])
     return be
 
 
@@ -139,6 +145,7 @@ def brkt_env_from_domain(domain):
     return BracketEnvironment(
         api_host='yetiapi.' + domain,
         hsmproxy_host='hsmproxy.' + domain,
+        network_host='network.' + domain,
         public_api_host='api.' + domain
     )
 
@@ -386,8 +393,11 @@ def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
         api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
         hsmproxy_host_port = '%s:%d' % (
             brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
+        network_host_port = '%s:%d' % (
+            brkt_env.network_host, brkt_env.network_port)
         brkt_config['api_host'] = api_host_port
         brkt_config['hsmproxy_host'] = hsmproxy_host_port
+        brkt_config['network_host'] = network_host_port
 
 
 class SortingHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -413,6 +413,7 @@ class TestBrktEnv(unittest.TestCase):
 
         api_host_port = 'api.example.com:777'
         hsmproxy_host_port = 'hsmproxy.example.com:888'
+        network_host_port = 'network.example.com:999'
         aws_svc, encryptor_image, guest_image = build_aws_service()
 
         def run_instance_callback(args):
@@ -427,8 +428,13 @@ class TestBrktEnv(unittest.TestCase):
                     hsmproxy_host_port,
                     d['brkt']['hsmproxy_host']
                 )
+                self.assertEquals(
+                    network_host_port,
+                    d['brkt']['network_host']
+                )
 
-        cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
+        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
+                                         network_host_port)
         values = instance_config_args_to_values(cli_args)
         brkt_env = brkt_cli.brkt_env_from_values(values)
         ic = make_instance_config(values, brkt_env)
@@ -455,7 +461,9 @@ class TestBrktEnv(unittest.TestCase):
 
         api_host_port = 'api.example.com:777'
         hsmproxy_host_port = 'hsmproxy.example.com:888'
-        cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
+        network_host_port = 'network.example.com:999'
+        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
+                                         network_host_port)
         values = instance_config_args_to_values(cli_args)
         brkt_env = brkt_cli.brkt_env_from_values(values)
         ic = make_instance_config(values, brkt_env)
@@ -471,6 +479,10 @@ class TestBrktEnv(unittest.TestCase):
                 self.assertEquals(
                     hsmproxy_host_port,
                     d['brkt']['hsmproxy_host']
+                )
+                self.assertEquals(
+                    network_host_port,
+                    d['brkt']['network_host']
                 )
                 self.assertEquals(
                     'updater',

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -80,10 +80,10 @@ def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE,
         # brkt_env_group = parser.add_mutually_exclusive_group()
 
         # Optional yeti endpoints. Hidden because it's only used for
-        # development. The value contains the hosts and ports of the RPC and
-        # HSM proxy, separated by commas:
+        # development. The value contains the hosts and ports of the RPC,
+        # HSM proxy, Network RPC separated by commas:
         #
-        # <rpc-host>:<rpc-port>,<hsmproxy-host>:<hsmproxy-port>
+        # <rpc-host>:<rpc-port>,<hsmproxy-host>:<hsmproxy-port>,<network-host>:<network-port>
         parser.add_argument(
             '--brkt-env',
             dest='brkt_env',

--- a/brkt_cli/test_instance_config.py
+++ b/brkt_cli/test_instance_config.py
@@ -46,6 +46,7 @@ test_jwt = (
 # Some test constants
 api_host_port = 'api.example.com:777'
 hsmproxy_host_port = 'hsmproxy.example.com:888'
+network_host_port = 'network.example.com:999'
 ntp_server1 = '10.4.5.6'
 ntp_server2 = '199.55.32.1'
 proxy_host = '10.22.33.44'
@@ -74,12 +75,14 @@ class TestInstanceConfig(unittest.TestCase):
     def test_brkt_env(self):
         brkt_config_in = {
             'api_host': api_host_port,
-            'hsmproxy_host': hsmproxy_host_port
+            'hsmproxy_host': hsmproxy_host_port,
+            'network_host': network_host_port
         }
         ic = InstanceConfig(brkt_config_in)
         config_json = ic.make_brkt_config_json()
-        expected_json = '{"brkt": {"api_host": "%s", "hsmproxy_host": "%s"}}' % \
-                        (api_host_port, hsmproxy_host_port)
+        expected_json = ('{"brkt": {"api_host": "%s", ' +
+            '"hsmproxy_host": "%s", "network_host": "%s"}}') % \
+            (api_host_port, hsmproxy_host_port, network_host_port)
         self.assertEqual(config_json, expected_json)
 
     def test_ntp_servers(self):
@@ -117,6 +120,7 @@ class TestInstanceConfig(unittest.TestCase):
         brkt_config_in = {
             'api_host': api_host_port,
             'hsmproxy_host': hsmproxy_host_port,
+            'network_host': network_host_port,
             'ntp_servers': [ntp_server1],
             'identity_token': test_jwt
         }
@@ -130,6 +134,7 @@ class TestInstanceConfig(unittest.TestCase):
         self.assertEqual(brkt_config['ntp_servers'], [ntp_server1])
         self.assertEqual(brkt_config['api_host'], api_host_port)
         self.assertEqual(brkt_config['hsmproxy_host'], hsmproxy_host_port)
+        self.assertEqual(brkt_config['network_host'], network_host_port)
 
         brkt_files = get_mime_part_payload(ud, BRKT_FILES_CONTENT_TYPE)
         self.assertEqual(brkt_files,
@@ -159,10 +164,12 @@ def _get_brkt_config_for_cli_args(cli_args='', mode=INSTANCE_CREATOR_MODE):
 class TestInstanceConfigFromCliArgs(unittest.TestCase):
 
     def test_brkt_env(self):
-        cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
+        cli_args = '--brkt-env %s,%s,%s' % (
+            api_host_port, hsmproxy_host_port, network_host_port)
         brkt_config = _get_brkt_config_for_cli_args(cli_args)
         self.assertEqual(brkt_config['api_host'], api_host_port)
         self.assertEqual(brkt_config['hsmproxy_host'], hsmproxy_host_port)
+        self.assertEqual(brkt_config['network_host'], network_host_port)
 
     def test_service_domain(self):
         brkt_config = _get_brkt_config_for_cli_args(
@@ -171,6 +178,8 @@ class TestInstanceConfigFromCliArgs(unittest.TestCase):
         self.assertEqual(brkt_config['api_host'], 'yetiapi.example.com:443')
         self.assertEqual(
             brkt_config['hsmproxy_host'], 'hsmproxy.example.com:443')
+        self.assertEqual(
+            brkt_config['network_host'], 'network.example.com:443')
 
     def test_default_env_prod(self):
         """ Test that Yeti endpoints aren't set when they're not specified
@@ -179,6 +188,7 @@ class TestInstanceConfigFromCliArgs(unittest.TestCase):
         brkt_config = _get_brkt_config_for_cli_args()
         self.assertIsNone(brkt_config.get('api_host'))
         self.assertIsNone(brkt_config.get('hsmproxy_host'))
+        self.assertIsNone(brkt_config.get('network_host'))
 
     def test_ntp_servers(self):
         cli_args = '--ntp-server %s' % ntp_server1
@@ -212,7 +222,8 @@ class TestInstanceConfigFromCliArgs(unittest.TestCase):
             ic = make_instance_config(values)
 
         # Now specify endpoint args but use a bogus cert
-        endpoint_args = '--brkt-env api.%s:7777,hsmproxy.%s:8888' % (domain, domain)
+        endpoint_args = ('--brkt-env api.%s:7777,hsmproxy.%s:8888,' +
+            'network.%s:9999') % (domain, domain, domain)
         dummy_ca_cert = 'THIS IS NOT A CERTIFICATE'
         with tempfile.NamedTemporaryFile() as f:
             f.write(dummy_ca_cert)

--- a/test.py
+++ b/test.py
@@ -163,16 +163,20 @@ class TestCommandLineOptions(unittest.TestCase):
         """ Test parsing of the command-line --brkt-env value.
         """
         be = brkt_cli.parse_brkt_env(
-            'api.example.com:777,hsmproxy.example.com:888')
+            'api.example.com:777,hsmproxy.example.com:888,' +
+            'network.example.com:999'
+        )
         self.assertEqual('api.example.com', be.api_host)
         self.assertEqual(777, be.api_port)
         self.assertEqual('hsmproxy.example.com', be.hsmproxy_host)
         self.assertEqual(888, be.hsmproxy_port)
+        self.assertEqual('network.example.com', be.network_host)
+        self.assertEqual(999, be.network_port)
 
         with self.assertRaises(ValidationError):
-            brkt_cli.parse_brkt_env('a:7,b:8:9')
+            brkt_cli.parse_brkt_env('a:7,b:8:9,d:10')
         with self.assertRaises(ValidationError):
-            brkt_cli.parse_brkt_env('a:7,b?:8')
+            brkt_cli.parse_brkt_env('a:7,b?:8,d:7')
 
     def test_brkt_env_from_domain(self):
         be = brkt_cli.brkt_env_from_domain('example.com')
@@ -180,6 +184,8 @@ class TestCommandLineOptions(unittest.TestCase):
         self.assertEqual(443, be.api_port)
         self.assertEqual('hsmproxy.example.com', be.hsmproxy_host)
         self.assertEqual(443, be.hsmproxy_port)
+        self.assertEqual('network.example.com', be.network_host)
+        self.assertEqual(443, be.network_port)
         self.assertEqual('api.example.com', be.public_api_host)
         self.assertEqual(443, be.public_api_port)
 
@@ -289,12 +295,14 @@ class TestBrktEnv(unittest.TestCase):
         userdata = {}
         api_host_port = 'api.example.com:777'
         hsmproxy_host_port = 'hsmproxy.example.com:888'
+        network_host_port = 'network.example.com:999'
         expected_userdata = {
             'api_host': api_host_port,
-            'hsmproxy_host': hsmproxy_host_port
+            'hsmproxy_host': hsmproxy_host_port,
+            'network_host': network_host_port
         }
         brkt_env = brkt_cli.parse_brkt_env(
-            api_host_port + ',' + hsmproxy_host_port)
+            api_host_port + ',' + hsmproxy_host_port + ',' + network_host_port)
         brkt_cli.add_brkt_env_to_brkt_config(brkt_env, userdata)
         self.assertEqual(userdata, expected_userdata)
 
@@ -316,7 +324,8 @@ class TestBrktEnv(unittest.TestCase):
 
         # Test --brkt-env
         values = DummyValues()
-        values.brkt_env = 'yetiapi.example.com:443,hsmproxy.example.com:443'
+        values.brkt_env = 'yetiapi.example.com:443,' + \
+            'hsmproxy.example.com:443,network.example.com:443'
         brkt_env = brkt_cli.brkt_env_from_values(values)
         self.assertEqual(
             str(brkt_cli.parse_brkt_env(values.brkt_env)),


### PR DESCRIPTION
This is needed for metavisor services talking to the Yeti
network service.

Testing done:
- make test