### PR TITLE
Hide bucket-name argument

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -125,14 +125,6 @@ def setup_encrypt_vmdk_args(parser):
         required=False
     )
     parser.add_argument(
-        '--bucket-name',
-        metavar='NAME',
-        dest='bucket_name',
-        help='Name of the bucket containing the Metavisor OVF',
-        default="solo-brkt-prod-ovf-image",
-        required=False
-    )
-    parser.add_argument(
         '--ovf-source-directory',
         metavar='PATH',
         dest='source_image_path',
@@ -200,4 +192,13 @@ def setup_encrypt_vmdk_args(parser):
         action='store_true',
         default=False,
         help=argparse.SUPPRESS
+    )
+    # Optional bucket-name in case dev/qa need to use
+    # other internal buckets to fetch the MV image from
+    parser.add_argument(
+        '--bucket-name',
+        metavar='NAME',
+        dest='bucket_name',
+        help=argparse.SUPPRESS,
+        default="solo-brkt-prod-ovf-image"
     )

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -110,14 +110,6 @@ def setup_update_vmdk_args(parser):
         help="Don't validate VMDKs and vCenter credentials"
     )
     parser.add_argument(
-        '--bucket-name',
-        metavar='NAME',
-        dest='bucket_name',
-        help='Name of the bucket containing the Metavisor OVF',
-        default="solo-brkt-prod-ovf-image",
-        required=False
-    )
-    parser.add_argument(
         '--ovf-source-directory',
         metavar='PATH',
         dest='source_image_path',
@@ -156,4 +148,13 @@ def setup_update_vmdk_args(parser):
         metavar='PATH',
         dest='ssh_public_key_file',
         help=argparse.SUPPRESS
+    )
+    # Optional bucket-name in case dev/qa need to use
+    # other internal buckets to fetch the MV image from
+    parser.add_argument(
+        '--bucket-name',
+        metavar='NAME',
+        dest='bucket_name',
+        help=argparse.SUPPRESS,
+        default="solo-brkt-prod-ovf-image"
     )


### PR DESCRIPTION
Since customers should always be using the prod bucket
to fetch MV images from, hiding the bucket-name arguement
from encrypt-vmdk and update-vmdk.