### PR TITLE
Write debug log to a temp file

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -132,6 +132,9 @@ class EncryptAMISubcommand(Subcommand):
         setup_instance_config_args(encrypt_ami_parser,
                                    mode=INSTANCE_CREATOR_MODE)
 
+    def debug_log_to_temp_file(self):
+        return True
+
     def run(self, values):
         return _run_subcommand(self.name(), values)
 
@@ -163,6 +166,9 @@ class UpdateAMISubcommand(Subcommand):
             update_encrypted_ami_parser)
         setup_instance_config_args(update_encrypted_ami_parser,
                                    mode=INSTANCE_UPDATER_MODE)
+
+    def debug_log_to_temp_file(self):
+        return True
 
     def run(self, values):
         return _run_subcommand(self.name(), values)

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -58,6 +58,9 @@ class EncryptGCEImageSubcommand(Subcommand):
             '%s.zone' % (self.name(),),
             'The GCE zone metavisors will be launched into')
 
+    def debug_log_to_temp_file(self):
+        return True
+
     def run(self, values):
         return _run_subcommand(self.name(), values)
 
@@ -79,6 +82,9 @@ class UpdateGCEImageSubcommand(Subcommand):
         update_encrypted_gce_image_args.setup_update_gce_image_args(update_gce_image_parser)
         setup_instance_config_args(update_gce_image_parser,
                                    brkt_env_default=BRKT_ENV_PROD)
+
+    def debug_log_to_temp_file(self):
+        return True
 
     def run(self, values):
         return _run_subcommand(self.name(), values)

--- a/brkt_cli/subcommand.py
+++ b/brkt_cli/subcommand.py
@@ -68,6 +68,11 @@ class Subcommand(object):
         """
         pass
 
+    def debug_log_to_temp_file(self):
+        """ Return True if debug logging should be written to a temporary
+        file.  The file is deleted if the command succeeds. """
+        return False
+
     @abc.abstractmethod
     def run(self, values):
         """ Run the subcommand.


### PR DESCRIPTION
Write debug log output to a temporary file unless the user specified -v.
If the command succeeds, we delete the file.  If the command fails, we
print the location of the debug log.