### PR TITLE
Add --guest-fqdn option to make-user-data

### DIFF
--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -69,6 +69,15 @@ class MakeUserDataSubcommand(Subcommand):
             action='append',
             help=argparse.SUPPRESS
         )
+        # Certain customers need to set the FQDN of the guest instance, which
+        # is used by Metavisor as the CN field of the Subject DN in the cert
+        # requests it submits to an EST server (for North-South VPN tunneling).
+        parser.add_argument(
+            '--guest-fqdn',
+            metavar='FQDN',
+            dest='make_user_data_guest_fqdn',
+            help=argparse.SUPPRESS
+        )
 
     def verbose(self, values):
         return values.make_user_data_verbose
@@ -80,6 +89,11 @@ class MakeUserDataSubcommand(Subcommand):
         if values.make_user_data_brkt_files:
             _add_files_to_instance_config(instance_cfg,
                                           values.make_user_data_brkt_files)
+
+        if values.make_user_data_guest_fqdn:
+            instance_cfg.brkt_config['vpn_config'] = {
+                'guest_fqdn': values.make_user_data_guest_fqdn
+            }
 
         out.write(instance_cfg.make_userdata())
         return 0

--- a/brkt_cli/make_user_data/test_make_user_data.py
+++ b/brkt_cli/make_user_data/test_make_user_data.py
@@ -40,41 +40,56 @@ class TestMakeUserData(unittest.TestCase):
 
         knowngood_file = os.path.join(self.testdata_dir,
                                       self.test_name + ".out")
+        if not os.path.exists(knowngood_file):
+            print 'knowngood file does not exist: %s' % (knowngood_file)
+            print 'test_output = \n------\n%s\n------\n' % (output)
+            raise
+
         with open(knowngood_file, 'r') as f:
             knowngood = f.read()
 
         self.assertMultiLineEqual(output, knowngood)
 
-    def test_token_and_one_brkt_file(self):
+    def _init_values(self):
         values = instance_config_args_to_values('')
+        values.make_user_data_brkt_files = None
+        values.make_user_data_guest_fqdn = None
+        return values
+
+    def test_token_and_one_brkt_file(self):
+        values = self._init_values()
         values.token = 'THIS_IS_NOT_A_JWT'
         infile = os.path.join(self.testdata_dir, 'logging.yaml')
         values.make_user_data_brkt_files = [ infile ]
         self.run_cmd(values)
 
     def test_add_one_brkt_file(self):
-        values = instance_config_args_to_values('')
+        values = self._init_values()
         infile = os.path.join(self.testdata_dir, 'logging.yaml')
         values.make_user_data_brkt_files = [ infile ]
         self.run_cmd(values)
 
     def test_add_one_binary_brkt_file(self):
-        values = instance_config_args_to_values('')
+        values = self._init_values()
         infile = os.path.join(self.testdata_dir, 'rand_bytes.bin')
         values.make_user_data_brkt_files = [ infile ]
         self.run_cmd(values)
 
     def test_proxy_and_one_brkt_file(self):
-        values = instance_config_args_to_values('')
+        values = self._init_values()
         values.proxies = [ '10.2.3.4:3128' ]
         infile = os.path.join(self.testdata_dir, 'colors.json')
         values.make_user_data_brkt_files = [ infile ]
-        #values.make_user_data_brkt_files = None
         self.run_cmd(values)
 
     def test_add_two_brkt_files(self):
-        values = instance_config_args_to_values('')
+        values = self._init_values()
         infile1 = os.path.join(self.testdata_dir, 'logging.yaml')
         infile2 = os.path.join(self.testdata_dir, 'colors.json')
         values.make_user_data_brkt_files = [ infile1, infile2 ]
+        self.run_cmd(values)
+
+    def test_guest_fqdn(self):
+        values = self._init_values()
+        values.make_user_data_guest_fqdn = 'instance.foo.bar.com'
         self.run_cmd(values)

--- a/brkt_cli/make_user_data/testdata/test_guest_fqdn.out
+++ b/brkt_cli/make_user_data/testdata/test_guest_fqdn.out
@@ -1,0 +1,11 @@
+From nobody Tue Dec  3 19:00:57 2013
+Content-Type: multipart/mixed; boundary="--===============HI-20131203==--"
+MIME-Version: 1.0
+
+----===============HI-20131203==--
+Content-Type: text/brkt-config; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+{"brkt": {"vpn_config": {"guest_fqdn": "instance.foo.bar.com"}}}
+----===============HI-20131203==----


### PR DESCRIPTION
To allow customers to specify the instance's FQDN in the certs used for North-South (VPN) tunnels, add the "--guest-fqdn" option to make-user-data.