### PR TITLE
Remove default value for update-encrypted-ami --region

### DIFF
--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -64,7 +64,6 @@ def setup_update_encrypted_ami(parser):
         metavar='REGION',
         help='AWS region (e.g. us-west-2)',
         dest='region',
-        default='us-west-2',
         required=True
     )
     parser.add_argument(


### PR DESCRIPTION
We shouldn't assume that the user wants to run in a given region.