### PR TITLE
Add token to config

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -444,6 +444,12 @@ def main():
 
     config = CLIConfig()
 
+    # Add config options that span multiple commands
+    config.register_option(
+        'token',
+        'The default token to use when encrypting, updating, or launching'
+        ' images')
+
     # Dynamically load subcommands from modules.
     subcommands = []
     for module_path in SUBCOMMAND_MODULE_PATHS:

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -269,7 +269,7 @@ class EncryptAMISubcommand(Subcommand):
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         encrypt_ami_args.setup_encrypt_ami_args(encrypt_ami_parser)
-        setup_instance_config_args(encrypt_ami_parser,
+        setup_instance_config_args(encrypt_ami_parser, parsed_config,
                                    mode=INSTANCE_CREATOR_MODE)
 
     def debug_log_to_temp_file(self):
@@ -370,6 +370,7 @@ class UpdateAMISubcommand(Subcommand):
         update_encrypted_ami_args.setup_update_encrypted_ami(
             update_encrypted_ami_parser)
         setup_instance_config_args(update_encrypted_ami_parser,
+                                   parsed_config,
                                    mode=INSTANCE_UPDATER_MODE)
 
     def debug_log_to_temp_file(self):

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -66,7 +66,7 @@ class EncryptVMDKSubcommand(Subcommand):
         )
         encrypt_vmdk_args.setup_encrypt_vmdk_args(
             encrypt_vmdk_parser)
-        setup_instance_config_args(encrypt_vmdk_parser)
+        setup_instance_config_args(encrypt_vmdk_parser, parsed_config)
 
     def run(self, values):
         return _run_subcommand(self.name(), values, self.config)
@@ -87,7 +87,7 @@ class UpdateVMDKSubcommand(Subcommand):
         )
         update_encrypted_vmdk_args.setup_update_vmdk_args(
             update_encrypted_vmdk_parser)
-        setup_instance_config_args(update_encrypted_vmdk_parser)
+        setup_instance_config_args(update_encrypted_vmdk_parser, parsed_config)
 
     def run(self, values):
         return _run_subcommand(self.name(), values, self.config)

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -56,7 +56,7 @@ class EncryptGCEImageSubcommand(Subcommand):
         )
         encrypt_gce_image_args.setup_encrypt_gce_image_args(
             encrypt_gce_image_parser, parsed_config)
-        setup_instance_config_args(encrypt_gce_image_parser)
+        setup_instance_config_args(encrypt_gce_image_parser, parsed_config)
 
     def debug_log_to_temp_file(self):
         return True
@@ -120,7 +120,7 @@ class UpdateGCEImageSubcommand(Subcommand):
         )
         update_encrypted_gce_image_args.setup_update_gce_image_args(
             update_gce_image_parser)
-        setup_instance_config_args(update_gce_image_parser)
+        setup_instance_config_args(update_gce_image_parser, parsed_config)
 
     def debug_log_to_temp_file(self):
         return True
@@ -180,7 +180,7 @@ class LaunchGCEImageSubcommand(Subcommand):
         )
         launch_gce_image_args.setup_launch_gce_image_args(
             launch_gce_image_parser)
-        setup_instance_config_args(launch_gce_image_parser,
+        setup_instance_config_args(launch_gce_image_parser, parsed_config,
                                    mode=INSTANCE_METAVISOR_MODE)
 
     def run(self, values):

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -24,7 +24,7 @@ from brkt_cli import (
     encryptor_service,
     get_proxy_config
 )
-
+from brkt_cli.config import CLIConfig
 from brkt_cli.instance_config import (
     InstanceConfig,
     INSTANCE_CREATOR_MODE,
@@ -39,7 +39,8 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
-def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE):
+def setup_instance_config_args(parser, parsed_config,
+                               mode=INSTANCE_CREATOR_MODE):
     parser.add_argument(
         '--ntp-server',
         metavar='DNS_NAME',
@@ -130,6 +131,7 @@ def setup_instance_config_args(parser, mode=INSTANCE_CREATOR_MODE):
         ),
         metavar='TOKEN',
         dest='token',
+        default=parsed_config.get_option('token'),
         required=False
     )
 
@@ -219,6 +221,11 @@ def instance_config_args_to_values(cli_args, mode=INSTANCE_CREATOR_MODE):
     :return the values object as returned from argparser.parse_args()
     """
     parser = argparse.ArgumentParser()
-    setup_instance_config_args(parser, mode)
+    config = CLIConfig()
+    config.register_option(
+        'token',
+        'The default token to use when encrypting, updating, or launching'
+        ' images')
+    setup_instance_config_args(parser, config, mode)
     argv = cli_args.split()
     return parser.parse_args(argv)

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -53,7 +53,7 @@ class MakeUserDataSubcommand(Subcommand):
             formatter_class=brkt_cli.SortingHelpFormatter
         )
 
-        setup_instance_config_args(parser)
+        setup_instance_config_args(parser, parsed_config)
 
         parser.add_argument(
             '-v',


### PR DESCRIPTION
Users may now specify a token in their config file that will be
used as by default when encrypting, updating, or launching images.