### PR TITLE
Add method to validate if GCE project exists

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -240,6 +240,8 @@ def check_args(values, gce_svc):
         raise ValidationError('Must provide a token')
 
     if values.validate:
+        if not gce_svc.project_exists(values.project):
+            raise ValidationError("Project provided does not exist")
         if not gce_svc.network_exists(values.network):
             raise ValidationError("Network provided does not exist")
         brkt_env = brkt_cli.brkt_env_from_values(values)

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -86,6 +86,10 @@ class BaseGCEService(object):
         pass
 
     @abc.abstractmethod
+    def project_exists(self, project):
+        pass
+
+    @abc.abstractmethod
     def delete_instance(self, zone, instance):
         pass
 
@@ -261,6 +265,16 @@ class GCEService(BaseGCEService):
     def image_exists(self, image, image_project=None):
         try:
             self.get_image(image, image_project)
+        except:
+            return False
+        return True
+
+    def get_project(self, project):
+        return self.compute.projects().get(project=project).execute()
+
+    def project_exists(self, project=None):
+        try:
+            self.get_project(project)
         except:
             return False
         return True
@@ -625,6 +639,7 @@ def validate_images(gce_svc, encrypted_image_name, encryptor, guest_image, image
     # check that there is no existing image named encrypted_image_name
     if gce_svc.image_exists(encrypted_image_name):
         raise ValidationError('An image already exists with name %s. Encryption Failed.' % encrypted_image_name)
+
 
 
 def validate_image_name(name):

--- a/test_gce.py
+++ b/test_gce.py
@@ -77,6 +77,11 @@ class DummyGCEService(gce_service.BaseGCEService):
             return True
         else:
             return False
+            
+    def project_exists(self, project=None):
+        if project == 'testproject':
+            return True
+        return False
 
     def delete_instance(self, zone, instance):
         if instance in self.instances:


### PR DESCRIPTION
Provide a more meaningful error if the GCE project entered is invalid. This was tested locally.