### PR TITLE
Add network flag to GCE launch image

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -132,6 +132,7 @@ def command_launch_gce_image(values, log):
                             values.zone,
                             values.delete_boot,
                             values.instance_type,
+                            values.network,
                             metadata)
     return 0
 

--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -3,7 +3,7 @@ import uuid
 
 log = logging.getLogger(__name__)
 
-def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, metadata={}):
+def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, metadata={}):
     if not instance_name:
         instance_name = 'brkt' + '-' + str(uuid.uuid4().hex)
     guest = instance_name + '-guest'
@@ -19,6 +19,7 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_ty
                          disks=[guest_disk],
                          metadata=metadata,
                          delete_boot=delete_boot,
+                         network=network,
                          instance_type=instance_type)
     gce_svc.wait_instance(instance_name, zone)
     log.info("Instance %s (%s) launched successfully" % (instance_name,

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -39,6 +39,12 @@ def setup_launch_gce_image_args(parser):
         dest='project',
         required=True
     )
+    parser.add_argument(
+        '--network',
+        dest='network',
+        default='default',
+        required=False
+    )
 
     # Optional startup script. Hidden because it is only used for development
     # and testing. It should be passed as a string containing a multi-line


### PR DESCRIPTION
Provide an option to specify a network when launching GCE images via the CLI tool. Defaults to the 'default' network.