### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,18 @@
-**brkt-cli** is a command-line interface to the [Bracket Computing](http://www.brkt.com)
-service.  It produces an encrypted version of an Amazon Machine Image, which can then be
-launched in EC2. It can also update an already encrypted version of an Amazon Machine Image,
-which can then be launched in EC2.
+**brkt-cli** is a command-line interface to the
+[Bracket Computing](http://www.brkt.com) service. It produces an
+encrypted version of an operating system image in [Amazon Web Services]
+(https://aws.amazon.com/)
+(AWS) or [Google Compute Engine](https://cloud.google.com/compute/)
+(GCE). The resulting encrypted image can then be launched in the same
+manner as the original.
 
-The latest release of **brkt-cli** is [1.0.2](https://github.com/brkt/brkt-cli/releases/tag/brkt-cli-1.0.2).
-
-## Process
-
-The `encrypt-ami` subcommand performs the following steps to create an
-encrypted image:
-
-1. Launch an instance based on the specified unencrypted AMI.  We call this
-the guest instance.
-1. Snapshot the root volume of the guest instance.
-1. Launch a Bracket Encryptor instance.
-1. Attach the unencrypted guest root volume to the Bracket encryptor instance.
-1. Copy the unencrypted root volume to a new, encrypted volume.
-1. Create a new AMI based on the encrypted root volume and other volumes
-required by the metavisor at runtime.
-
-The `update-encrypted-ami` subcommand updates an encrypted AMI with the latest
-version of the metavisor code.
+The latest release of **brkt-cli** is [1.0.2]
+(https://github.com/brkt/brkt-cli/releases/tag/brkt-cli-1.0.2).
 
 ## Requirements
 
 In order to use the Bracket service, you must be a
-registered Bracket customer.  Email support@brkt.com for
+registered Bracket Computing customer.  Email support@brkt.com for
 more information.
 
 **brkt-cli** requires Python 2.7.
@@ -99,155 +86,43 @@ order to do this, port 443 must be accessible on the following hosts:
 * **brkt-cli** talks to `api.mgmt.brkt.com` on port 443.
 * Both **brkt-cli** and the Encryptor also need to access Amazon S3.
 
-When launching the Encryptor instance, **brkt-cli** creates a temporary
-security group that allows inbound access on port 80.  Alternately, you can
-use the `--security-group` option to specify one or more existing security
-groups.
+## Authentication
 
-## Usage
-```
-$ brkt encrypt-ami --help
-usage: brkt encrypt-ami [-h] [--encrypted-ami-name NAME]
-                        [--guest-instance-type TYPE] [--pv] [--no-validate]
-                        [--proxy HOST:PORT | --proxy-config-file PATH]
-                        --region NAME [--security-group ID] [--subnet ID]
-                        [--tag KEY=VALUE] [--ntp-server DNS Name]
-                        ID
+The Encryptor and Metavisor use a [JSON Web Token](https://jwt.io/)
+(JWT) to authenticate with the Bracket Service. The token is derived
+from an ECDSA 384 private key in PEM format. 
 
-Create an encrypted AMI from an existing AMI.
+The process works like this:
 
-positional arguments:
-  ID                    The guest AMI that will be encrypted
+1. Run `brkt make-key` to create a public/private key pair.
+1. Register the public key with the Bracket Service (see **Token
+Verification Keys** in the **Settings** section of the admin UI.
+1. Run `brkt make-token` and pass your private key to generate a
+token.
+1. Pass the token to the encryption or update subcommand via the
+`--token` option.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --encrypted-ami-name NAME
-                        Specify the name of the generated encrypted AMI
-  --guest-instance-type TYPE
-                        The instance type to use when running the unencrypted
-                        guest instance
-  --pv                  Use the PV encryptor
-  --no-validate         Don't validate AMIs, subnet, and security groups
-  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
-                        specified multiple times.
-  --proxy-config-file PATH
-                        Path to proxy.yaml file that will be used during
-                        encryption
-  --region NAME         AWS region (e.g. us-west-2)
-  --security-group ID   Use this security group when running the encryptor
-                        instance. May be specified multiple times.
-  --status-port         By default, port 80 is used to talk to receive
-                        encryptor status. Any port in range 1-65535 except for
-			port 81 can be used.
-  --subnet ID           Launch instances in this subnet
-  --tag KEY=VALUE       Custom tag for resources created during encryption.
-                        May be specified multiple times.
-  --ntp-server DNS Name
-                        Optional NTP server to sync Metavisor clock. May be
-                        specified multiple times.
-```
-```
-$ brkt update-encrypted-ami --help
-usage: brkt update-encrypted-ami [-h] [--encrypted-ami-name NAME]
-                                 [--guest-instance-type TYPE] [--pv]
-                                 [--no-validate]
-                                 [--proxy HOST:PORT | --proxy-config-file PATH]
-                                 --region REGION [--security-group ID]
-                                 [--subnet ID] [--ntp-server DNS Name]
-                                 [--tag KEY=VALUE]
-                                 ID
+**brkt-cli** will then pass the token to the Encryptor or Updater,
+to allow it to authenticate with the Bracket service. The token will
+also be embedded into the encrypted image. This allows the encrypted
+instance to authenticate with the Bracket service on startup.
 
-Update an encrypted AMI with the latest Metavisor release.
-
-positional arguments:
-  ID                    The encrypted AMI that will be updated
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --encrypted-ami-name NAME
-                        Specify the name of the generated encrypted AMI
-  --guest-instance-type TYPE
-                        The instance type to use when running the unencrypted
-                        guest instance
-  --pv                  Use the PV encryptor
-  --no-validate         Don't validate AMIs, subnet, and security groups
-  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
-                        specified multiple times.
-  --proxy-config-file PATH
-                        Path to proxy.yaml file that will be used during
-                        encryption
-  --region REGION       AWS region (e.g. us-west-2)
-  --security-group ID   Use this security group when running the encryptor
-                        instance. May be specified multiple times.
-  --status-port         By default, port 80 is used to talk to receive
-                        updater status. Any port in range 1-65535 except for
-			port 81 can be used.
-  --subnet ID           Launch instances in this subnet
-  --ntp-server DNS Name
-                        Optional NTP server to sync Metavisor clock. May be
-                        specified multiple times.
-  --tag KEY=VALUE       Custom tag for resources created during encryption.
-                        May be specified multiple times.
-```
-
-## Configuration
-
-Before running the **brkt** command, make sure that you've set the AWS
-environment variables:
+#### Sample usage
 
 ```
-$ export AWS_ACCESS_KEY_ID=<access key>
-$ export AWS_SECRET_ACCESS_KEY=<secret key>
+$ brkt make-key --public-out public.pem > private.pem
+Passphrase:
+Reenter passphrase:
+
+$ brkt make-token --signing-key private.pem
+Encrypted private key password:
+eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZC...
 ```
 
-You'll also need to make sure that your AWS account has the required
-permissions, such as running an instance, describing an image, and
-creating snapshots.  See [brkt-cli-iam-permissions.json](https://github.com/brkt/brkt-cli/blob/master/reference_templates/brkt-cli-iam-permissions.json)
-for the complete list of required permissions.
+## Encrypting an image
 
-## Encrypting an AMI
-
-Run **brkt encrypt-ami** to create a new encrypted AMI based on an existing
-image:
-
-```
-$ brkt encrypt-ami --region us-east-1 ami-76e27e1e
-15:28:37 Starting encryptor session caabe51a
-15:28:38 Launching instance i-703f4c99 to snapshot root disk for ami-76e27e1e
-...
-15:57:11 Created encrypted AMI ami-07c2a262 based on ami-76e27e1e
-15:57:11 Terminating encryptor instance i-753e4d9c
-15:57:12 Deleting snapshot copy of original root volume snap-847da3e1
-15:57:12 Done.
-ami-07c2a262
-```
-
-When the process completes, the new AMI id is written to stdout.  All log
-messages are written to stderr.
-
-## Updating an encrypted AMI
-
-Run **brkt update-encrypted-ami** to update an encrypted AMI based on an existing
-encrypted image:
-
-```
-$ brkt update-encrypted-ami --region us-east-1 ami-72094e18
-13:38:14 Using zone us-east-1a
-13:38:15 Updating ami-72094e18
-13:38:15 Creating guest volume snapshot
-...
-13:39:25 Encrypted root drive created.
-...
-13:39:28 waiting for snapshot ready
-13:39:48 metavisor updater snapshots ready
-...
-13:39:54 Created encrypted AMI ami-63733e09 based on ami-72094e18
-13:39:54 Done.
-ami-63733e09
-```
-
-When the process completes, the new AMI id is written to stdout.  All log
-messages are written to stderr.
+See the [AWS](aws.md) or [GCE](gce.md) pages for platform-specific
+documentation on encrypting and updating an image.
 
 ## <a name="docker"/>Running in a Docker container
 

--- a/aws.md
+++ b/aws.md
@@ -1,0 +1,190 @@
+# Encrypting images in AWS
+
+The `encrypt-ami` subcommand performs the following steps to create an
+encrypted image:
+
+1. Launch an instance based on an unencrypted AMI.  We call this
+the guest instance.
+1. Snapshot the root volume of the guest instance.
+1. Launch a Bracket Encryptor instance.
+1. Attach the unencrypted guest root volume to the Bracket encryptor instance.
+1. Copy the unencrypted root volume to a new, encrypted volume.
+1. Create a new AMI based on the encrypted root volume and other volumes
+required by the Metavisor at runtime.
+
+## Usage
+```
+$ brkt encrypt-ami --help
+usage: brkt encrypt-ami [-h] [--encrypted-ami-name NAME]
+                        [--guest-instance-type TYPE] [--pv] [--no-validate]
+                        --region NAME [--security-group ID] [--subnet ID]
+                        [--tag KEY=VALUE] [-v] [--ntp-server DNS Name]
+                        [--proxy HOST:PORT | --proxy-config-file PATH]
+                        [--status-port PORT] [--token TOKEN]
+                        ID
+
+Create an encrypted AMI from an existing AMI.
+
+positional arguments:
+  ID                    The guest AMI that will be encrypted
+
+optional arguments:
+  --encrypted-ami-name NAME
+                        Specify the name of the generated encrypted AMI
+                        (default: None)
+  --guest-instance-type TYPE
+                        The instance type to use when running the unencrypted
+                        guest instance (default: m3.medium)
+  --no-validate         Don't validate AMIs, subnet, and security groups
+                        (default: True)
+  --ntp-server DNS Name
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --pv                  Use the PV encryptor (default: False)
+  --region NAME         AWS region (e.g. us-west-2) (default: None)
+  --security-group ID   Use this security group when running the encryptor
+                        instance. May be specified multiple times. (default:
+                        None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --subnet ID           Launch instances in this subnet (default: None)
+  --tag KEY=VALUE       Custom tag for resources created during encryption.
+                        May be specified multiple times. (default: None)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  -h, --help            show this help message and exit
+  -v, --verbose         Print status information to the console (default:
+                        False)
+```
+
+The `update-encrypted-ami` subcommand updates an encrypted AMI with the latest
+version of the Metavisor code.
+
+```
+$ brkt update-encrypted-ami --help
+usage: brkt update-encrypted-ami [-h] [--encrypted-ami-name NAME]
+                                 [--guest-instance-type TYPE]
+                                 [--updater-instance-type TYPE] [--pv]
+                                 [--no-validate] --region REGION
+                                 [--security-group ID] [--subnet ID]
+                                 [--tag KEY=VALUE] [-v]
+                                 [--ntp-server DNS Name]
+                                 [--proxy HOST:PORT | --proxy-config-file PATH]
+                                 [--status-port PORT] [--token TOKEN]
+                                 ID
+
+Update an encrypted AMI with the latest Metavisor release.
+
+positional arguments:
+  ID                    The encrypted AMI that will be updated
+
+optional arguments:
+  --encrypted-ami-name NAME
+                        Specify the name of the generated encrypted AMI
+                        (default: None)
+  --guest-instance-type TYPE
+                        The instance type to use when running the encrypted
+                        guest instance. Default: m3.medium (default:
+                        m3.medium)
+  --no-validate         Don't validate AMIs, subnet, and security groups
+                        (default: True)
+  --ntp-server DNS Name
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --pv                  Use the PV encryptor (default: False)
+  --region REGION       AWS region (e.g. us-west-2) (default: us-west-2)
+  --security-group ID   Use this security group when running the encryptor
+                        instance. May be specified multiple times. (default:
+                        None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --subnet ID           Launch instances in this subnet (default: None)
+  --tag KEY=VALUE       Custom tag for resources created during encryption.
+                        May be specified multiple times. (default: None)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --updater-instance-type TYPE
+                        The instance type to use when running the updater
+                        instance. Default: m3.medium (default: m3.medium)
+  -h, --help            show this help message and exit
+  -v, --verbose         Print status information to the console (default:
+                        False)
+```
+
+## Configuration
+
+Before running the **brkt** command, make sure that you've set your AWS
+environment variables:
+
+```
+$ export AWS_ACCESS_KEY_ID=<access key>
+$ export AWS_SECRET_ACCESS_KEY=<secret key>
+```
+
+You'll also need to make sure that your AWS account has the required
+permissions, such as running an instance, describing an image, and
+creating snapshots.  See [brkt-cli-iam-permissions.json](https://github.com/brkt/brkt-cli/blob/master/reference_templates/brkt-cli-iam-permissions.json)
+for the complete list of required permissions.
+
+When launching the Encryptor or Updater instance, **brkt-cli** creates
+a temporary security group that allows inbound access on port 80.
+Alternately, you can use the `--security-group` option to specify one
+or more existing security groups.
+
+## Encrypting an AMI
+
+Run **brkt encrypt-ami** to create a new encrypted AMI based on an existing
+image:
+
+```
+$ brkt encrypt-ami --region us-east-1 --token <token> ami-76e27e1e
+15:28:37 Starting encryptor session caabe51a
+15:28:38 Launching instance i-703f4c99 to snapshot root disk for ami-76e27e1e
+...
+15:57:11 Created encrypted AMI ami-07c2a262 based on ami-76e27e1e
+15:57:11 Terminating encryptor instance i-753e4d9c
+15:57:12 Deleting snapshot copy of original root volume snap-847da3e1
+15:57:12 Done.
+ami-07c2a262
+```
+
+When the process completes, the new AMI id is written to stdout.  Log
+messages are written to stderr.
+
+## Updating an encrypted AMI
+
+Run **brkt update-encrypted-ami** to update an encrypted AMI based on an existing
+encrypted image:
+
+```
+$ brkt update-encrypted-ami --region us-east-1 --token <token> ami-72094e18
+13:38:14 Using zone us-east-1a
+13:38:15 Updating ami-72094e18
+13:38:15 Creating guest volume snapshot
+...
+13:39:25 Encrypted root drive created.
+...
+13:39:28 waiting for snapshot ready
+13:39:48 metavisor updater snapshots ready
+...
+13:39:54 Created encrypted AMI ami-63733e09 based on ami-72094e18
+13:39:54 Done.
+ami-63733e09
+```
+
+When the process completes, the new AMI id is written to stdout.  Log
+messages are written to stderr.

--- a/gce.md
+++ b/gce.md
@@ -1,0 +1,150 @@
+# Encrypting images in GCE
+
+The `encrypt-gce-image` subcommand creates an encrypted version of a
+GCE image.
+
+```
+$ brkt encrypt-gce-image --help
+usage: brkt encrypt-gce-image [-h] [--encrypted-image-name NAME] --zone ZONE
+                              [--encryptor-image-bucket BUCKET] --project
+                              PROJECT [--image-project NAME]
+                              [--encryptor-image ENCRYPTOR_IMAGE]
+                              [--network NETWORK] [--ntp-server DNS Name]
+                              [--proxy HOST:PORT | --proxy-config-file PATH]
+                              [--status-port PORT] [--token TOKEN]
+                              ID
+
+positional arguments:
+  ID                    The image that will be encrypted
+
+optional arguments:
+  --encrypted-image-name NAME
+                        Specify the name of the generated encrypted Image
+                        (default: None)
+  --encryptor-image ENCRYPTOR_IMAGE
+  --encryptor-image-bucket BUCKET
+                        Bucket to retrieve encryptor image from (prod, stage,
+                        shared, <custom>) (default: prod)
+  --image-project NAME  GCE project name which owns the image (e.g. centos-
+                        cloud) (default: None)
+  --network NETWORK
+  --ntp-server DNS Name
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --project PROJECT     GCE project name (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --zone ZONE           GCE zone to operate in (default: None)
+  -h, --help            show this help message and exit
+```
+
+  The `update-gce-image` subcommand updates an encrypted
+image with the latest version of the Metavisor code.
+
+```
+$ ./brkt update-gce-image --help
+usage: brkt update-gce-image [-h] [--encrypted-image-name NAME] --zone ZONE
+                             [--encryptor-image-bucket BUCKET] --project
+                             PROJECT [--encryptor-image ENCRYPTOR_IMAGE]
+                             [--network NETWORK] [--ntp-server DNS Name]
+                             [--proxy HOST:PORT | --proxy-config-file PATH]
+                             [--status-port PORT] [--token TOKEN]
+                             ID
+
+positional arguments:
+  ID                    The image that will be encrypted
+
+optional arguments:
+  --encrypted-image-name NAME
+                        Specify the name of the generated encrypted Image
+                        (default: None)
+  --encryptor-image ENCRYPTOR_IMAGE
+  --encryptor-image-bucket BUCKET
+                        Bucket to retrieve encryptor image from (prod, stage,
+                        shared, <custom>) (default: prod)
+  --network NETWORK
+  --ntp-server DNS Name
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --project PROJECT     GCE project name (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --zone ZONE           GCE zone to operate in (default: us-central1-a)
+  -h, --help            show this help message and exit
+```
+
+## Configuration
+
+Before running the GCE commands in **brkt-cli**, you'll need to install
+[gcloud](https://cloud.google.com/sdk/gcloud/) and configure it
+to work with your Google account and GCP project.
+
+You'll also need to add a Firewall rule that allows inbound access
+to the Encryptor or Updater instance on port **80**, or the port that
+you specify with the **--status-port** option.
+
+## Encrypting an image
+
+Run `encrypt-gce-image` to encrypt an image:
+
+```
+$ brkt encrypt-gce-image --zone us-central1-a --project brkt-dev --token <token> --image-project ubuntu-os-cloud ubuntu-1404-trusty-v20160627
+...
+14:30:23 Starting encryptor session 59e3b3a7
+...
+14:55:18 Encryption is 99% complete
+14:55:28 Encrypted root drive created.
+14:55:29 Creating snapshot of encrypted image disk
+14:56:21 Disk detach successful
+14:56:21 Creating metavisor image
+14:58:25 Image ubuntu-1404-trusty-v20160627-encrypted-a1fe1069 successfully created!
+14:58:25 Cleaning up
+14:58:25 deleting disk brkt-guest-59e3b3a7
+14:58:25 Disk detach successful
+14:58:26 deleting disk encrypted-image-59e3b3a7
+14:58:26 Disk detach successful
+14:58:27 deleting disk brkt-guest-59e3b3a7-encryptor
+14:58:27 Disk detach successful
+14:58:28 Deleting encryptor image encryptor-59e3b3a7
+ubuntu-1404-trusty-v20160627-encrypted-a1fe1069
+```
+
+## Updating an image
+
+Run `update-gce-image` to update an encrypted image with the latest
+Metavisor code:
+
+```
+$ ./brkt update-gce-image --zone us-central1-a --project brkt-dev --token <token> ubuntu-1404-trusty-v20160627-encrypted-ee521b31
+...
+15:50:04 Starting updater session 80985e58
+...
+15:55:02 Encrypted root drive created.
+15:55:02 Deleting updater instance
+15:55:54 Disk detach successful
+15:55:54 Creating updated metavisor image
+15:56:45 deleting disk brkt-updater-80985e58-guest
+15:56:46 Disk detach successful
+15:56:46 deleting disk brkt-updater-80985e58-metavisor
+15:56:47 Disk detach successful
+15:56:47 Deleting encryptor image encryptor-80985e58
+ubuntu-1404-trusty-v20160627-encrypted-63e57e6e
+```


### PR DESCRIPTION
Add docs for the make-key and make-token commands.  Move docs for AWS
and GCE commands into separate pages, to keep the main page shorter.