### PR TITLE
Add no-cleanup option to gce encrypt and update

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -95,7 +95,8 @@ class EncryptGCEImageSubcommand(Subcommand):
             image_bucket=values.bucket,
             network=values.network,
             subnetwork=values.subnetwork,
-            status_port=values.status_port
+            status_port=values.status_port,
+            cleanup=values.cleanup
         )
         # Print the image name to stdout, in case the caller wants to process
         # the output.  Log messages go to stderr.
@@ -158,7 +159,8 @@ class UpdateGCEImageSubcommand(Subcommand):
             image_bucket=values.bucket,
             network=values.network,
             subnetwork=values.subnetwork,
-            status_port=values.status_port
+            status_port=values.status_port,
+            cleanup=values.cleanup
         )
 
         print(updated_image_id)

--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -103,7 +103,8 @@ def create_image(gce_svc, zone, encrypted_image_disk, encrypted_image_name, encr
 def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, instance_config, image_project=None,
             keep_encryptor=False, image_file=None, image_bucket=None,
-            network=None, subnetwork=None, status_port=ENCRYPTOR_STATUS_PORT):
+            network=None, subnetwork=None, status_port=ENCRYPTOR_STATUS_PORT,
+            cleanup=True):
     try:
         # create metavisor image from file in GCS bucket
         log.info('Retrieving encryptor image from GCS bucket')
@@ -140,5 +141,8 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
     except errors.HttpError as e:
         log.exception('GCE API request failed: {}'.format(e.message))
     finally:
+        if not cleanup:
+            log.info("Not cleaning up")
+            return
         log.info("Cleaning up")
         gce_svc.cleanup(zone, encryptor_image, keep_encryptor)

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -84,6 +84,14 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
         help=argparse.SUPPRESS
     )
     parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        required=False,
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
         '--keep-encryptor',
         dest='keep_encryptor',
         action='store_true',

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -67,6 +67,14 @@ def setup_update_gce_image_args(parser):
         help=argparse.SUPPRESS
     )
     parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        required=False,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
         '--keep-encryptor',
         dest='keep_encryptor',
         action='store_true',

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -34,7 +34,8 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
                      encrypted_image_name, zone, instance_config,
                      keep_encryptor=False, image_file=None,
                      image_bucket=None, network=None,
-                     subnetwork=None, status_port=ENCRYPTOR_STATUS_PORT):
+                     subnetwork=None, status_port=ENCRYPTOR_STATUS_PORT,
+                     cleanup=True):
     snap_created = None
     instance_name = 'brkt-updater-' + gce_svc.get_session_id()
     updater = instance_name + '-metavisor'
@@ -106,8 +107,12 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
         log.info("Update failed. Cleaning up")
         if snap_created:
             gce_svc.delete_snapshot(encrypted_image_name)
+        if not cleanup:
+            return
         gce_svc.cleanup(zone, encryptor_image, keep_encryptor)
         raise
     finally:
+        if not cleanup:
+            return
         gce_svc.cleanup(zone, encryptor_image, keep_encryptor)
     return encrypted_image_name


### PR DESCRIPTION
the no cleanup option prevents the encryptor
from being deleted. In case more debugging
is required than just looking at the logs

Testing: ran encrypt-gce-image with the no-cleanup
option and interrupted it