### PR TITLE
Update the AWS command line spec

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -543,7 +543,7 @@ def main():
     # the user can get more details.
     debug_handler = None
     debug_log_file = None
-    if subcommand.debug_log_to_temp_file() and log_level != logging.DEBUG:
+    if subcommand.debug_log_to_temp_file(values) and log_level != logging.DEBUG:
         debug_log_file = tempfile.NamedTemporaryFile(
             delete=False, prefix='brkt_cli')
         debug_handler = logging.FileHandler(debug_log_file.name)

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -79,7 +79,7 @@ def setup_diag_args(parser):
     parser.add_argument(
         '-v',
         '--verbose',
-        dest='diag_verbose',
+        dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
     )

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -86,7 +86,7 @@ def setup_encrypt_ami_args(parser):
     parser.add_argument(
         '-v',
         '--verbose',
-        dest='encrypt_ami_verbose',
+        dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
     )

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -44,7 +44,7 @@ def setup_share_logs_args(parser):
     parser.add_argument(
         '-v',
         '--verbose',
-        dest='share_logs_verbose',
+        dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
     )

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -104,7 +104,7 @@ def setup_update_encrypted_ami(parser):
     parser.add_argument(
         '-v',
         '--verbose',
-        dest='update_encrypted_ami_verbose',
+        dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
     )

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -58,7 +58,7 @@ class EncryptGCEImageSubcommand(Subcommand):
             encrypt_gce_image_parser, parsed_config)
         setup_instance_config_args(encrypt_gce_image_parser, parsed_config)
 
-    def debug_log_to_temp_file(self):
+    def debug_log_to_temp_file(self, values):
         return True
 
     def run(self, values):
@@ -123,7 +123,7 @@ class UpdateGCEImageSubcommand(Subcommand):
             update_gce_image_parser, parsed_config)
         setup_instance_config_args(update_gce_image_parser, parsed_config)
 
-    def debug_log_to_temp_file(self):
+    def debug_log_to_temp_file(self, values):
         return True
 
     def run(self, values):

--- a/brkt_cli/subcommand.py
+++ b/brkt_cli/subcommand.py
@@ -68,7 +68,7 @@ class Subcommand(object):
         """
         pass
 
-    def debug_log_to_temp_file(self):
+    def debug_log_to_temp_file(self, values):
         """ Return True if debug logging should be written to a temporary
         file.  The file is deleted if the command succeeds. """
         return False


### PR DESCRIPTION
Update the AWS command line spec to follow our new convention.  Move the
following commands:

* encrypt-ami -> aws encrypt
* update-encrypted-ami -> aws update
* diag -> aws diag
* share-logs -> aws share-logs

Hide the old commands and log a deprecation warning when they are used.
Refactor the AWS module, so that the run() functions in both the old
and new commands call the same code.

The GCE and VMware commands will be updated in separate commits.