### PR TITLE
Make esx encryption use aws credentials to get image from s3

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -867,8 +867,8 @@ def download_ovf_from_s3(bucket_name, image_name=None):
     ovf_name = None
     download_file_list = []
     try:
-        conn = boto.connect_s3(None, None, anon=True,
-                               host="s3.amazonaws.com")
+        anon = not (set(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']) <= set(os.environ))
+        conn = boto.connect_s3(None, None, anon=anon, host="s3.amazonaws.com")
         bucket = boto.s3.bucket.Bucket(connection=conn, name=bucket_name)
         if (image_name is None):
             # Get the last one


### PR DESCRIPTION
Forcing anonymous s3 access to the bucket locked us out from
using non-public buckets. This change addresses that by allowing
the use aws credentials (if they exist).

If no credentials are found in the environment, we will fall back
to an anonymous connection.