### PR TITLE
Switch default bucket to prod bucket

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -119,13 +119,12 @@ def setup_encrypt_vmdk_args(parser):
         default="ovftool",
         required=False
     )
-    # TBD Change the name of the default bucket to prod
     parser.add_argument(
         '--bucket-name',
         metavar='NAME',
         dest='bucket_name',
         help='Name of the bucket containing the Metavisor OVF',
-        default="solo-brkt-164337164081-ovf-image",
+        default="solo-brkt-prod-ovf-image",
         required=False
     )
     parser.add_argument(

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -850,11 +850,9 @@ def download_ovf_from_s3(bucket_name, image_name=None):
             c_list = list(bucket.list("", "/"))
             dir_list = []
             for content in c_list:
-                dir_list.append(str(content.name))
-            try:
-                dir_list.remove('Users/')
-            except:
-                pass
+                dir_name = str(content.name)
+                if "release" in dir_name:
+                    dir_list.append(dir_name)
             image_name = (sorted(dir_list))[len(dir_list)-1]
         file_list_obj = list(bucket.list(image_name))
         if len(file_list_obj) is 0:

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -110,7 +110,7 @@ def setup_update_vmdk_args(parser):
         metavar='NAME',
         dest='bucket_name',
         help='Name of the bucket containing the Metavisor OVF',
-        default="solo-brkt-164337164081-ovf-image",
+        default="solo-brkt-prod-ovf-image",
         required=False
     )
     parser.add_argument(


### PR DESCRIPTION
1. Default ovf-image should be prod.
2. Only retain release directories in the bucket.