### PR TITLE
Add a hidden option for keeping the encryptor running after failure

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -333,7 +333,9 @@ class EncryptAMISubcommand(Subcommand):
             instance_config=instance_config_from_values(
                 values, mode=INSTANCE_CREATOR_MODE, cli_config=self.config),
             status_port=values.status_port,
-            save_encryptor_logs=values.save_encryptor_logs
+            save_encryptor_logs=values.save_encryptor_logs,
+            terminate_encryptor_on_failure=(
+                values.terminate_encryptor_on_failure)
         )
         # Print the AMI ID to stdout, in case the caller wants to process
         # the output.  Log messages go to stderr.

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -124,10 +124,21 @@ def setup_encrypt_ami_args(parser):
         help=argparse.SUPPRESS,
         default=0.25
     )
+
     parser.add_argument(
         '--save-encryptor-logs',
         dest='save_encryptor_logs',
         action='store_true',
         help=argparse.SUPPRESS,
         default=False
+    )
+
+    # Optional argument for development: if encryption fails, keep the
+    # encryptor running so that we can debug it.
+    parser.add_argument(
+        '--no-terminate-encryptor-on-failure',
+        dest='terminate_encryptor_on_failure',
+        action='store_false',
+        default=True,
+        help=argparse.SUPPRESS
     )

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -92,6 +92,7 @@ class DummyAWSService(aws_service.BaseAWSService):
         self.stop_instance_callback = None
         self.create_tags_callback = None
         self.terminate_instance_callback = None
+        self.delete_security_group_callback = None
 
     def get_regions(self):
         return self.regions
@@ -330,6 +331,8 @@ class DummyAWSService(aws_service.BaseAWSService):
         pass
 
     def delete_security_group(self, sg_id):
+        if self.delete_security_group_callback:
+            self.delete_security_group_callback(sg_id)
         pass
 
     def get_key_pair(self, keyname):


### PR DESCRIPTION
Add a hidden --no-terminate-encryptor-on-failure option.  When this
option is specified and encryption fails, we terminate the guest
instance but not the encryptor.  This allows a developer to connect to
the encryptor instance to diagnose the problem.