### PR TITLE
Clean up guest and encryptor instances

### DIFF
--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -90,6 +90,8 @@ class DummyAWSService(aws_service.BaseAWSService):
         self.get_snapshot_callback = None
         self.delete_snapshot_callback = None
         self.stop_instance_callback = None
+        self.create_tags_callback = None
+        self.terminate_instance_callback = None
 
     def get_regions(self):
         return self.regions
@@ -161,6 +163,8 @@ class DummyAWSService(aws_service.BaseAWSService):
         return instance
 
     def create_tags(self, resource_id, name=None, description=None):
+        if self.create_tags_callback:
+            self.create_tags_callback(resource_id, name, description)
         pass
 
     def stop_instance(self, instance_id):
@@ -173,6 +177,9 @@ class DummyAWSService(aws_service.BaseAWSService):
         return instance
 
     def terminate_instance(self, instance_id):
+        if self.terminate_instance_callback:
+            self.terminate_instance_callback(instance_id)
+
         instance = self.instances[instance_id]
         if self.terminate_instance_callback:
             self.terminate_instance_callback(instance)

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -523,3 +523,73 @@ class TestBrktEnv(unittest.TestCase):
         )
 
         self.assertEquals(3, self.call_count)
+
+    def test_clean_up_guest_instance(self):
+        """ Test that we clean up the guest instance if an exception is
+        raised inside run_guest_instance().
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        self.guest_instance_id = None
+        self.guest_terminated = False
+
+        def run_instance_callback(args):
+            if args.image_id == guest_image.id:
+                self.guest_instance_id = args.instance.id
+
+        def create_tags_callback(resource_id, name, description):
+            if resource_id == self.guest_instance_id:
+                raise TestException()
+
+        def terminate_instance_callback(instance_id):
+            if instance_id == self.guest_instance_id:
+                self.guest_terminated = True
+
+        aws_svc.run_instance_callback = run_instance_callback
+        aws_svc.create_tags_callback = create_tags_callback
+        aws_svc.terminate_instance_callback = terminate_instance_callback
+
+        with self.assertRaises(TestException):
+            encrypt_ami.encrypt(
+                aws_svc=aws_svc,
+                enc_svc_cls=DummyEncryptorService,
+                image_id=guest_image.id,
+                encryptor_ami=encryptor_image.id
+            )
+
+        self.assertTrue(self.guest_terminated)
+
+    def test_clean_up_encryptor_instance(self):
+        """ Test that we clean up the encryptor instance if an exception is
+        raised inside _run_encryptor_instance().
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        self.encryptor_instance_id = None
+        self.encryptor_terminated = False
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                self.encryptor_instance_id = args.instance.id
+
+        def create_tags_callback(resource_id, name, description):
+            if resource_id == self.encryptor_instance_id:
+                raise TestException()
+
+        def terminate_instance_callback(instance_id):
+            if instance_id == self.encryptor_instance_id:
+                self.encryptor_terminated = True
+
+        aws_svc.run_instance_callback = run_instance_callback
+        aws_svc.create_tags_callback = create_tags_callback
+        aws_svc.terminate_instance_callback = terminate_instance_callback
+
+        with self.assertRaises(TestException):
+            encrypt_ami.encrypt(
+                aws_svc=aws_svc,
+                enc_svc_cls=DummyEncryptorService,
+                image_id=guest_image.id,
+                encryptor_ami=encryptor_image.id
+            )
+
+        self.assertTrue(self.encryptor_terminated)


### PR DESCRIPTION
Do a better job of cleaning up the guest and encryptor instances.  We
didn't handle the case where an exception was thrown inside
run_guest_instance() or _run_encryptor_instance().  Add exception
handling and cleanup inside both of those functions.