### PR TITLE
Don't append guest to instance name

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -139,6 +139,9 @@ def command_launch_gce_image(values, log):
     if not values.verbose:
         logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 
+    if values.instance_name:
+        gce_service.validate_image_name(values.instance_name)
+
     launch_gce_image.launch(log,
                             gce_svc,
                             values.image,

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -633,9 +633,9 @@ def validate_image_name(name):
 
     : raises ValidationError if name is invalid
     """
-    if not (name and len(name) <= 63):
+    if not (name and len(name) <= 64):
         raise ValidationError(
-            'Image name may be at most 63 characters')
+            'Image name may be at most 64 characters')
 
     m = re.match(r'[a-z0-9\-]*[a-z0-9]$', name)
     if not m:

--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -1,17 +1,22 @@
 import logging
 import uuid
 
+from brkt_cli.util import (
+    append_suffix
+)
+
 log = logging.getLogger(__name__)
 
 def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, metadata={}):
     if not instance_name:
         instance_name = 'brkt' + '-' + str(uuid.uuid4().hex)
-    guest = instance_name + '-guest'
+
+    snap_name = append_suffix(instance_name, '-snap', 64)
     log.info("Creating guest root disk from snapshot")
-    gce_svc.disk_from_snapshot(zone, image_id, guest)
-    gce_svc.wait_for_disk(zone, guest)
+    gce_svc.disk_from_snapshot(zone, image_id, snap_name)
+    gce_svc.wait_for_disk(zone, snap_name)
     log.info("Starting instance")
-    guest_disk = gce_svc.get_disk(zone, guest)
+    guest_disk = gce_svc.get_disk(zone, snap_name)
     guest_disk['autoDelete'] = True
     gce_svc.run_instance(zone=zone,
                          name=instance_name,

--- a/test_gce.py
+++ b/test_gce.py
@@ -189,11 +189,11 @@ class TestEncryptedImageName(unittest.TestCase):
         self.assertNotEqual(n1, n2)
 
     def test_long_image_name(self):
-        image_name = 'test-image-with-long-name-encrypted-so-we-hit-63-char-limit'
+        image_name = 'test-image-with-long-name-encrypted-so-we-hit-63-char-limit-a'
         n1 = gce_service.get_image_name(None, image_name)
         n2 = gce_service.get_image_name(None, image_name)
         self.assertNotEqual(n1, n2)
-        self.assertTrue('63-char-limit' not in n1 and '63-char-limit' not in n2)
+        self.assertTrue('64-char-limit' not in n1 and '64-char-limit' not in n2)
 
     def test_user_supplied_name(self):
         encrypted_image_name = 'something'
@@ -214,7 +214,7 @@ class TestEncryptedImageName(unittest.TestCase):
         with self.assertRaises(ValidationError):
             gce_service.validate_image_name('validname-')
         with self.assertRaises(ValidationError):
-            gce_service.validate_image_name('a' * 64)
+            gce_service.validate_image_name('a' * 65)
         for c in '?!#$%^&*~`{}\|"<>()[]./\'@_':
             with self.assertRaises(ValidationError):
                 gce_service.validate_image_name('valid' + c)


### PR DESCRIPTION
launch-gce-image no longer append 'guest'
to the instance name. However because the
root disk and guest disk cant have the same
name '-s' is appended to instance_name and
used as the name for the disk created from
the encrypted guest root snapshot

the launch command now validates the instance
name before trying to launch the instance