### PR TITLE
Add support for user-specified environments stored in config

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -261,6 +261,7 @@ class EncryptAMISubcommand(Subcommand):
         return values.encrypt_ami_verbose
 
     def register(self, subparsers, parsed_config):
+        self.config = parsed_config
         encrypt_ami_parser = subparsers.add_parser(
             'encrypt-ami',
             description='Create an encrypted AMI from an existing AMI.',
@@ -330,7 +331,7 @@ class EncryptAMISubcommand(Subcommand):
             security_group_ids=values.security_group_ids,
             guest_instance_type=values.guest_instance_type,
             instance_config=instance_config_from_values(
-                values, mode=INSTANCE_CREATOR_MODE),
+                values, mode=INSTANCE_CREATOR_MODE, cli_config=self.config),
             status_port=values.status_port,
             save_encryptor_logs=values.save_encryptor_logs
         )
@@ -354,6 +355,7 @@ class UpdateAMISubcommand(Subcommand):
         return values.update_encrypted_ami_verbose
 
     def register(self, subparsers, parsed_config):
+        self.config = parsed_config
         update_encrypted_ami_parser = subparsers.add_parser(
             'update-encrypted-ami',
             description=(
@@ -456,7 +458,7 @@ class UpdateAMISubcommand(Subcommand):
             guest_instance_type=values.guest_instance_type,
             updater_instance_type=values.updater_instance_type,
             instance_config=instance_config_from_values(
-                values, mode=INSTANCE_UPDATER_MODE),
+                values, mode=INSTANCE_UPDATER_MODE, cli_config=self.config),
             status_port=values.status_port,
         )
         print(updated_ami_id)

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -82,10 +82,13 @@ def _bracket_environment_from_dict(d):
     :return a BracketEnvironment object
     """
     benv = brkt_cli.BracketEnvironment()
-    key_attr = zip(
-        ('api', 'keyserver', 'public-api', 'network'),
-        ('api', 'hsmproxy', 'public_api', 'network'))
-    for k, attr in key_attr:
+    key_attr = {
+        'api': 'api',
+        'keyserver': 'hsmproxy',
+        'public-api': 'public_api',
+        'network': 'network',
+    }
+    for k, attr in key_attr.iteritems():
         for suff in ('host', 'port'):
             fk = k + '-' + suff
             if fk in d:
@@ -366,7 +369,7 @@ class ConfigSubcommand(Subcommand):
         # Define or update an environment
         set_env_parser = config_subparsers.add_parser(
             'set-env',
-            help='update the attributes of an environment',
+            help='Update the attributes of an environment',
             description="""
 Update the attributes of an environment
 
@@ -398,37 +401,44 @@ The leading `*' indicates that the `stage' environment is currently active.
             formatter_class=argparse.RawDescriptionHelpFormatter)
         set_env_parser.add_argument(
             'env_name',
-            help='the environment name (e.g. stage)')
+            help='The environment name (e.g. stage)')
         set_env_parser.add_argument(
             '--api-server',
-            help='the api server (host[:port]) the metavisor will connect to')
+            help='The api server (host[:port]) the metavisor will connect to')
         set_env_parser.add_argument(
             '--key-server',
-            help='the key server (host[:port]) the metavisor will connect to')
+            help='The key server (host[:port]) the metavisor will connect to')
         set_env_parser.add_argument(
             '--network-server',
-            help='the network server (host[:port]) the metavisor will connect to')
+            help='The network server (host[:port]) the metavisor will connect to')
         set_env_parser.add_argument(
             '--public-api-server',
-            help='the public api (host[:port])')
+            help='The public api (host[:port])')
         set_env_parser.add_argument(
             '--service-domain',
-            help='set server values from the service domain')
+            help=('Set server values from the service domain. This option '
+                  ' assumes that each server is resolvable via a hostname'
+                  ' rooted at service-domain. Specifically, api is expected to'
+                  ' live at yetiapi.<service-domain>, key-server at '
+                  ' hsmproxy.<service-domain>, network at '
+                  ' network.<service-domain>, and public-api-server at'
+                  ' api.<service-domain>.')
+            )
 
         # Set the active environment
         use_env_parser = config_subparsers.add_parser(
             'use-env',
-            help='set the active environment',
+            help='Set the active environment',
             description='Set the active environment',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         use_env_parser.add_argument(
             'env_name',
-            help='the environment name (e.g. stage)')
+            help='The environment name (e.g. stage)')
 
         # Display all defined environments
         config_subparsers.add_parser(
             'list-envs',
-            help='display all environments',
+            help='Display all environments',
             description=(
                 "Display all environments. The leading `*' indicates"
                 " the currently active environment."))
@@ -436,21 +446,21 @@ The leading `*' indicates that the `stage' environment is currently active.
         # Get the details of a specific environment
         get_env_parser = config_subparsers.add_parser(
             'get-env',
-            help='display the details of a specific environment',
+            help='Display the details of a specific environment',
             description='Display the details of an environment',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         get_env_parser.add_argument(
             'env_name',
-            help='the environment name')
+            help='The environment name')
 
         # Unset a specific environment
         unset_env_parser = config_subparsers.add_parser(
             'unset-env',
-            help='delete an environment',
+            help='Delete an environment',
             description='Delete an environment')
         unset_env_parser.add_argument(
             'env_name',
-            help='the environment name')
+            help='The environment name')
 
     def _unlink_noraise(self, path):
         try:

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -21,8 +21,10 @@ import sys
 import tempfile
 import yaml
 
+import brkt_cli
+
 from brkt_cli.subcommand import Subcommand
-from brkt_cli.util import render_table_rows
+from brkt_cli.util import parse_endpoint, render_table_rows
 from brkt_cli.validation import ValidationError
 
 log = logging.getLogger(__name__)
@@ -30,12 +32,79 @@ log = logging.getLogger(__name__)
 CONFIG_DIR = os.path.expanduser('~/.brkt')
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config')
 
-VERSION = 1
+VERSION = 2
 
 
 class InvalidOptionError(Exception):
     def __init__(self, option):
         self.option = option
+
+
+class UnknownEnvironmentError(Exception):
+    def __init__(self, env):
+        self.env = env
+
+
+class InvalidEnvironmentError(Exception):
+    def __init__(self, missing_keys):
+        self.missing_keys = missing_keys
+
+
+BRKT_HOSTED_ENV_NAME = 'brkt-hosted'
+
+
+def _bracket_environment_to_dict(benv):
+    """Convert a BracketEnvironment object to a dictionary that can be stored
+    in a config.
+
+    :param benv a BracketEnvironment object
+
+    :return a dictionary
+    """
+    return {
+        'api-host': benv.api_host,
+        'api-port': benv.api_port,
+        'keyserver-host': benv.hsmproxy_host,
+        'keyserver-port': benv.hsmproxy_port,
+        'public-api-host': benv.public_api_host,
+        'public-api-port': benv.public_api_port,
+        'network-host': benv.network_host,
+        'network-port': benv.network_port,
+    }
+
+
+def _bracket_environment_from_dict(d):
+    """Convert a bracket environment from the config into a BracketEnvironment
+    object
+
+    :param d a dictionary
+
+    :return a BracketEnvironment object
+    """
+    benv = brkt_cli.BracketEnvironment()
+    key_attr = zip(
+        ('api', 'keyserver', 'public-api', 'network'),
+        ('api', 'hsmproxy', 'public_api', 'network'))
+    for k, attr in key_attr:
+        for suff in ('host', 'port'):
+            fk = k + '-' + suff
+            if fk in d:
+                setattr(benv, attr + '_' + suff, d[fk])
+    return benv
+
+
+def _validate_environment(benv):
+    """Make sure all the necessary attributes of an environment are set.
+
+    :raises InvalidEnvironmentError
+    """
+    attrs = ('api_host', 'hsmproxy_host', 'public_api_host', 'network_host')
+    missing = []
+    for attr in attrs:
+        if getattr(benv, attr) is None:
+            missing.append(attr)
+    if len(missing) > 0:
+        raise InvalidEnvironmentError(missing)
 
 
 class CLIConfig(object):
@@ -45,10 +114,75 @@ class CLIConfig(object):
 
     def __init__(self):
         self._config = {
+            'current-environment': None,
+            'environments': {},
+            'options': {},
             'version': VERSION,
-            'options': {}
         }
+        self._add_prod_env()
         self._registered_options = collections.defaultdict(dict)
+
+    def _get_env(self, env_name):
+        if env_name not in self._config['environments']:
+            raise UnknownEnvironmentError(env_name)
+        d = self._config['environments'][env_name]
+        return _bracket_environment_from_dict(d)
+
+    def set_env(self, name, env):
+        """Update the named environment.
+
+        :param name the environment name (e.g. stage)
+        :param env a BracketEnvironment instance
+        """
+        d = _bracket_environment_to_dict(env)
+        self._config['environments'][name] = d
+
+    def get_current_env(self):
+        """Return the current environment.
+
+        :return a tuple of environment name, BracketEnvironment
+        """
+        env_name = self._config['current-environment']
+        return env_name, self.get_env(env_name)
+
+    def set_current_env(self, env_name):
+        """Change the current environment
+
+        :param env_name the named env
+        """
+        env = self._get_env(env_name)
+        _validate_environment(env)
+        self._config['current-environment'] = env_name
+
+    def get_env_meta(self):
+        """Return all defined environments"""
+        meta = {}
+        for env_name in self._config['environments'].iterkeys():
+            meta[env_name] = {
+                'is_current': self._config['current-environment'] == env_name
+            }
+        return meta
+
+    def get_env(self, env_name):
+        """Return the named environment
+
+        :param env_name a string
+
+        :return a BracketEnvironment instance
+        :raises UnknownEnvironmentError
+        """
+        return self._get_env(env_name)
+
+    def unset_env(self, env_name):
+        """Delete the named environment
+
+        :param env_name a string
+        :raises UnknownEnvironmentError
+        """
+        self._get_env(env_name)
+        del self._config['environments'][env_name]
+        if self._config['current-environment'] == env_name:
+            self._config['current-environment'] = BRKT_HOSTED_ENV_NAME
 
     def _check_option(self, option):
         if option not in self._registered_options:
@@ -121,12 +255,27 @@ class CLIConfig(object):
         # Clean up any empty sub-sections
         self._remove_empty_dicts(self._config['options'])
 
+    def _migrate_config(self, config):
+        """Handle migrating between different config versions"""
+        if config['version'] == 1:
+            config['environments'] = {}
+            config['version'] = VERSION
+        return config
+
+    def _add_prod_env(self):
+        prod_env = brkt_cli.get_prod_brkt_env()
+        prod_dict = _bracket_environment_to_dict(prod_env)
+        self._config['environments'][BRKT_HOSTED_ENV_NAME] = prod_dict
+        if self._config['current-environment'] is None:
+            self._config['current-environment'] = BRKT_HOSTED_ENV_NAME
+
     def read(self):
         """Read the config from disk"""
         try:
             with open(CONFIG_PATH) as f:
                 config = yaml.safe_load(f)
-            self._config = config
+            self._config = self._migrate_config(config)
+            self._add_prod_env()
         except IOError as e:
             if e.errno != errno.ENOENT:
                 raise
@@ -214,6 +363,95 @@ class ConfigSubcommand(Subcommand):
             'option',
             help='The option name (e.g. encrypt-gce-image.project)')
 
+        # Define or update an environment
+        set_env_parser = config_subparsers.add_parser(
+            'set-env',
+            help='update the attributes of an environment',
+            description="""
+Update the attributes of an environment
+
+Environments are persisted in your configuration and can be activated via the
+`use-env` config subcommand. This command is particularly helpful if you need
+to work with multiple on-prem control-plane deployments. For example, we could
+define stage and prod control planes hosted at stage.foo.com and prod.foo.com,
+respectively, by executing:
+
+    > brkt config set-env stage --service-domain stage.foo.com
+    > brkt config set-env prod --service-domain prod.foo.com
+
+We can switch between the environments using the `use-env` config subcommand
+like so:
+
+    > brkt config use-env stage
+
+We can determine the current environment using the `list-envs` config
+subcommand:
+
+    > brkt config list-envs
+      brkt-hosted
+      prod
+    * stage
+    >
+
+The leading `*' indicates that the `stage' environment is currently active.
+""",
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        set_env_parser.add_argument(
+            'env_name',
+            help='the environment name (e.g. stage)')
+        set_env_parser.add_argument(
+            '--api-server',
+            help='the api server (host[:port]) the metavisor will connect to')
+        set_env_parser.add_argument(
+            '--key-server',
+            help='the key server (host[:port]) the metavisor will connect to')
+        set_env_parser.add_argument(
+            '--network-server',
+            help='the network server (host[:port]) the metavisor will connect to')
+        set_env_parser.add_argument(
+            '--public-api-server',
+            help='the public api (host[:port])')
+        set_env_parser.add_argument(
+            '--service-domain',
+            help='set server values from the service domain')
+
+        # Set the active environment
+        use_env_parser = config_subparsers.add_parser(
+            'use-env',
+            help='set the active environment',
+            description='Set the active environment',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        use_env_parser.add_argument(
+            'env_name',
+            help='the environment name (e.g. stage)')
+
+        # Display all defined environments
+        config_subparsers.add_parser(
+            'list-envs',
+            help='display all environments',
+            description=(
+                "Display all environments. The leading `*' indicates"
+                " the currently active environment."))
+
+        # Get the details of a specific environment
+        get_env_parser = config_subparsers.add_parser(
+            'get-env',
+            help='display the details of a specific environment',
+            description='Display the details of an environment',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        get_env_parser.add_argument(
+            'env_name',
+            help='the environment name')
+
+        # Unset a specific environment
+        unset_env_parser = config_subparsers.add_parser(
+            'unset-env',
+            help='delete an environment',
+            description='Delete an environment')
+        unset_env_parser.add_argument(
+            'env_name',
+            help='the environment name')
+
     def _unlink_noraise(self, path):
         try:
             os.unlink(path)
@@ -283,6 +521,100 @@ class ConfigSubcommand(Subcommand):
         self._write_config()
         return 0
 
+    def _set_env(self, values):
+        """Update attributes for the named environment"""
+        if values.env_name == BRKT_HOSTED_ENV_NAME:
+            raise ValidationError(
+                'Error: cannot modify environment ' + values.env_name)
+        try:
+            env = self.parsed_config.get_env(values.env_name)
+        except UnknownEnvironmentError:
+            env = brkt_cli.BracketEnvironment()
+        opt_attr = {
+            'api': 'api',
+            'key': 'hsmproxy',
+            'public_api': 'public_api',
+            'network': 'network',
+        }
+        for k in opt_attr.iterkeys():
+            endpoint = k + '_server'
+            endpoint = getattr(values, endpoint)
+            if endpoint is None:
+                continue
+            try:
+                parts = parse_endpoint(endpoint)
+            except ValueError:
+                raise ValidationError('Error: Invalid value for option --' + k + '-server')
+            setattr(env, opt_attr[k] + '_host', parts['host'])
+            setattr(env, opt_attr[k] + '_port', parts.get('port', 443))
+        if values.service_domain is not None:
+            env = brkt_cli.brkt_env_from_domain(values.service_domain)
+        self.parsed_config.set_env(values.env_name, env)
+        self._write_config()
+        return 0
+
+    def _use_env(self, values):
+        """Set the active environemnt"""
+        try:
+            self.parsed_config.set_current_env(values.env_name)
+        except UnknownEnvironmentError:
+            raise ValidationError('Error: unknown environment ' + values.env_name)
+        except InvalidEnvironmentError, e:
+            attr_opt = {
+                'api_host': 'api-server',
+                'hsmproxy_host': 'key-server',
+                'public_api_host': 'public-api-server',
+                'network_host': 'network',
+            }
+            msg = ("Error: the environment %s is missing values for %s."
+                   " Use `brkt config set-env` to set the appropriate values.")
+            opts = []
+            for attr in e.missing_keys:
+                opts.append(attr_opt[attr])
+            raise ValidationError(msg % (values.env_name, ', '.join(opts)))
+        self._write_config()
+
+    def _list_envs(self):
+        """Display all envs"""
+        meta = self.parsed_config.get_env_meta()
+        rows = []
+        for env_name in sorted(meta.keys()):
+            marker = ' '
+            if meta[env_name]['is_current']:
+                marker = '*'
+            rows.append((marker, env_name))
+        self.stdout.write(render_table_rows(rows) + "\n")
+
+    def _get_env(self, values):
+        """Display the details of an environment"""
+        try:
+            env = self.parsed_config.get_env(values.env_name)
+        except UnknownEnvironmentError:
+            raise ValidationError('Error: unknown environment ' + values.env_name)
+        attr_opt = {
+            'api': 'api',
+            'hsmproxy': 'key',
+            'public_api': 'public-api',
+            'network': 'network',
+        }
+        for k in sorted(attr_opt.keys()):
+            host = getattr(env, k + '_host')
+            if host is None:
+                continue
+            port = getattr(env, k + '_port')
+            self.stdout.write("%s-server=%s:%d\n" % (attr_opt[k], host, port))
+
+    def _unset_env(self, values):
+        """Delete the named environment"""
+        if values.env_name == BRKT_HOSTED_ENV_NAME:
+            raise ValidationError(
+                'Error: cannot delete environment ' + values.env_name)
+        try:
+            self.parsed_config.unset_env(values.env_name)
+        except UnknownEnvironmentError:
+            raise ValidationError('Error: unknown environment ' + values.env_name)
+        self._write_config()
+
     def run(self, values):
         subcommand = values.config_subcommand
         if subcommand == 'list':
@@ -293,6 +625,16 @@ class ConfigSubcommand(Subcommand):
             self._get_option(values.option)
         elif subcommand == 'unset':
             self._unset_option(values.option)
+        elif subcommand == 'set-env':
+            self._set_env(values)
+        elif subcommand == 'use-env':
+            self._use_env(values)
+        elif subcommand == 'list-envs':
+            self._list_envs()
+        elif subcommand == 'get-env':
+            self._get_env(values)
+        elif subcommand == 'unset-env':
+            self._unset_env(values)
         return 0
 
 

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -2,7 +2,12 @@ import argparse
 import StringIO
 import unittest
 
-from brkt_cli.config import CLIConfig, ConfigSubcommand
+from brkt_cli.config import (
+    BRKT_HOSTED_ENV_NAME,
+    CLIConfig,
+    ConfigSubcommand,
+    UnknownEnvironmentError
+)
 from brkt_cli.validation import ValidationError
 
 
@@ -28,6 +33,42 @@ class UnsetValues(object):
 class ListValues(object):
     def __init__(self):
         self.config_subcommand = 'list'
+
+
+class GetEnvValues(object):
+    def __init__(self, env_name):
+        self.config_subcommand = 'get-env'
+        self.env_name = env_name
+
+
+class SetEnvValues(object):
+    def __init__(self, env_name, api_server=None, key_server=None,
+                 network_server=None, public_api_server=None,
+                 service_domain=None):
+        self.config_subcommand = 'set-env'
+        self.env_name = env_name
+        self.api_server = api_server
+        self.key_server = key_server
+        self.network_server = network_server
+        self.public_api_server = public_api_server
+        self.service_domain = service_domain
+
+
+class UnsetEnvValues(object):
+    def __init__(self, env_name):
+        self.config_subcommand = 'unset-env'
+        self.env_name = env_name
+
+
+class ListEnvsValues(object):
+    def __init__(self):
+        self.config_subcommand = 'list-envs'
+
+
+class UseEnvValues(object):
+    def __init__(self, env_name):
+        self.config_subcommand = 'use-env'
+        self.env_name = env_name
 
 
 def noop():
@@ -103,3 +144,139 @@ class ConfigCommandTestCase(unittest.TestCase):
 
         self.cmd.run(UnsetValues(opt2))
         self.assertEquals(self.cfg._config['options'], {})
+
+    def test_get_default_env(self):
+        """Verify that the brkt hosted environment is present by default"""
+        self.cmd.run(GetEnvValues('brkt-hosted'))
+        exp = "\n".join([
+            'api-server=yetiapi.mgmt.brkt.com:443',
+            'key-server=hsmproxy.mgmt.brkt.com:443',
+            'network-server=network.mgmt.brkt.com:443',
+            'public-api-server=api.mgmt.brkt.com:443'])
+        self.assertEqual(self.out.getvalue(), exp + "\n")
+
+    def test_set_default_env(self):
+        """Verify that you cannot alter the default environment"""
+        with self.assertRaises(ValidationError):
+            self.cmd.run(SetEnvValues(BRKT_HOSTED_ENV_NAME))
+
+    def test_set_env_from_service_domain(self):
+        """Verify that you can define an environment using its service
+        domain.
+        """
+        service_domain = 'foo.com'
+        self.cmd.run(SetEnvValues('test', service_domain=service_domain))
+        env = self.cfg.get_env('test')
+        attr_host = {
+            'api': 'yetiapi',
+            'hsmproxy': 'hsmproxy',
+            'network': 'network',
+            'public_api': 'api',
+        }
+        for attr, host in attr_host.iteritems():
+            exp = "%s.%s" % (host, service_domain)
+            self.assertEqual(getattr(env, attr + '_host'), exp)
+
+    def test_set_env_hosts(self):
+        """Verify that you can set individual services of an environment"""
+        test_cases = {
+            'api': {
+                'host': 'api.test.com',
+                'port': 1,
+                'attr': 'api',
+            },
+            'key': {
+                'host': 'key.test.com',
+                'port': 2,
+                'attr': 'hsmproxy',
+            },
+            'network': {
+                'host': 'network.test.com',
+                'port': 3,
+                'attr': 'network',
+            },
+            'public_api': {
+                'host': 'public.test.com',
+                'port': 4,
+                'attr': 'public_api',
+            },
+        }
+        for arg, tc in test_cases.iteritems():
+            kwargs = {
+                arg + '_server': '%s:%d' % (tc['host'], tc['port']),
+            }
+            self.cmd.run(SetEnvValues('test', **kwargs))
+            env = self.cfg.get_env('test')
+            host_attr = getattr(env, tc['attr'] + '_host')
+            self.assertEqual(tc['host'], host_attr)
+            port_attr = getattr(env, tc['attr'] + '_port')
+            self.assertEqual(tc['port'], port_attr)
+
+    def test_unset_unknown_env(self):
+        """Verify that an error is raised when attempting to delete
+        an unknown environment.
+        """
+        with self.assertRaises(ValidationError):
+            self.cmd.run(UnsetEnvValues('unknown'))
+
+    def test_unset_known_env(self):
+        """Verify that we can delete an environment we have created
+        """
+        self.cmd.run(SetEnvValues('test', service_domain='foo.com'))
+        self.cfg.get_env('test')
+        self.cmd.run(UnsetEnvValues('test'))
+        with self.assertRaises(UnknownEnvironmentError):
+            self.cfg.get_env('test')
+
+    def test_list_envs_default(self):
+        """Verify that the hosted environment is marked as the
+        active environment by default.
+        """
+        self.cmd.run(ListEnvsValues())
+        self.assertEqual(self.out.getvalue(), "* brkt-hosted\n")
+
+    def test_use_unknown_env(self):
+        """Verify that we raise an error when the user attempts to
+        activate an unknown environment.
+        """
+        with self.assertRaises(ValidationError):
+            self.cmd.run(UseEnvValues('unknown'))
+
+    def test_use_env(self):
+        """Verify that we can switch between defined environments"""
+        self.cmd.run(SetEnvValues('test1', service_domain='foo.com'))
+        self.cmd.run(SetEnvValues('test2', service_domain='bar.com'))
+        self.cmd.run(ListEnvsValues())
+        out = "\n".join([
+            "* brkt-hosted",
+            "  test1      ",
+            "  test2      "
+        ])
+        self.assertEqual(self.out.getvalue(), out + "\n")
+        self.cmd.run(UseEnvValues('test2'))
+        self.out.truncate(0)
+        self.cmd.run(ListEnvsValues())
+        out = "\n".join([
+            "  brkt-hosted",
+            "  test1      ",
+            "* test2      "
+        ])
+        self.assertEqual(self.out.getvalue(), out + "\n")
+
+    def test_use_incomplete_env(self):
+        """Verify that we raise an error if a user attempts to
+        use an incomplete environment.
+        """
+        self.cmd.run(SetEnvValues('test1', api_server='test.com'))
+        with self.assertRaises(ValidationError):
+            self.cmd.run(UseEnvValues('test1'))
+
+    def test_fallback_env(self):
+        """Verify that we fall back to the hosted environment if
+        the user delete the current environment.
+        """
+        self.cmd.run(SetEnvValues('test1', service_domain='test.com'))
+        self.cmd.run(UseEnvValues('test1'))
+        self.cmd.run(UnsetEnvValues('test1'))
+        self.cmd.run(ListEnvsValues())
+        self.assertEqual(self.out.getvalue(), "* brkt-hosted\n")

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -87,7 +87,6 @@ def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE,
         parser.add_argument(
             '--brkt-env',
             dest='brkt_env',
-            default=brkt_env_default,
             help=argparse.SUPPRESS
         )
 
@@ -136,12 +135,14 @@ def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE,
     )
 
 
-def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE):
+def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
+                                cli_config=None):
     """ Return an InstanceConfig object, based on options specified on
     the command line and Metavisor mode.
 
     :param values an argparse.Namespace object
     :param mode the mode in which Metavisor is running
+    :param cli_config an brkt_cli.config.CLIConfig instance
     """
     brkt_config = {}
     if not values:
@@ -157,6 +158,10 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE):
         # If the Yeti environment was not specified, use the production
         # environment.
         brkt_env = brkt_cli.brkt_env_from_values(values)
+        if cli_config is not None and brkt_env is None:
+            name, brkt_env = cli_config.get_current_env()
+            log.info('Using %s environment', name)
+            log.debug(brkt_env)
         config_brkt_env = brkt_env or brkt_cli.get_prod_brkt_env()
         add_brkt_env_to_brkt_config(config_brkt_env, brkt_config)
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -237,6 +237,7 @@ def render_table_rows(rows, row_prefix=''):
     rendered.
     :param row_prefix an optional string that will be prepended to each
     row after it has been rendered.
+
     :return the rows rendered as a string.
     """
     if len(rows) == 0:
@@ -254,3 +255,30 @@ def render_table_rows(rows, row_prefix=''):
         lines.append(row_prefix + fmt.format(*row))
     table = "\n".join(lines)
     return table
+
+
+def parse_endpoint(endpoint):
+    """Parse a <host>[:<port>] string into its constituent parts.
+
+    :param endpoint a string of the form <host>[:<port>]
+
+    :return a dictionary of the form {"hostname": <hostname>, "port": <port>}
+        The "port" key will only exist if it is parsed from endpoint.
+
+    :raises ValueError if an invalid string is supplied.
+
+    """
+
+    host_port_pattern = r'([^:]+)(:\d+)?$'
+    m = re.match(host_port_pattern, endpoint)
+    if not m:
+        raise ValueError('Invalid endpoint: ' + endpoint)
+    elif not validate_dns_name_ip_address(m.group(1)):
+        raise ValidationError('Invalid hostname: ' + m.group(1))
+    groups = m.groups()
+    ret = {
+        'host': groups[0],
+    }
+    if groups[1] is not None:
+        ret['port'] = int(groups[1][1:])
+    return ret


### PR DESCRIPTION
This commit makes environment a first class concept in the CLI. Environments are
defined as the set of Yeti backends that the CLI/MV talk to. Users declare new
environments via the `set-env` config subcommand. For example, to define the
`foo.com` environment, one does:

    > brkt config set-env foo --service-domain foo.com

Use the `use-env` config subcommand to switch between environments:

    > brkt config use-env stage

Use the `list-envs` config subcommand to list all the declared environments. A
leading `*` indicates the current environment.

    > ./brkt config list-envs
      brkt-hosted
    * foo
    >

The `brkt-hosted` environment corresponds to our hosted production environment.
It is the default environment and may not be changed by users.

Use the `get-env` config subcommand to get the details of an environment:

    > ./brkt config get-env foo
    api-server=yetiapi.foo.com:443
    key-server=hsmproxy.foo.com:443
    network-server=network.foo.com:443
    public-api-server=api.foo.com:443
    >

Finally, use the `unset-env` config subcommand to delete an environment:

    > ./brkt config unset-env foo