### PR TITLE
Add all common command line options to ESX

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -169,7 +169,6 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
         _, brkt_env = parsed_config.get_current_env()
     if not values.token:
         raise ValidationError('Must provide a token')
-    token = values.token
 
     # Download images from S3
     try:
@@ -208,10 +207,8 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
     try:
         instance_config = instance_config_from_values(
             values, mode=INSTANCE_UPDATER_MODE, cli_config=parsed_config)
-        user_data_str = vc_swc.create_userdata_str(
-            brkt_env, values.ntp_servers, instance_config,
-            token, values.ssh_public_key_file,
-            update=True)
+        user_data_str = vc_swc.create_userdata_str(instance_config,
+            update=True, ssh_key_file=values.ssh_public_key_file)
         if (values.encryptor_vmdk is not None):
             # Create from MV VMDK
             update_vmdk.update_from_vmdk(
@@ -290,7 +287,6 @@ def command_encrypt_vmdk(values, parsed_config, log):
         _, brkt_env = parsed_config.get_current_env()
     if not values.token:
         raise ValidationError('Must provide a token')
-    token = values.token
     # Download images from S3
     try:
         if (values.encryptor_vmdk is None and
@@ -345,10 +341,9 @@ def command_encrypt_vmdk(values, parsed_config, log):
     try:
         instance_config = instance_config_from_values(
             values, mode=INSTANCE_CREATOR_MODE, cli_config=parsed_config)
-        user_data_str = vc_swc.create_userdata_str(
-            brkt_env, values.ntp_servers, instance_config,
-            token, values.ssh_public_key_file,
-            update=False)
+        user_data_str = vc_swc.create_userdata_str(instance_config,
+            update=False, ssh_key_file=values.ssh_public_key_file)
+        import ipdb;ipdb.set_trace()
         if (values.encryptor_vmdk is not None):
             # Create from MV VMDK
             encrypt_vmdk.encrypt_from_vmdk(
@@ -426,8 +421,7 @@ def command_rescue_metavisor(values, parsed_config, log):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter ", e)
     try:
-        user_data_str = vc_swc.create_userdata_str(
-            None, None, None, None,
+        user_data_str = vc_swc.create_userdata_str(None,
             rescue_proto=values.protocol,
             rescue_url=values.url)
         rescue_metavisor.rescue_metavisor_vcenter(

--- a/brkt_cli/instance_config.py
+++ b/brkt_cli/instance_config.py
@@ -57,11 +57,7 @@ class InstanceConfig(object):
 
         self.brkt_config = brkt_config
         self._brkt_files = []
-        self._mode = mode
-        if mode is INSTANCE_METAVISOR_MODE:
-            self._brkt_files_dest_dir = BRKT_FILE_INSTANCE_CONFIG
-        else:
-            self._brkt_files_dest_dir = BRKT_FILE_AMI_CONFIG
+        self.set_mode(mode)
 
     def brkt_files_dest_dir(self):
         return self._brkt_files_dest_dir
@@ -71,6 +67,19 @@ class InstanceConfig(object):
         dest_path = posixpath.join(self._brkt_files_dest_dir, dest_filename)
         brkt_file = BrktFile(dest_path, file_contents)
         self._brkt_files.append(brkt_file)
+
+    def set_mode(self, mode=INSTANCE_CREATOR_MODE):
+        self._mode = mode
+        if mode is INSTANCE_METAVISOR_MODE:
+            self._brkt_files_dest_dir = BRKT_FILE_INSTANCE_CONFIG
+        else:
+            self._brkt_files_dest_dir = BRKT_FILE_AMI_CONFIG
+
+    def get_brkt_config(self):
+        return self.brkt_config
+
+    def set_brkt_config(self, brkt_config):
+        self.brkt_config = brkt_config
 
     def make_brkt_config_json(self):
         brkt_config_dict = {'brkt': self.brkt_config}


### PR DESCRIPTION
Passing userdata in MIME - as AWS & GCE do - allows ESX to use all shared
command line options (e.g. proxy settings). This change also removes
redundant logic in the ESX creation of userdata.