### PR TITLE
Update GCE command line spec

### DIFF
--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -291,6 +291,23 @@ class CLIConfig(object):
         yaml.dump(self._config, f)
 
 
+    def save_config(self):
+        """Save the current config to disk.
+        """
+        f = tempfile.NamedTemporaryFile(delete=False, prefix='brkt_cli')
+        try:
+            yaml.dump(self._config, f)
+            f.close()
+        except:
+            self._unlink_noraise(f.name)
+            raise
+        try:
+            os.rename(f.name, CONFIG_PATH)
+        except:
+            self._unlink_noraise(f.name)
+            raise
+
+
 class ConfigSubcommand(Subcommand):
     def __init__(self, stdout=sys.stdout):
         self.stdout = stdout

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -27,6 +27,201 @@ from brkt_cli.validation import ValidationError
 log = logging.getLogger(__name__)
 
 
+def run_encrypt(values, config):
+    session_id = util.make_nonce()
+    gce_svc = gce_service.GCEService(values.project, session_id, log)
+    check_args(values, gce_svc, config)
+
+    encrypted_image_name = gce_service.get_image_name(
+        values.encrypted_image_name, values.image)
+    gce_service.validate_image_name(encrypted_image_name)
+    if values.validate:
+        gce_service.validate_images(gce_svc,
+                                    encrypted_image_name,
+                                    values.encryptor_image,
+                                    values.image,
+                                    values.image_project)
+    if not values.verbose:
+        logging.getLogger('googleapiclient').setLevel(logging.ERROR)
+
+    log.info('Starting encryptor session %s', gce_svc.get_session_id())
+
+    encrypted_image_id = encrypt_gce_image.encrypt(
+        gce_svc=gce_svc,
+        enc_svc_cls=encryptor_service.EncryptorService,
+        image_id=values.image,
+        encryptor_image=values.encryptor_image,
+        encrypted_image_name=encrypted_image_name,
+        zone=values.zone,
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_CREATOR_MODE, cli_config=config),
+        image_project=values.image_project,
+        keep_encryptor=values.keep_encryptor,
+        image_file=values.image_file,
+        image_bucket=values.bucket,
+        network=values.network,
+        subnetwork=values.subnetwork,
+        status_port=values.status_port,
+        cleanup=values.cleanup
+    )
+    # Print the image name to stdout, in case the caller wants to process
+    # the output.  Log messages go to stderr.
+    print(encrypted_image_id)
+    return 0
+
+
+def run_update(values, config):
+    session_id = util.make_nonce()
+    gce_svc = gce_service.GCEService(values.project, session_id, log)
+    check_args(values, gce_svc, config)
+
+    encrypted_image_name = gce_service.get_image_name(
+        values.encrypted_image_name, values.image)
+    gce_service.validate_image_name(encrypted_image_name)
+    if values.validate:
+        gce_service.validate_images(gce_svc,
+                                    encrypted_image_name,
+                                    values.encryptor_image,
+                                    values.image)
+    if not values.verbose:
+        logging.getLogger('googleapiclient').setLevel(logging.ERROR)
+
+    log.info('Starting updater session %s', gce_svc.get_session_id())
+
+    updated_image_id = update_gce_image.update_gce_image(
+        gce_svc=gce_svc,
+        enc_svc_cls=encryptor_service.EncryptorService,
+        image_id=values.image,
+        encryptor_image=values.encryptor_image,
+        encrypted_image_name=encrypted_image_name,
+        zone=values.zone,
+        instance_config=instance_config_from_values(
+            values, mode=INSTANCE_UPDATER_MODE,
+            cli_config=config),
+        keep_encryptor=values.keep_encryptor,
+        image_file=values.image_file,
+        image_bucket=values.bucket,
+        network=values.network,
+        subnetwork=values.subnetwork,
+        status_port=values.status_port,
+        cleanup=values.cleanup
+    )
+
+    print(updated_image_id)
+    return 0
+
+
+def run_launch(values, config):
+    gce_svc = gce_service.GCEService(values.project, None, log)
+    instance_config = instance_config_from_values(
+        values, mode=INSTANCE_METAVISOR_MODE, cli_config=config)
+    if values.startup_script:
+        extra_items = [{
+            'key': 'startup-script',
+            'value': values.startup_script
+        }]
+    else:
+        extra_items = None
+    brkt_userdata = instance_config.make_userdata()
+    metadata = gce_service.gce_metadata_from_userdata(
+        brkt_userdata, extra_items=extra_items)
+    if not values.verbose:
+        logging.getLogger('googleapiclient').setLevel(logging.ERROR)
+
+    if values.instance_name:
+        gce_service.validate_image_name(values.instance_name)
+
+    encrypted_instance_id = launch_gce_image.launch(log,
+                            gce_svc,
+                            values.image,
+                            values.instance_name,
+                            values.zone,
+                            values.delete_boot,
+                            values.instance_type,
+                            values.network,
+                            values.subnetwork,
+                            metadata)
+    print(encrypted_instance_id)
+    return 0
+
+
+class GCESubcommand(Subcommand):
+
+    def name(self):
+        return 'gce'
+
+    def setup_config(self, config):
+        config.register_option(
+            '%s.project' % (self.name(),),
+            'The GCE project metavisors will be launched into')
+        config.register_option(
+            '%s.network' % (self.name(),),
+            'The GCE network metavisors will be launched into')
+        config.register_option(
+            '%s.subnetwork' % (self.name(),),
+            'The GCE subnetwork metavisors will be launched into')
+        config.register_option(
+            '%s.zone' % (self.name(),),
+            'The GCE zone metavisors will be launched into')
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+
+        gce_parser = subparsers.add_parser(
+            self.name(),
+            description='GCE Operations',
+            help='GCE Operations'
+        )
+
+        gce_subparsers = gce_parser.add_subparsers(
+            dest='gce_subcommand'
+        )
+
+        encrypt_gce_image_parser = gce_subparsers.add_parser(
+            'encrypt',
+            description='Create an encrypted GCE image from an existing image',
+            help='Encrypt a GCE image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        encrypt_gce_image_args.setup_encrypt_gce_image_args(
+            encrypt_gce_image_parser, parsed_config)
+        setup_instance_config_args(encrypt_gce_image_parser, parsed_config)
+
+        update_gce_image_parser = gce_subparsers.add_parser(
+            'update',
+            description=(
+                'Update an encrypted GCE image with the latest Metavisor '
+                'release'),
+            help='Update an encrypted GCE image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        update_encrypted_gce_image_args.setup_update_gce_image_args(
+            update_gce_image_parser, parsed_config)
+        setup_instance_config_args(update_gce_image_parser, parsed_config)
+
+        launch_gce_image_parser = gce_subparsers.add_parser(
+            'launch',
+            description='Launch a GCE image',
+            help='Launch a GCE image',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        launch_gce_image_args.setup_launch_gce_image_args(
+            launch_gce_image_parser)
+        setup_instance_config_args(launch_gce_image_parser, parsed_config,
+                                   mode=INSTANCE_METAVISOR_MODE)
+
+    def debug_log_to_temp_file(self):
+        return True
+
+    def run(self, values):
+        if values.gce_subcommand == 'encrypt':
+            return run_encrypt(values, self.config)
+        if values.gce_subcommand == 'update':
+            return run_update(values, self.config)
+        if values.gce_subcommand == 'launch':
+            return run_launch(values, self.config)
+
+
 class EncryptGCEImageSubcommand(Subcommand):
 
     def name(self):
@@ -46,14 +241,37 @@ class EncryptGCEImageSubcommand(Subcommand):
             '%s.zone' % (self.name(),),
             'The GCE zone metavisors will be launched into')
 
+
     def register(self, subparsers, parsed_config):
         self.config = parsed_config
         encrypt_gce_image_parser = subparsers.add_parser(
             'encrypt-gce-image',
             description='Create an encrypted GCE image from an existing image',
-            help='Encrypt a GCE image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
+
+        # Migrate any config options if there were set
+        project = parsed_config.get_option('%s.project' % (self.name(),))
+        if project:
+            parsed_config.set_option('gce.project', project)
+            parsed_config.unset_option('%s.project' % (self.name(),))
+
+        network = parsed_config.get_option('%s.network' % (self.name(),))
+        if network:
+            parsed_config.set_option('gce.network', network)
+            parsed_config.unset_option('%s.network' % (self.name(),))
+
+        subnetwork = parsed_config.get_option('%s.subnetwork' % (self.name(),))
+        if subnetwork:
+            parsed_config.set_option('gce.subnetwork', subnetwork)
+            parsed_config.unset_option('%s.subnetwork' % (self.name(),))
+
+        zone = parsed_config.get_option('%s.zone' % (self.name(),))
+        if zone:
+            parsed_config.set_option('gce.zone', zone)
+            parsed_config.unset_option('%s.zone' % (self.name(),))
+        parsed_config.save_config()
+
         encrypt_gce_image_args.setup_encrypt_gce_image_args(
             encrypt_gce_image_parser, parsed_config)
         setup_instance_config_args(encrypt_gce_image_parser, parsed_config)
@@ -61,47 +279,15 @@ class EncryptGCEImageSubcommand(Subcommand):
     def debug_log_to_temp_file(self):
         return True
 
+    def exposed(self):
+        return False
+
     def run(self, values):
-        session_id = util.make_nonce()
-        gce_svc = gce_service.GCEService(values.project, session_id, log)
-        check_args(values, gce_svc, self.config)
-
-        encrypted_image_name = gce_service.get_image_name(
-            values.encrypted_image_name, values.image)
-        gce_service.validate_image_name(encrypted_image_name)
-        if values.validate:
-            gce_service.validate_images(gce_svc,
-                                        encrypted_image_name,
-                                        values.encryptor_image,
-                                        values.image,
-                                        values.image_project)
-        if not values.verbose:
-            logging.getLogger('googleapiclient').setLevel(logging.ERROR)
-
-        log.info('Starting encryptor session %s', gce_svc.get_session_id())
-
-        encrypted_image_id = encrypt_gce_image.encrypt(
-            gce_svc=gce_svc,
-            enc_svc_cls=encryptor_service.EncryptorService,
-            image_id=values.image,
-            encryptor_image=values.encryptor_image,
-            encrypted_image_name=encrypted_image_name,
-            zone=values.zone,
-            instance_config=instance_config_from_values(
-                values, mode=INSTANCE_CREATOR_MODE, cli_config=self.config),
-            image_project=values.image_project,
-            keep_encryptor=values.keep_encryptor,
-            image_file=values.image_file,
-            image_bucket=values.bucket,
-            network=values.network,
-            subnetwork=values.subnetwork,
-            status_port=values.status_port,
-            cleanup=values.cleanup
+        log.warn(
+            'This command syntax has been deprecated.  Please use brkt gce '
+            'encrypt instead'
         )
-        # Print the image name to stdout, in case the caller wants to process
-        # the output.  Log messages go to stderr.
-        print(encrypted_image_id)
-        return 0
+        return run_encrypt(values, self.config)
 
 
 class UpdateGCEImageSubcommand(Subcommand):
@@ -116,7 +302,6 @@ class UpdateGCEImageSubcommand(Subcommand):
             description=(
                 'Update an encrypted GCE image with the latest Metavisor '
                 'release'),
-            help='Update an encrypted GCE image',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         update_encrypted_gce_image_args.setup_update_gce_image_args(
@@ -126,45 +311,15 @@ class UpdateGCEImageSubcommand(Subcommand):
     def debug_log_to_temp_file(self):
         return True
 
+    def exposed(self):
+        return False
+
     def run(self, values):
-        session_id = util.make_nonce()
-        gce_svc = gce_service.GCEService(values.project, session_id, log)
-        check_args(values, gce_svc, self.config)
-
-        encrypted_image_name = gce_service.get_image_name(
-            values.encrypted_image_name, values.image)
-        gce_service.validate_image_name(encrypted_image_name)
-        if values.validate:
-            gce_service.validate_images(gce_svc,
-                                        encrypted_image_name,
-                                        values.encryptor_image,
-                                        values.image)
-        if not values.verbose:
-            logging.getLogger('googleapiclient').setLevel(logging.ERROR)
-
-        log.info('Starting updater session %s', gce_svc.get_session_id())
-
-        updated_image_id = update_gce_image.update_gce_image(
-            gce_svc=gce_svc,
-            enc_svc_cls=encryptor_service.EncryptorService,
-            image_id=values.image,
-            encryptor_image=values.encryptor_image,
-            encrypted_image_name=encrypted_image_name,
-            zone=values.zone,
-            instance_config=instance_config_from_values(
-                values, mode=INSTANCE_UPDATER_MODE,
-                cli_config=self.config),
-            keep_encryptor=values.keep_encryptor,
-            image_file=values.image_file,
-            image_bucket=values.bucket,
-            network=values.network,
-            subnetwork=values.subnetwork,
-            status_port=values.status_port,
-            cleanup=values.cleanup
-        )
-
-        print(updated_image_id)
-        return 0
+        log.warn(
+            'This command syntax has been deprecated.  Please use brkt gce '
+            'update instead'
+            )
+        return run_update(values, self.config)
 
 
 class LaunchGCEImageSubcommand(Subcommand):
@@ -178,49 +333,26 @@ class LaunchGCEImageSubcommand(Subcommand):
             'launch-gce-image',
             formatter_class=brkt_cli.SortingHelpFormatter,
             description='Launch a GCE image',
-            help='Launch a GCE image'
         )
         launch_gce_image_args.setup_launch_gce_image_args(
             launch_gce_image_parser)
         setup_instance_config_args(launch_gce_image_parser, parsed_config,
                                    mode=INSTANCE_METAVISOR_MODE)
 
+    def exposed(self):
+        return False
+
     def run(self, values):
-        gce_svc = gce_service.GCEService(values.project, None, log)
-        instance_config = instance_config_from_values(
-            values, mode=INSTANCE_METAVISOR_MODE, cli_config=self.config)
-        if values.startup_script:
-            extra_items = [{
-                'key': 'startup-script',
-                'value': values.startup_script
-            }]
-        else:
-            extra_items = None
-        brkt_userdata = instance_config.make_userdata()
-        metadata = gce_service.gce_metadata_from_userdata(
-            brkt_userdata, extra_items=extra_items)
-        if not values.verbose:
-            logging.getLogger('googleapiclient').setLevel(logging.ERROR)
-
-        if values.instance_name:
-            gce_service.validate_image_name(values.instance_name)
-
-        encrypted_instance_id = launch_gce_image.launch(log,
-                                gce_svc,
-                                values.image,
-                                values.instance_name,
-                                values.zone,
-                                values.delete_boot,
-                                values.instance_type,
-                                values.network,
-                                values.subnetwork,
-                                metadata)
-        print(encrypted_instance_id)
-        return 0
+        log.warn(
+            'This command syntax has been deprecated.  Please use brkt gce '
+            'launch instead'
+        )
+        return run_launch(values, self.config)
 
 
 def get_subcommands():
-    return [EncryptGCEImageSubcommand(),
+    return [GCESubcommand(),
+            EncryptGCEImageSubcommand(),
             UpdateGCEImageSubcommand(),
             LaunchGCEImageSubcommand()]
 


### PR DESCRIPTION
Update the GCE command line spec to follow our new convention. Move the following commands:

 - encrypt-gce-image -> gce encrypt-image
 - update-gce-image -> gce update-image
 - launch-gce-image -> gce launch-image

Hide the old commands and log a deprecation warning when they are used.
Refactor the GCE module so that the run() functions in both the old
and new commands call the same code.
Migrate the GCE config options based on the new command convention.

The AWS and ESX commands will be udpated in separate commits.