### PR TITLE
Use vpn.yaml brkt-file instead of brkt-config

### DIFF
--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -91,9 +91,8 @@ class MakeUserDataSubcommand(Subcommand):
                                           values.make_user_data_brkt_files)
 
         if values.make_user_data_guest_fqdn:
-            instance_cfg.brkt_config['vpn_config'] = {
-                'guest_fqdn': values.make_user_data_guest_fqdn
-            }
+            vpn_config = 'fqdn: %s\n' % (values.make_user_data_guest_fqdn,)
+            instance_cfg.add_brkt_file('vpn.yaml', vpn_config)
 
         out.write(instance_cfg.make_userdata())
         return 0

--- a/brkt_cli/make_user_data/testdata/test_guest_fqdn.out
+++ b/brkt_cli/make_user_data/testdata/test_guest_fqdn.out
@@ -7,5 +7,14 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"vpn_config": {"guest_fqdn": "instance.foo.bar.com"}}}
+{"brkt": {}}
+----===============HI-20131203==--
+Content-Type: text/brkt-files; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+/var/brkt/instance_config/vpn.yaml: {contents: 'fqdn: instance.foo.bar.com
+
+    '}
+
 ----===============HI-20131203==----


### PR DESCRIPTION
To convey the FQDN to use for North-South cert requests, pass in a vpn.yaml file (to be stored in /var/brkt/instance_config/) rather than putting the field in the brkt-config part.