### PR TITLE
Re-add subnetwork argument to launch-gce-image

### DIFF
--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -55,3 +55,10 @@ def setup_launch_gce_image_args(parser):
         dest='startup_script',
         metavar='SCRIPT'
     )
+    parser.add_argument(
+        '--subnetwork',
+        metavar='NAME',
+        help='Launch instance in this subnetwork',
+        dest='subnetwork',
+        required=False
+    )


### PR DESCRIPTION
Re-adding the subnetwork argument to the launch-gce-image command.
This was accidentally removed in commit: a599ad9a6b4a4afdcdbcd67284efff9c2de34d16.
Tested this locally by launching a new GCE image.