### PR TITLE
Raise exceptions for missing environment variables.

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -45,6 +45,12 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
+def _check_env_vars_set(*var_names):
+    for n in var_names:
+        if not os.getenv(n):
+            raise ValidationError("Environment variable %s is not set" % (n,))
+
+
 class EncryptVMDKSubcommand(Subcommand):
 
     def name(self):
@@ -156,6 +162,7 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
             raise ValidationError("Encrypted image not provided")
     if (values.source_image_path is not None and values.image_name is None):
         raise ValidationError("Specify the Metavisor OVF file.")
+    _check_env_vars_set('VCENTER_USER_NAME', 'VCENTER_PASSWORD')
     brkt_cli.validate_ntp_servers(values.ntp_servers)
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
@@ -189,7 +196,7 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
             esx_host=values.esx_host,
             cluster_name=values.vcenter_cluster,
             no_of_cpus=values.no_of_cpus,
-            memoryGB=values.memoryGB,
+            memory_gb=values.memory_gb,
             session_id=session_id,
         )
     except Exception as e:
@@ -276,6 +283,7 @@ def command_encrypt_vmdk(values, parsed_config, log):
                                   "template VM")
     if (values.source_image_path is not None and values.image_name is None):
         raise ValidationError("Specify the Metavisor OVF file.")
+    _check_env_vars_set('VCENTER_USER_NAME', 'VCENTER_PASSWORD')
     brkt_cli.validate_ntp_servers(values.ntp_servers)
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
@@ -308,7 +316,7 @@ def command_encrypt_vmdk(values, parsed_config, log):
             esx_host=values.esx_host,
             cluster_name=values.vcenter_cluster,
             no_of_cpus=values.no_of_cpus,
-            memoryGB=values.memoryGB,
+            memory_gb=values.memory_gb,
             session_id=session_id,
         )
     except Exception as e:
@@ -399,10 +407,7 @@ def command_rescue_metavisor(values, parsed_config, log):
     if values.protocol != 'http':
         raise ValidationError("Unsupported rescue protocol %s",
                               values.protocol)
-    if os.getenv('VCENTER_USER_NAME') is None:
-        raise ValidationError("VCENTER_USER_NAME environment variable is not set")
-    if os.getenv('VCENTER_PASSWORD') is None:
-        raise ValidationError("VCENTER_PASSWORD environment variable is not set")
+    _check_env_vars_set('VCENTER_USER_NAME', 'VCENTER_PASSWORD')
     # Connect to vCenter
     try:
         vc_swc = esx_service.initialize_vcenter(
@@ -415,7 +420,7 @@ def command_rescue_metavisor(values, parsed_config, log):
             esx_host=False,
             cluster_name=values.vcenter_cluster,
             no_of_cpus=None,
-            memoryGB=None,
+            memory_gb=None,
             session_id=session_id,
         )
     except Exception as e:

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -64,8 +64,8 @@ def setup_encrypt_vmdk_args(parser):
     parser.add_argument(
         "--memory",
         help="Memory to assign to Encryptor VM",
-        metavar='N',
-        dest="GB",
+        metavar='GB',
+        dest="memory_gb",
         default="1",
         required=False)
     parser.add_argument(

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -471,10 +471,14 @@ class VCenterService(BaseVCenterService):
     def add_disk(self, vm, disk_size=12*1024*1024,
                  filename=None, unit_number=0):
         spec = vim.vm.ConfigSpec()
+        controller = None
         for dev in vm.config.hardware.device:
             if isinstance(dev, vim.vm.device.VirtualSCSIController):
                 controller = dev
                 break
+        if controller is None:
+            raise Exception("Did not find SCSI controller in the "
+                            "Encryptor VM %s" % (vm.config.name,))
         dev_changes = []
         disk_spec = vim.vm.device.VirtualDeviceSpec()
         disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
@@ -822,10 +826,10 @@ class VCenterService(BaseVCenterService):
 
 def initialize_vcenter(host, user, password, port,
                        datacenter_name, datastore_name, esx_host,
-                       cluster_name, no_of_cpus, memoryGB, session_id):
+                       cluster_name, no_of_cpus, memory_gb, session_id):
     vc_swc = VCenterService(host, user, password, port,
                             datacenter_name, datastore_name, esx_host,
-                            cluster_name, no_of_cpus, memoryGB, session_id)
+                            cluster_name, no_of_cpus, memory_gb, session_id)
     vc_swc.connect()
     return vc_swc
 

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -57,8 +57,8 @@ def setup_update_vmdk_args(parser):
     parser.add_argument(
         "--memory",
         help="Memory to assign to Encryptor VM",
-        metavar='N',
-        dest="GB",
+        metavar='GB',
+        dest="memory_gb",
         default="1",
         required=False)
     parser.add_argument(


### PR DESCRIPTION
1. Raise exception if environment variables for vcenter username and password are not set.
2. Gracefully exit if SCSI controller is not found in the Encryptor VM.
3. Fix the destination of memory variable.