### PR TITLE
Fix teardown implementation

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -323,6 +323,8 @@ def command_encrypt_vmdk(values, parsed_config, log):
             raise ValidationError("VM with the same name as requested "
                                   "template VM name %s already exists" %
                                   values.template_vm_name)
+    # Set tear-down
+    vc_swc.set_teardown(values.no_teardown)
     # Set the disk-type
     if values.disk_type == "thin":
         vc_swc.set_thin_disk(True)

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -94,17 +94,18 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
             if target_path is None:
                 raise Exception("Cannot create ova/ovf as target path is None")
             ovf = vc_swc.export_to_ovf(vm, target_path, ovf_name=image_name)
-            log.info("OVF is at %s" % ovf)
             if create_ova is True:
                 if ovftool_path is not None:
                     ova = vc_swc.convert_ovf_to_ova(ovftool_path, ovf)
-                    log.info("OVA is at %s" % ova)
+                    print(ova)
+            else:
+                print(ovf)
         else:
             # clone the vm to create template
             if vc_swc.is_esx_host() is False:
                 log.info("Creating the template VM")
                 template_vm = vc_swc.clone_vm(vm, vm_name=vm_name, template=True)
-                log.info("template vm is %s", vc_swc.get_vm_name(template_vm))
+                print(vc_swc.get_vm_name(template_vm))
     except EncryptionError as e:
         log.exception("Failed to encrypt the image with error %s", e)
         try:

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -77,7 +77,6 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
                 os.system(rm_cmd)
             # import the new OVF
             ovf = vc_swc.export_to_ovf(guest_vm, target_path, ovf_name=ovf_name)
-            log.info("OVF is at %s" % ovf)
             if ova_name:
                 if ovftool_path is not None:
                     # delete the old ova
@@ -85,7 +84,9 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
                                                         ova_name + ".ova"))
                     os.system(rm_cmd)
                     ova = vc_swc.convert_ovf_to_ova(ovftool_path, ovf)
-                    log.info("OVA is at %s" % ova)
+                    print(ova)
+            else:
+                print(ovf)
         else:
             # delete the old vm template
             log.info("Deleting the old template")
@@ -96,7 +97,7 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
             log.info("Creating the template VM")
             template_vm = vc_swc.clone_vm(guest_vm, vm_name=template_vm_name,
                                           template=True)
-            log.info("template vm is %s", vc_swc.get_vm_name(template_vm))
+            print(vc_swc.get_vm_name(template_vm))
     except Exception as e:
         log.exception("Failed to update the image with error %s", e)
         raise


### PR DESCRIPTION
1. Pass no-teardown value from user argument to esx-service.
Without this change, configuration of no-teardown has no impact.
2. Print final output (template/ovf/ova name) to stdout.
This makes ESX output the same as AWS where the output of the operation
is written to stdout and not stderr.