### PR TITLE
Change "S3" to "Cloud Storage" in status message

### DIFF
--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -198,7 +198,7 @@ def wait_for_encryption(enc_svc,
             else:
                 state_display = 'Encryption'
                 if state == ENCRYPT_DOWNLOADING:
-                    state_display = 'Download from S3'
+                    state_display = 'Download from cloud storage'
                 log.info(
                     '%s is %d%% complete', state_display, percent_complete)
             last_log_time = now


### PR DESCRIPTION
We can download encrypted guest images from either AWS S3 or Google Cloud Storage (GCS).  So make the status message generic.