### PR TITLE
Abort if the token is invalid

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -357,6 +357,11 @@ def check_jwt_auth(brkt_env, jwt):
     except urllib2.HTTPError as e:
         if e.code == 401:
             raise ValidationError('Unauthorized token.')
+        elif e.code == 400:
+            payload = e.read()
+            if payload:
+                log.error(payload)
+            raise ValidationError('Invalid token.')
         else:
             # Unexpected server response.  Log a warning and continue, so
             # that we don't unnecessarily interrupt the encryption process.


### PR DESCRIPTION
If the token auth check returns 400, log the message returned by the
server.  This can happen when Yeti uses a 3rd party JWK server and the
token does not have a customer claim.