### PR TITLE
Make the VM name a positional argument

### DIFF
--- a/brkt_cli/esx/rescue_metavisor_args.py
+++ b/brkt_cli/esx/rescue_metavisor_args.py
@@ -31,11 +31,9 @@ def setup_rescue_metavisor_args(parser):
         metavar='NAME',
         required=True)
     parser.add_argument(
-        '--vm-name',
-        metavar='NAME',
-        dest='vm_name',
-        help='Specify the name of the metavisor VM',
-        required=True
+        'vm_name',
+        metavar='VM-NAME',
+        help='Specify the name of the metavisor VM'
     )
     parser.add_argument(
         '--rescue-upload-protocol',


### PR DESCRIPTION
The intention of this operation is to change the core upload
location of the MV VM being identified by its name.
Hence, moving the vm-name to a positional argument.