### PR TITLE
Clean up brkt_env defaulting

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -27,9 +27,6 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
-BRKT_ENV_PROD = 'yetiapi.mgmt.brkt.com:443,hsmproxy.mgmt.brkt.com:443'
-
-
 class EncryptGCEImageSubcommand(Subcommand):
 
     def name(self):
@@ -56,8 +53,7 @@ class EncryptGCEImageSubcommand(Subcommand):
         )
         encrypt_gce_image_args.setup_encrypt_gce_image_args(
             encrypt_gce_image_parser, parsed_config)
-        setup_instance_config_args(encrypt_gce_image_parser,
-                                   brkt_env_default=BRKT_ENV_PROD)
+        setup_instance_config_args(encrypt_gce_image_parser)
 
     def debug_log_to_temp_file(self):
         return True
@@ -120,8 +116,7 @@ class UpdateGCEImageSubcommand(Subcommand):
         )
         update_encrypted_gce_image_args.setup_update_gce_image_args(
             update_gce_image_parser)
-        setup_instance_config_args(update_gce_image_parser,
-                                   brkt_env_default=BRKT_ENV_PROD)
+        setup_instance_config_args(update_gce_image_parser)
 
     def debug_log_to_temp_file(self):
         return True

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -39,8 +39,7 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
-def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE,
-                               brkt_env_default=None):
+def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE):
     parser.add_argument(
         '--ntp-server',
         metavar='DNS Name',


### PR DESCRIPTION
* Delete BRKT_ENV_PROD as it is no longer used.
* Remove the default_brkt_env arg to setup_instance_config_args() as it is no longer used.

Testing:
* Ran unit tests
* Ran 'brkt encrypt-ami'