### PR TITLE
Add sub-network to GCE image launch command

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -211,6 +211,7 @@ class LaunchGCEImageSubcommand(Subcommand):
                                 values.delete_boot,
                                 values.instance_type,
                                 values.network,
+                                values.subnetwork,
                                 metadata)
         return 0
 

--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -7,7 +7,7 @@ from brkt_cli.util import (
 
 log = logging.getLogger(__name__)
 
-def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, metadata={}):
+def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, subnetwork, metadata={}):
     if not instance_name:
         instance_name = 'brkt' + '-' + str(uuid.uuid4().hex)
 
@@ -25,6 +25,7 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_ty
                          metadata=metadata,
                          delete_boot=delete_boot,
                          network=network,
+                         subnet=subnetwork,
                          instance_type=instance_type)
     gce_svc.wait_instance(instance_name, zone)
     log.info("Instance %s (%s) launched successfully" % (instance_name,

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -42,11 +42,15 @@ def setup_launch_gce_image_args(parser):
     parser.add_argument(
         '--network',
         dest='network',
+        metavar='NAME',
+        help='Launch instance in this network',
         default='default',
         required=False
     )
     parser.add_argument(
         '--subnetwork',
+        metavar='NAME',
+        help='Launch instance in this subnetwork',
         dest='subnetwork',
         required=False
     )

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -45,6 +45,11 @@ def setup_launch_gce_image_args(parser):
         default='default',
         required=False
     )
+    parser.add_argument(
+        '--subnetwork',
+        dest='subnetwork',
+        required=False
+    )
 
     # Optional startup script. Hidden because it is only used for development
     # and testing. It should be passed as a string containing a multi-line


### PR DESCRIPTION
Provide a subnetwork argument to launch a GCE image in a specific subnet. This was tested in my personal account.