### PR TITLE
Log status when encryption fails

### DIFF
--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -247,7 +247,7 @@ def wait_for_encryption(enc_svc,
             log.info('Encrypted root drive created.')
             return
         elif state == ENCRYPT_FAILED:
-            log.debug('Encryption failed with status %s', status)
+            log.error('Encryption status: %s', json.dumps(status))
             _handle_failure_code(status.get('failure_code'))
 
         sleep(10)


### PR DESCRIPTION
When encryption or update fails, log the entire data structure returned
by Metavisor at error level.  This gives us more context about the
failure, even if the user isn't running with -v.