### PR TITLE
Clean up InstanceConfig parsing and arguments

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import json
 import logging
-import os
 import re
 import urllib2
 
@@ -21,34 +20,33 @@ import boto
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
 
 import brkt_cli
-from brkt_cli import brkt_jwt, encryptor_service, util
+import brkt_cli.aws.diag_args
+import brkt_cli.aws.encrypt_ami_args
+import brkt_cli.aws.share_logs_args
+import brkt_cli.aws.update_encrypted_ami_args
+from brkt_cli import encryptor_service, util
 from brkt_cli.aws import (
     aws_service,
     diag,
     encrypt_ami,
     share_logs
 )
+from brkt_cli.aws.encrypt_ami import (
+    TAG_ENCRYPTOR,
+    TAG_ENCRYPTOR_AMI,
+    TAG_ENCRYPTOR_SESSION_ID)
+from brkt_cli.aws.update_ami import update_ami
 from brkt_cli.instance_config import (
     INSTANCE_CREATOR_MODE,
     INSTANCE_UPDATER_MODE
 )
 from brkt_cli.instance_config_args import (
-    make_instance_config,
+    instance_config_from_values,
     setup_instance_config_args
 )
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.util import BracketError
 from brkt_cli.validation import ValidationError
-from brkt_cli.aws.encrypt_ami import (
-    TAG_ENCRYPTOR,
-    TAG_ENCRYPTOR_AMI,
-    TAG_ENCRYPTOR_SESSION_ID)
-
-import brkt_cli.aws.diag_args
-import brkt_cli.aws.encrypt_ami_args
-import brkt_cli.aws.share_logs_args
-import brkt_cli.aws.update_encrypted_ami_args
-from brkt_cli.aws.update_ami import update_ami
 
 log = logging.getLogger(__name__)
 
@@ -487,7 +485,8 @@ def command_encrypt_ami(values):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
-        instance_config=make_instance_config(values, brkt_env),
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_CREATOR_MODE),
         status_port=values.status_port,
         save_encryptor_logs=values.save_encryptor_logs
     )
@@ -599,7 +598,8 @@ def command_update_encrypted_ami(values):
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
         updater_instance_type=values.updater_instance_type,
-        instance_config=make_instance_config(values, brkt_env),
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_UPDATER_MODE),
         status_port=values.status_port,
     )
     print(updated_ami_id)

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -32,7 +32,7 @@ from brkt_cli.aws.test_aws_service import build_aws_service
 from brkt_cli.instance_config import BRKT_CONFIG_CONTENT_TYPE
 from brkt_cli.instance_config_args import (
     instance_config_args_to_values,
-    make_instance_config
+    instance_config_from_values
 )
 from brkt_cli.test_encryptor_service import (
     DummyEncryptorService,
@@ -430,8 +430,7 @@ class TestBrktEnv(unittest.TestCase):
 
         cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
         values = instance_config_args_to_values(cli_args)
-        brkt_env = brkt_cli.brkt_env_from_values(values)
-        ic = make_instance_config(values, brkt_env)
+        ic = instance_config_from_values(values)
         aws_svc.run_instance_callback = run_instance_callback
         encrypt_ami.encrypt(
             aws_svc=aws_svc,
@@ -457,8 +456,7 @@ class TestBrktEnv(unittest.TestCase):
         hsmproxy_host_port = 'hsmproxy.example.com:888'
         cli_args = '--brkt-env %s,%s' % (api_host_port, hsmproxy_host_port)
         values = instance_config_args_to_values(cli_args)
-        brkt_env = brkt_cli.brkt_env_from_values(values)
-        ic = make_instance_config(values, brkt_env)
+        ic = instance_config_from_values(values)
 
         def run_instance_callback(args):
             if args.image_id == encryptor_image.id:

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -1,4 +1,3 @@
-import argparse
 import brkt_cli
 import logging
 
@@ -11,7 +10,7 @@ from brkt_cli.instance_config import (
     INSTANCE_UPDATER_MODE
 )
 from brkt_cli.instance_config_args import (
-    make_instance_config,
+    instance_config_from_values,
     setup_instance_config_args
 )
 from brkt_cli.gce import (
@@ -114,9 +113,8 @@ def _run_subcommand(subcommand, values):
 
 def command_launch_gce_image(values, log):
     gce_svc = gce_service.GCEService(values.project, None, log)
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    instance_config = make_instance_config(values, brkt_env,
-                                           mode=INSTANCE_METAVISOR_MODE)
+    instance_config = instance_config_from_values(
+        values, mode=INSTANCE_METAVISOR_MODE)
     if values.startup_script:
         extra_items = [{'key': 'startup-script', 'value': values.startup_script}]
     else:
@@ -155,11 +153,6 @@ def command_update_encrypted_gce_image(values, log):
 
     log.info('Starting updater session %s', gce_svc.get_session_id())
 
-    brkt_env = (
-        brkt_cli.brkt_env_from_values(values) or
-        brkt_cli.get_prod_brkt_env()
-    )
-
     updated_image_id = update_gce_image.update_gce_image(
         gce_svc=gce_svc,
         enc_svc_cls=encryptor_service.EncryptorService,
@@ -167,8 +160,8 @@ def command_update_encrypted_gce_image(values, log):
         encryptor_image=values.encryptor_image,
         encrypted_image_name=encrypted_image_name,
         zone=values.zone,
-        instance_config=make_instance_config(
-            values, brkt_env,mode=INSTANCE_UPDATER_MODE),
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_UPDATER_MODE),
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,
         image_bucket=values.bucket,
@@ -197,11 +190,6 @@ def command_encrypt_gce_image(values, log):
 
     log.info('Starting encryptor session %s', gce_svc.get_session_id())
 
-    brkt_env = (
-        brkt_cli.brkt_env_from_values(values) or
-        brkt_cli.get_prod_brkt_env()
-    )
-
     encrypted_image_id = encrypt_gce_image.encrypt(
         gce_svc=gce_svc,
         enc_svc_cls=encryptor_service.EncryptorService,
@@ -209,8 +197,8 @@ def command_encrypt_gce_image(values, log):
         encryptor_image=values.encryptor_image,
         encrypted_image_name=encrypted_image_name,
         zone=values.zone,
-        instance_config=make_instance_config(
-            values, brkt_env,mode=INSTANCE_CREATOR_MODE),
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_CREATOR_MODE),
         image_project=values.image_project,
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -16,7 +16,7 @@ import logging
 import brkt_cli
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.instance_config_args import (
-    make_instance_config,
+    instance_config_from_values,
     setup_instance_config_args
 )
 log = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class MakeUserDataSubcommand(Subcommand):
         return values.make_user_data_verbose
 
     def run(self, values):
-        instance_cfg = make_instance_config(values)
+        instance_cfg = instance_config_from_values(values)
         print instance_cfg.make_userdata()
         return 0
 


### PR DESCRIPTION
Move BracketEnvironment handling back into make_instance_config() and
rename it to instance_config_from_values().  The behavior was becoming
confusing because BracketEnvironment was handled at the callsite, but
other config stuff was parsed from values.

The current behavior is a bit funky because the logic switches on the
metavisor mode.  I think it's better than the alternative, since
callsites don't have to worry about explicitly handling every option
that goes into InstanceConfig.

Move the add_argument() calls for --brkt-env and --service-domain inside
the mode check.  We don't want to allow these options when launching a
GCE image.  When launching, Metavisor should talk to the Yeti
environment that was specified at encryption time.