### PR TITLE
Fix update-vmdk and use-esx-host functionality and usage.

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -130,20 +130,27 @@ def _run_subcommand(subcommand, values, parsed_config):
 
 def command_update_encrypted_vmdk(values, parsed_config, log):
     session_id = util.make_nonce()
-    if (values.encrypted_ovf_name or values.encrypted_ova_name):
+    encrypted_ovf_name = None
+    encrypted_ova_name = None
+    if values.create_ovf or values.create_ova:
         # verify we have a valid input directory
-        if (values.target_path is None):
+        if values.target_path is None:
             raise ValidationError("Missing directory path to fetch "
                                   "encrypted OVF/OVA images from")
-        if (values.encrypted_ovf_name):
+        if not os.path.exists(values.target_path):
+            raise ValidationError("Target path %s not present",
+                                  values.target_path)
+        if values.create_ovf:
             name = os.path.join(values.target_path,
                                 values.encrypted_ovf_name + ".ovf")
             if (os.path.exists(name) is False):
                 raise ValidationError("Encrypted OVF image not found at "
                                       "%s", name)
+            encrypted_ovf_name = values.encrypted_ovf_name
         else:
+            encrypted_ova_name = values.encrypted_ovf_name
             name = os.path.join(values.target_path,
-                                values.encrypted_ova_name + ".ova")
+                                values.encrypted_ovf_name + ".ova")
             if (os.path.exists(name) is False):
                 raise ValidationError("Encrypted OVA image not found at "
                                       "%s", name)
@@ -215,8 +222,8 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
                 vc_swc, encryptor_service.EncryptorService,
                 template_vm_name=values.template_vm_name,
                 target_path=values.target_path,
-                ovf_name=values.encrypted_ovf_name,
-                ova_name=values.encrypted_ova_name,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
                 ovftool_path=values.ovftool_path,
                 metavisor_vmdk=values.encryptor_vmdk,
                 user_data_str=user_data_str,
@@ -228,8 +235,8 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
                 vc_swc, encryptor_service.EncryptorService,
                 template_vm_name=values.template_vm_name,
                 target_path=values.target_path,
-                ovf_name=values.encrypted_ovf_name,
-                ova_name=values.encrypted_ova_name,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
                 ovftool_path=values.ovftool_path,
                 source_image_path=values.source_image_path,
                 ovf_image_name=values.image_name,
@@ -242,8 +249,8 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
                 vc_swc, encryptor_service.EncryptorService,
                 template_vm_name=values.template_vm_name,
                 target_path=values.target_path,
-                ovf_name=values.encrypted_ovf_name,
-                ova_name=values.encrypted_ova_name,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
                 ovftool_path=values.ovftool_path,
                 mv_ovf_name=ovf_name,
                 download_file_list=download_file_list,
@@ -258,15 +265,15 @@ def command_update_encrypted_vmdk(values, parsed_config, log):
 
 def command_encrypt_vmdk(values, parsed_config, log):
     session_id = util.make_nonce()
-    if ((values.create_ovf is True) or (values.create_ova is True)):
+    if values.create_ovf or values.create_ova:
         # verify we have a valid output directory
-        if (values.target_path is None):
+        if values.target_path is None:
             raise ValidationError("Missing directory path to store "
                                   "final OVF/OVA images")
-        if (os.path.exists(values.target_path) is False):
+        if not os.path.exists(values.target_path):
             raise ValidationError("Target path %s not present",
                                   values.target_path)
-        if (values.create_ova is True):
+        if values.create_ova:
             # verify ovftool is present
             try:
                 cmd = [values.ovftool_path, '-v']

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -158,7 +158,11 @@ def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
         if (ovf_name is None or download_file_list is None):
             log.error("Cannot get metavisor OVF from S3")
             raise Exception("Invalid MV OVF")
-        vm = launch_mv_vm_from_s3(vc_swc, ovf_name, download_file_list)
+        mv_vm_name = None
+        if vc_swc.is_esx_host() is True:
+            mv_vm_name = vm_name
+        vm = launch_mv_vm_from_s3(vc_swc, ovf_name,
+                                  download_file_list, mv_vm_name)
     except Exception as e:
         log.exception("Failed to launch metavisor OVF from S3 (%s)", e)
         if (vm is not None):

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -72,8 +72,7 @@ def setup_encrypt_vmdk_args(parser):
         '--encrypted-image-name',
         metavar='NAME',
         dest='encrypted_ovf_name',
-        #help='Specify the name of the generated OVF',
-        help=argparse.SUPPRESS,
+        help='Specify the name of the generated OVF/OVA',
         required=False
     )
     parser.add_argument(
@@ -95,23 +94,20 @@ def setup_encrypt_vmdk_args(parser):
         dest='create_ovf',
         action='store_true',
         default=False,
-        #help="Create OVF package"
-        help=argparse.SUPPRESS
+        help="Create OVF package"
     )
     parser.add_argument(
         '--create-ova',
         dest='create_ova',
         action='store_true',
         default=False,
-        #help="Create OVA package"
-        help=argparse.SUPPRESS
+        help="Create OVA package"
     )
     parser.add_argument(
-        '--encrypted-image-target-directory',
+        '--encrypted-image-directory',
         metavar='NAME',
         dest='target_path',
-        #help='Directory to store the generated OVF/OVA image',
-        help=argparse.SUPPRESS,
+        help='Directory to store the generated OVF/OVA image',
         default=None,
         required=False
     )
@@ -119,8 +115,7 @@ def setup_encrypt_vmdk_args(parser):
         '--ovftool-path',
         metavar='PATH',
         dest='ovftool_path',
-	help=argparse.SUPPRESS,
-        #help='ovftool executable path',
+        help='ovftool executable path',
         default="ovftool",
         required=False
     )

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -32,8 +32,7 @@ def setup_update_vmdk_args(parser):
         "--vcenter-datacenter",
         help="vCenter Datacenter to use",
         dest="vcenter_datacenter",
-        metavar='NAME',
-        required=True)
+        metavar='NAME')
     parser.add_argument(
         "--vcenter-datastore",
         help="vCenter datastore to use",
@@ -46,7 +45,8 @@ def setup_update_vmdk_args(parser):
         help="vCenter cluster to use",
         dest="vcenter_cluster",
         metavar='NAME',
-        required=True)
+        required=False,
+        default=None)
     parser.add_argument(
         "--cpu-count",
         help="Number of CPUs to assign to Encryptor VM",
@@ -72,8 +72,7 @@ def setup_update_vmdk_args(parser):
         '--encrypted-image-directory',
         metavar='NAME',
         dest='target_path',
-        #help='Directory to fetch the encrypted OVF/OVA image',
-        help=argparse.SUPPRESS,
+        help='Directory to fetch the encrypted OVF/OVA image',
         default=None,
         required=False
     )
@@ -81,26 +80,30 @@ def setup_update_vmdk_args(parser):
         '--ovftool-path',
         metavar='PATH',
         dest='ovftool_path',
-        #help='ovftool executable path',
-        help=argparse.SUPPRESS,
+        help='ovftool executable path',
         default="ovftool",
         required=False
     )
     parser.add_argument(
-        '--encrypted-ovf-image-name',
+        '--encrypted-image-name',
         metavar='NAME',
         dest='encrypted_ovf_name',
-        #help='Specify the name of the encrypted OVF image to update',
-        help=argparse.SUPPRESS,
+        help='Specify the name of the encrypted OVF/OVA image to update',
         required=False
     )
     parser.add_argument(
-        '--encrypted-ova-image-name',
-        metavar='NAME',
-        dest='encrypted_ova_name',
-        #help='Specify the name of the encrypted OVA image to update',
-        help=argparse.SUPPRESS,
-        required=False
+        '--update-ovf',
+        dest='create_ovf',
+        action='store_true',
+        default=False,
+        help="Update OVF package"
+    )
+    parser.add_argument(
+        '--update-ova',
+        dest='create_ova',
+        action='store_true',
+        default=False,
+        help="Update OVA package"
     )
     parser.add_argument(
         '--no-validate',

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -72,17 +72,13 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
                 raise Exception("Cannot create ova/ovf as target path is None")
             if (ova_name):
                 # delete the old mf file
-                rm_cmd = "rm -f %s" % (os.path.join(target_path,
-                                                    ova_name + ".mf"))
-                os.system(rm_cmd)
+                os.remove(os.path.join(target_path, ova_name + ".mf"))
             # import the new OVF
             ovf = vc_swc.export_to_ovf(guest_vm, target_path, ovf_name=ovf_name)
             if ova_name:
                 if ovftool_path is not None:
                     # delete the old ova
-                    rm_cmd = "rm -f %s" % (os.path.join(target_path,
-                                                        ova_name + ".ova"))
-                    os.system(rm_cmd)
+                    os.remove(os.path.join(target_path, ova_name + ".ova"))
                     ova = vc_swc.convert_ovf_to_ova(ovftool_path, ovf)
                     print(ova)
             else:
@@ -117,9 +113,11 @@ def launch_guest_vm(vc_swc, template_vm_name, target_path, ovf_name,
         ova = os.path.join(target_path, ova_name + ".ova")
         vc_swc.convert_ova_to_ovf(ovftool_path, ova)
         ovf_name = ova_name + ".ovf"
-        vm = vc_swc.upload_ovf_to_vcenter(target_path, ovf_name)
+        vm = vc_swc.upload_ovf_to_vcenter(target_path, ovf_name,
+                                          validate_mf=False)
     elif ovf_name:
-        vm = vc_swc.upload_ovf_to_vcenter(target_path, ovf_name + ".ovf")
+        vm = vc_swc.upload_ovf_to_vcenter(target_path, ovf_name + ".ovf",
+                                          validate_mf=False)
     else:
         log.error("Cannot launch guest VM without template VM/OVF/OVA")
         vm = None

--- a/test_esx.py
+++ b/test_esx.py
@@ -191,7 +191,7 @@ class DummyVCenterService(esx_service.BaseVCenterService):
     def get_ovf_descriptor(self, ovf_path):
         return ovf_path
 
-    def upload_ovf_to_vcenter(self, target_path, ovf_name):
+    def upload_ovf_to_vcenter(self, target_path, ovf_name, vm_name=None):
         ovf = target_path
         if target_path == "./":
             ovf = self.ovfs[0]


### PR DESCRIPTION
1. Make update-vmdk and encrypt-vmdk input options consistent.
2. Unhide the OVF/OVA options.
3. Fix clone disk for use with esx host only.
4. Remove manifest validation with update-vmdk.
5. Remove use SIGALRM if not present.
6. Remove use of rm with os.remove.
7. Set template name to be the VM name when used with esx-host.