### PR TITLE
Print only fatal messages from boto

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -906,6 +906,7 @@ def initialize_vcenter(host, user, password, port,
 
 
 def download_ovf_from_s3(bucket_name, image_name=None):
+    logging.getLogger('boto').setLevel(logging.FATAL)
     log.info("Fetching Metavisor OVF from S3")
     if bucket_name is None:
         log.error("Bucket-name is unknown, cannot get metavisor OVF")


### PR DESCRIPTION
Boto tries to fetch the AWS credentials from metadata service before
doing a S3 download. If it does not get those credentials (which are
not present in ESX), it prints a confusing info message which looks
like an error. Hence, making the change to print only fatal messages
from boto.