### PR TITLE
Use posixpath for dest files in userdata

### DIFF
--- a/brkt_cli/instance_config.py
+++ b/brkt_cli/instance_config.py
@@ -14,7 +14,7 @@
 
 import json
 import logging
-import os
+import posixpath
 
 from brkt_cli.user_data import UserDataContainer
 
@@ -68,7 +68,7 @@ class InstanceConfig(object):
 
     def add_brkt_file(self, dest_filename, file_contents):
         # dest_filename will be relative to self._brkt_files_dest_dir
-        dest_path = os.path.join(self._brkt_files_dest_dir, dest_filename)
+        dest_path = posixpath.join(self._brkt_files_dest_dir, dest_filename)
         brkt_file = BrktFile(dest_path, file_contents)
         self._brkt_files.append(brkt_file)
 


### PR DESCRIPTION
When adding files with brkt-files parts in userdata, we must use Unix-style path separators for the destination file names, even when the brkt-cli command is being run on Windows.

Testing:
* Ran unit tests on Linux (no failures)
* Ran unit tests on Windows; this fix resolves 3 failures in existing
  tests (still need to fix temp file issue with
  test_util.TestReadPrivateKey.test_read_private_key()