### PR TITLE
No need to slip into 'legacy' mode for FreeBSD metavisors

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -1020,7 +1020,8 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami,
             aws_svc, guest_instance, image_id
         )
 
-        if guest_image.virtualization_type == 'hvm':
+        if (guest_image.virtualization_type == 'hvm' and
+            'brkt-avatar-freebsd' not in mv_image.name):
             net_sriov_attr = aws_svc.get_instance_attribute(guest_instance.id,
                                                             "sriovNetSupport")
             if net_sriov_attr.get("sriovNetSupport") == "simple":


### PR DESCRIPTION
FeeBSD metavisors have support for sriov drivers so we
don't have to play games with guest AMI's that require
sriov.

This preserves any 'pay as you go' licensing for such
guests.