### PR TITLE
Handle gce api failure better for project_exists

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -234,7 +234,7 @@ def check_args(values, gce_svc, cli_config):
 
     if values.validate:
         if not gce_svc.project_exists(values.project):
-            raise ValidationError("Project provided does not exist")
+            raise ValidationError("Project provider either does not exist or you do not have access to it")
         if not gce_svc.network_exists(values.network):
             raise ValidationError("Network provided does not exist")
         brkt_env = brkt_cli.brkt_env_from_values(values)

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -2,6 +2,7 @@
 
 import abc
 import datetime
+import json
 import re
 import socket
 import tempfile
@@ -276,8 +277,11 @@ class GCEService(BaseGCEService):
     def project_exists(self, project=None):
         try:
             self.get_project(project)
-        except:
-            return False
+        except errors.HttpError as e:
+            code = json.loads(e.content)['error']['code']
+            if code == 400 or code == 403 or code == 404:
+                return False
+            raise
         return True
 
     def delete_instance(self, zone, instance):


### PR DESCRIPTION
If project_exists receives a 400 http error return
false (indicating the project doesn't exists).
For any other exception raise