### PR TITLE
MV encrypted image name should not include .ovf.

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -34,7 +34,10 @@ from brkt_cli.encryptor_service import (
     ENCRYPTOR_STATUS_PORT
 )
 from brkt_cli.util import Deadline
-from brkt_cli.esx.esx_service import launch_mv_vm_from_s3
+from brkt_cli.esx.esx_service import (
+    launch_mv_vm_from_s3,
+    validate_local_mv_ovf
+)
 
 
 log = logging.getLogger(__name__)
@@ -189,6 +192,8 @@ def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
             return
         # Launch OVF
         log.info("Launching VM from local OVF")
+        ovf_image_name = ovf_image_name + ".ovf"
+        validate_local_mv_ovf(source_image_path, ovf_image_name)
         vm = vc_swc.upload_ovf_to_vcenter(source_image_path, ovf_image_name)
     except Exception as e:
         log.exception("Failed to launch from metavisor OVF (%s)", e)

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -960,3 +960,11 @@ def launch_mv_vm_from_s3(vc_swc, ovf_name, download_file_list, vm_name=None):
     for file_name in download_file_list:
         os.remove(file_name)
     return vm
+
+
+def validate_local_mv_ovf(source_image_path, ovf_image_name):
+    if not os.path.exists(os.path.join(source_image_path, ovf_image_name)):
+        if ".ovf.ovf" in ovf_image_name:
+            log.info("Metavisor ovf image name should not "
+                     "include .ovf extension")
+        raise ValidationError("Metavisor OVF image file not found")

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -19,7 +19,10 @@ from brkt_cli.encryptor_service import (
     ENCRYPTOR_STATUS_PORT
 )
 from brkt_cli.util import Deadline
-from brkt_cli.esx.esx_service import launch_mv_vm_from_s3
+from brkt_cli.esx.esx_service import (
+    launch_mv_vm_from_s3,
+    validate_local_mv_ovf
+)
 
 
 log = logging.getLogger(__name__)
@@ -177,6 +180,8 @@ def update_from_local_ovf(vc_swc, enc_svc_cls, template_vm_name=None,
         raise
     try:
         log.info("Launching MV VM from local OVF")
+        ovf_image_name = ovf_image_name + ".ovf"
+        validate_local_mv_ovf(source_image_path, ovf_image_name)
         mv_vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
                                              ovf_image_name)
     except Exception as e:


### PR DESCRIPTION
Not having .ovf extenstion in the MV image name makes
the user interface consistent between getting MV image
from S3 or locally.