### PR TITLE
Fix typo in install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'pyasn1>=0.1.9',
         'pyjwt>=1.4.0',
         'pyvmomi>=5.5.50,<=6.0.0',
-        'PyYaml>=3.11'
+        'PyYaml>=3.11',
         'requests>=2.7.0',
     ],
     zip_safe=False,


### PR DESCRIPTION
Missing a comma after a package named in the 'install_requires' list.