### PR TITLE
Allow passing guest FQDN when launching GCE instances

### DIFF
--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -62,3 +62,9 @@ def setup_launch_gce_image_args(parser):
         dest='subnetwork',
         required=False
     )
+    parser.add_argument(
+        '--guest-fqdn',
+        metavar='FQDN',
+        dest='guest_fqdn',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -206,6 +206,9 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
         ca_cert_filename = 'ca_cert.pem.' + domain
         ic.add_brkt_file(ca_cert_filename, ca_cert_data)
 
+    if values.guest_fqdn:
+        ic.add_brkt_file('vpn.yaml', 'fqdn: ' + values.guest_fqdn)
+
     return ic
 
 

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -206,7 +206,7 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
         ca_cert_filename = 'ca_cert.pem.' + domain
         ic.add_brkt_file(ca_cert_filename, ca_cert_data)
 
-    if values.guest_fqdn:
+    if 'guest_fqdn' in values and values.guest_fqdn:
         ic.add_brkt_file('vpn.yaml', 'fqdn: ' + values.guest_fqdn)
 
     return ic


### PR DESCRIPTION
The guest FQDN is required for north-south configuration to get enabled on the instance. This option allows setting this user-data value when launching GCE instances. This is very useful in testing and potentially automation of north-south.
Was tested locally in my account.