### PR TITLE
GCE: log the host and port of the encryptor/updater service

### DIFF
--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -61,9 +61,13 @@ def do_encryption(gce_svc,
                          metadata=metadata)
 
     try:
-        enc_svc = enc_svc_cls([gce_svc.get_instance_ip(encryptor, zone)],
-                              port=status_port)
+        ip = gce_svc.get_instance_ip(encryptor, zone)
+        enc_svc = enc_svc_cls([ip], port=status_port)
         wait_for_encryptor_up(enc_svc, Deadline(600))
+        log.info(
+            'Waiting for encryption service on %s (%s:%s)',
+            encryptor, ip, enc_svc.port
+        )
         wait_for_encryption(enc_svc)
     except Exception as e:
         f = gce_svc.write_serial_console_file(zone, encryptor)

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -68,11 +68,15 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
                              network=network,
                              disks=[],
                              metadata=user_data)
-        enc_svc = enc_svc_cls([gce_svc.get_instance_ip(updater, zone)],
-                              port=status_port)
+        ip = gce_svc.get_instance_ip(updater, zone)
+        enc_svc = enc_svc_cls([ip], port=status_port)
 
         # wait for updater to finish and guest root disk
         wait_for_encryptor_up(enc_svc, Deadline(600))
+        log.info(
+            'Waiting for updater service on %s (%s:%s)',
+            updater, ip, enc_svc.port
+        )
         try:
             wait_for_encryption(enc_svc)
         except:


### PR DESCRIPTION
Log the host and port that we use to monitor encryption/update progress,
to help the user diagnose networking issues.