### PR TITLE
Remove unused encryptor_launched variable

### DIFF
--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -52,7 +52,6 @@ def do_encryption(gce_svc,
                   status_port=ENCRYPTOR_STATUS_PORT):
     metadata = gce_metadata_from_userdata(instance_config.make_userdata())
     log.info('Launching encryptor instance')
-    encryptor_launched = False
     gce_svc.run_instance(zone=zone,
                          name=encryptor,
                          image=encryptor_image,
@@ -60,7 +59,6 @@ def do_encryption(gce_svc,
                          disks=[gce_svc.get_disk(zone, instance_name),
                                 gce_svc.get_disk(zone, encrypted_image_disk)],
                          metadata=metadata)
-    encryptor_launched = True
 
     try:
         ip = gce_svc.get_instance_ip(encryptor, zone)
@@ -71,12 +69,11 @@ def do_encryption(gce_svc,
             encryptor, ip, enc_svc.port
         )
         wait_for_encryption(enc_svc)
-    except Exception as e:
-        if encryptor_launched:
-            f = gce_svc.write_serial_console_file(zone, encryptor)
-            if f:
-                log.info('Encryption failed. Writing console to %s' % f)
-        raise e
+    except:
+        f = gce_svc.write_serial_console_file(zone, encryptor)
+        if f:
+            log.info('Encryption failed. Writing console to %s' % f)
+        raise
     retry(function=gce_svc.delete_instance,
             on=[httplib.BadStatusLine, socket.error, errors.HttpError])(zone, encryptor)
 


### PR DESCRIPTION
This variable was set outside the try/except block, so it ended up being
a no-op.  Also don't pass the Exception argument to raise, to preserve
the original traceback.