### PR TITLE
Add help to subcommands, usage cleanup

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -415,7 +415,7 @@ class SortingHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
 def main():
     parser = argparse.ArgumentParser(
         description='Command-line interface to the Bracket Computing service.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=SortingHelpFormatter
     )
     parser.add_argument(
         '-v',

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -73,6 +73,7 @@ class DiagSubcommand(Subcommand):
             description=(
                 'Create instance to diagnose an existing encrypted instance.'
             ),
+            help='Diagnose an encrypted instance',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         diag_args.setup_diag_args(diag_parser)
@@ -98,6 +99,7 @@ class ShareLogsSubcommand(Subcommand):
         share_logs_parser = subparsers.add_parser(
             'share-logs',
             description='Share logs from an existing encrypted instance.',
+            help='Share logs',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         share_logs_args.setup_share_logs_args(share_logs_parser)
@@ -123,6 +125,7 @@ class EncryptAMISubcommand(Subcommand):
         encrypt_ami_parser = subparsers.add_parser(
             'encrypt-ami',
             description='Create an encrypted AMI from an existing AMI.',
+            help='Encrypt an AWS image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
@@ -153,6 +156,7 @@ class UpdateAMISubcommand(Subcommand):
                 'Update an encrypted AMI with the latest Metavisor '
                 'release.'
             ),
+            help='Update an encrypted AWS image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         update_encrypted_ami_args.setup_update_encrypted_ami(

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -151,7 +151,8 @@ class ConfigSubcommand(Subcommand):
             self.name(),
             description=(
                 'Display or update brkt-cli options stored in'
-                ' ~/.brkt/config')
+                ' ~/.brkt/config'),
+            help='Display or update brkt-cli options'
         )
 
         config_subparsers = config_parser.add_subparsers(
@@ -161,7 +162,7 @@ class ConfigSubcommand(Subcommand):
         # List all options
         config_subparsers.add_parser(
             'list',
-            help='display the values of all options set in the config file',
+            help='Display the values of all options set in the config file',
             description='Display the values of all options set in the config file')
 
         # All the options available for retrieval/mutation
@@ -180,38 +181,38 @@ class ConfigSubcommand(Subcommand):
         # Set an option
         set_parser = config_subparsers.add_parser(
             'set',
-            help='set the value for an option',
+            help='Set the value for an option',
             description='Set the value for an option',
             epilog=epilog,
             formatter_class=argparse.RawDescriptionHelpFormatter)
         set_parser.add_argument(
             'option',
-            help='the option name (e.g. encrypt-gce-image.project)')
+            help='The option name (e.g. encrypt-gce-image.project)')
         set_parser.add_argument(
             'value',
-            help='the option value')
+            help='The option value')
 
         # Get the value for an option
         get_parser = config_subparsers.add_parser(
             'get',
-            help='get the value for an option',
+            help='Get the value for an option',
             description='Get the value for an option',
             epilog=epilog,
             formatter_class=argparse.RawDescriptionHelpFormatter)
         get_parser.add_argument(
             'option',
-            help='the option name (e.g. encrypt-gce-image.project)')
+            help='The option name (e.g. encrypt-gce-image.project)')
 
         # Unset the value for an option
         unset_parser = config_subparsers.add_parser(
             'unset',
-            help='unset the value for an option',
+            help='Unset the value for an option',
             description='Unset the value for an option',
             epilog=epilog,
             formatter_class=argparse.RawDescriptionHelpFormatter)
         unset_parser.add_argument(
             'option',
-            help='the option name (e.g. encrypt-gce-image.project)')
+            help='The option name (e.g. encrypt-gce-image.project)')
 
     def _unlink_noraise(self, path):
         try:

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -38,6 +38,8 @@ class EncryptGCEImageSubcommand(Subcommand):
     def register(self, subparsers, parsed_config):
         encrypt_gce_image_parser = subparsers.add_parser(
             'encrypt-gce-image',
+            description='Create an encrypted GCE image from an existing image',
+            help='Encrypt a GCE image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         encrypt_gce_image_args.setup_encrypt_gce_image_args(
@@ -68,6 +70,10 @@ class UpdateGCEImageSubcommand(Subcommand):
     def register(self, subparsers, parsed_config):
         update_gce_image_parser = subparsers.add_parser(
             'update-gce-image',
+            description=(
+                'Update an encrypted GCE image with the latest Metavisor '
+                'release'),
+            help='Update an encrypted GCE image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         update_encrypted_gce_image_args.setup_update_gce_image_args(update_gce_image_parser)
@@ -86,7 +92,9 @@ class LaunchGCEImageSubcommand(Subcommand):
     def register(self, subparsers, parsed_config):
         launch_gce_image_parser = subparsers.add_parser(
             'launch-gce-image',
-            formatter_class=brkt_cli.SortingHelpFormatter
+            formatter_class=brkt_cli.SortingHelpFormatter,
+            description='Launch a GCE image',
+            help='Launch a GCE image'
         )
         launch_gce_image_args.setup_launch_gce_image_args(launch_gce_image_parser)
         setup_instance_config_args(launch_gce_image_parser,

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -36,6 +36,7 @@ class GetPublicKeySubcommand(Subcommand):
                 'Print the public part of a private key.  If the private key '
                 'is encrypted, prompt for a password and decrypt the key.'
             ),
+            help='Print the public part of a private key',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         parser.add_argument(

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -46,6 +46,7 @@ class MakeKeySubcommand(Subcommand):
                 'PEM format and write the key to stdout.  Optionally write '
                 'the associated public key to a file.'
             ),
+            help='Make a PEM key',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         parser.add_argument(

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -34,6 +34,7 @@ class MakeUserDataSubcommand(Subcommand):
                 'Generate MIME multipart user-data that is passed to '
                 'Metavisor and cloud-init when running an instance.'
             ),
+            help='Make user data for passing to Metavisor',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
 


### PR DESCRIPTION
Add help to all subcommands.  This causes argparse to print a brief
description next to each subcommand in the top-level usage output.  Add
descriptions to GCE commands.  Capitalize config command descriptions,
so that they are consistent with the convention that we've been
following to date.

I couldn't figure out a way to sort the list of subcommands with
descriptions.

$ ./brkt -h
usage: brkt [-h] [-v] [--version] [--no-check-version]
            {config,diag,encrypt-ami,encrypt-gce-image,launch-gce-image
,make-key,make-token,make-user-data,share-logs,update-encrypted-ami
,update-gce-image}
            ...

Command-line interface to the Bracket Computing service.

positional arguments:
{config,diag,encrypt-ami,encrypt-gce-image,launch-gce-image,make-key
,make-token,make-user-data,share-logs,update-encrypted-ami,update-gce-
image}
    diag                Diagnose an encrypted instance
    encrypt-ami         Encrypt an AWS image
    share-logs          Share logs
    update-encrypted-ami
                        Update an encrypted AWS image
    config              Display or update brkt-cli options
    encrypt-gce-image   Encrypt a GCE image
    update-gce-image    Update an encrypted GCE image
    launch-gce-image    Launch a GCE image
    get-public-key      Print the public part of a private key
    make-key            Make a PEM key
    make-user-data      Make user data for passing to Metavisor

optional arguments:
--no-check-version    Don't check whether this version of brkt-cli is
                        supported (default: True)
--version             show program's version number and exit
-h, --help            show this help message and exit
-v, --verbose         Print status information to the console
(default:
                        False)