### PR TITLE
Attribute error when running brkt-cli

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -270,7 +270,8 @@ class EncryptGCEImageSubcommand(Subcommand):
         if zone:
             parsed_config.set_option('gce.zone', zone)
             parsed_config.unset_option('%s.zone' % (self.name(),))
-        parsed_config.save_config()
+        if project or network or subnetwork or zone:
+            parsed_config.save_config()
 
         encrypt_gce_image_args.setup_encrypt_gce_image_args(
             encrypt_gce_image_parser, parsed_config)


### PR DESCRIPTION
An attribute error was being reported when trying to save the
CLI Config. This happens in environments where the CLI Config
has never been initialized. This change ensures that the CLI
Config is attempted to be saved only if needed.

Also moved the _unlink_noraise method so that it can be called as a
common method instead of being restricted to the ConfigSubcommand class.