### PR TITLE
Don't allow oauth2client 3.x or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto == 2.38.0
 cryptography >= 1.3.2
 google-api-python-client >= 1.5.1
 iso8601 >= 0.1.11
-oauth2client >= 2.0.0
+oauth2client < 3, >= 2.0.0
 oauthlib >= 1.1.1
 pyasn1 >= 0.1.9
 pyjwt >= 1.4.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'cryptography>=1.3.2',
         'google-api-python-client>=1.5.0',
         'iso8601>=0.1.11',
-        'oauth2client>=2.0.0',
+        'oauth2client<3,>= 2.0.0',
         'oauthlib>=1.1.0',
         'pyasn1>=0.1.9',
         'pyjwt>=1.4.0',


### PR DESCRIPTION
google-api-python-client doesn't support oauth2client version 3 or
later.  Update the requirements list so that we use the latest 2.x
version.