### PR TITLE
Update the VMWare command line spec to follow our new convention. Mov…

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -40,6 +40,7 @@ from brkt_cli.esx import (
     rescue_metavisor_args,
     update_vmdk,
     update_encrypted_vmdk_args,
+    encrypt_with_esx_host_args,
 )
 from brkt_cli.validation import ValidationError
 
@@ -52,226 +53,20 @@ def _check_env_vars_set(*var_names):
             raise ValidationError("Environment variable %s is not set" % (n,))
 
 
-def _get_vcenter_password():
-    vcenter_password = os.getenv('VCENTER_PASSWORD')
+def _get_vcenter_password(use_esx):
+    if use_esx:
+        vcenter_password = os.getenv('ESX_PASSWORD')
+    else:
+        vcenter_password = os.getenv('VCENTER_PASSWORD')
     if not vcenter_password:
-        vcenter_password = getpass.getpass('Enter vCenter password:')
+        if use_esx:
+            vcenter_password = getpass.getpass('Enter ESX password:')
+        else:
+            vcenter_password = getpass.getpass('Enter vCenter password:')
     return vcenter_password
 
-class EncryptVMDKSubcommand(Subcommand):
 
-    def name(self):
-        return 'encrypt-vmdk'
-
-    def register(self, subparsers, parsed_config):
-        self.config = parsed_config
-        encrypt_vmdk_parser = subparsers.add_parser(
-            'encrypt-vmdk',
-            description='Create an encrypted VMDK from an existing VMDK',
-            help='Encrypt a VMDK',
-            formatter_class=brkt_cli.SortingHelpFormatter
-        )
-        encrypt_vmdk_args.setup_encrypt_vmdk_args(
-            encrypt_vmdk_parser)
-        setup_instance_config_args(encrypt_vmdk_parser, parsed_config)
-
-    def run(self, values):
-        return _run_subcommand(self.name(), values, self.config)
-
-
-class UpdateVMDKSubcommand(Subcommand):
-
-    def name(self):
-        return 'update-vmdk'
-
-    def register(self, subparsers, parsed_config):
-        self.config = parsed_config
-        update_encrypted_vmdk_parser = subparsers.add_parser(
-            'update-vmdk',
-            description='Update an encrypted VMDK with the latest Metavisor',
-            help='Update an encrypted VMDK',
-            formatter_class=brkt_cli.SortingHelpFormatter
-        )
-        update_encrypted_vmdk_args.setup_update_vmdk_args(
-            update_encrypted_vmdk_parser)
-        setup_instance_config_args(update_encrypted_vmdk_parser, parsed_config)
-
-    def run(self, values):
-        return _run_subcommand(self.name(), values, self.config)
-
-class RescueMetavisorSubcommand(Subcommand):
-
-    def name(self):
-        return 'rescue-metavisor'
-
-    def register(self, subparsers, parsed_config):
-        self.config = parsed_config
-        rescue_metavisor_parser = subparsers.add_parser(
-            'rescue-metavisor',
-            description=(
-                'Upload a Metavisor VM cores and diagonstics to an URL'
-            ),
-            help='Upload Metavisor VM and cores to URL',
-            formatter_class=brkt_cli.SortingHelpFormatter
-        )
-        rescue_metavisor_args.setup_rescue_metavisor_args(rescue_metavisor_parser)
-
-    def run(self, values):
-        return _run_subcommand(self.name(), values, self.config)
-
-
-def get_subcommands():
-    return [EncryptVMDKSubcommand(),
-            UpdateVMDKSubcommand(),
-            RescueMetavisorSubcommand()]
-
-
-def _run_subcommand(subcommand, values, parsed_config):
-    if subcommand == 'encrypt-vmdk':
-        return command_encrypt_vmdk(values, parsed_config, log)
-    if subcommand == 'update-vmdk':
-        return command_update_encrypted_vmdk(values, parsed_config, log)
-    if subcommand == 'rescue-metavisor':
-        return command_rescue_metavisor(values, parsed_config, log)
-
-
-def command_update_encrypted_vmdk(values, parsed_config, log):
-    session_id = util.make_nonce()
-    encrypted_ovf_name = None
-    encrypted_ova_name = None
-    if values.create_ovf or values.create_ova:
-        # verify we have a valid input directory
-        if values.target_path is None:
-            raise ValidationError("Missing directory path to fetch "
-                                  "encrypted OVF/OVA images from")
-        if not os.path.exists(values.target_path):
-            raise ValidationError("Target path %s not present",
-                                  values.target_path)
-        if values.create_ovf:
-            name = os.path.join(values.target_path,
-                                values.encrypted_ovf_name + ".ovf")
-            if (os.path.exists(name) is False):
-                raise ValidationError("Encrypted OVF image not found at "
-                                      "%s", name)
-            encrypted_ovf_name = values.encrypted_ovf_name
-        else:
-            encrypted_ova_name = values.encrypted_ovf_name
-            name = os.path.join(values.target_path,
-                                values.encrypted_ovf_name + ".ova")
-            if (os.path.exists(name) is False):
-                raise ValidationError("Encrypted OVA image not found at "
-                                      "%s", name)
-            # verify ovftool is present
-            try:
-                cmd = [values.ovftool_path, '-v']
-                subprocess.check_call(cmd)
-            except:
-                raise ValidationError("OVFtool not present. "
-                                      "Cannot process OVA")
-    else:
-        if values.esx_host:
-            raise ValidationError("Cannot use template VMs for "
-                                  "updation on a single ESX host")
-        if (values.template_vm_name is None):
-            raise ValidationError("Encrypted image not provided")
-    if (values.source_image_path is not None and values.image_name is None):
-        raise ValidationError("Specify the Metavisor OVF file.")
-    _check_env_vars_set('VCENTER_USER_NAME')
-    vcenter_password = _get_vcenter_password()
-    brkt_cli.validate_ntp_servers(values.ntp_servers)
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    if brkt_env is None:
-        _, brkt_env = parsed_config.get_current_env()
-    if not values.token:
-        raise ValidationError('Must provide a token')
-
-    # Download images from S3
-    try:
-        if (values.encryptor_vmdk is None and
-            values.source_image_path is None):
-            (ovf_name, download_file_list) = \
-                esx_service.download_ovf_from_s3(
-                    values.bucket_name,
-                    image_name=values.image_name
-                )
-            if ovf_name is None:
-                raise ValidationError("Did not find MV OVF images")
-    except Exception as e:
-        raise ValidationError("Failed to download MV image from S3: ", e)
-    # Connect to vCenter
-    try:
-        vc_swc = esx_service.initialize_vcenter(
-            host=values.vcenter_host,
-            user=os.getenv('VCENTER_USER_NAME'),
-            password=vcenter_password,
-            port=values.vcenter_port,
-            datacenter_name=values.vcenter_datacenter,
-            datastore_name=values.vcenter_datastore,
-            esx_host=values.esx_host,
-            cluster_name=values.vcenter_cluster,
-            no_of_cpus=values.no_of_cpus,
-            memory_gb=values.memory_gb,
-            session_id=session_id,
-        )
-    except Exception as e:
-        raise ValidationError("Failed to connect to vCenter: ", e)
-    if values.template_vm_name:
-        if vc_swc.find_vm(values.template_vm_name) is None:
-            raise ValidationError("Template VM %s not found" %
-                                  values.template_vm_name)
-    try:
-        instance_config = instance_config_from_values(
-            values, mode=INSTANCE_UPDATER_MODE, cli_config=parsed_config)
-        user_data_str = vc_swc.create_userdata_str(instance_config,
-            update=True, ssh_key_file=values.ssh_public_key_file)
-        if (values.encryptor_vmdk is not None):
-            # Create from MV VMDK
-            update_vmdk.update_from_vmdk(
-                vc_swc, encryptor_service.EncryptorService,
-                template_vm_name=values.template_vm_name,
-                target_path=values.target_path,
-                ovf_name=encrypted_ovf_name,
-                ova_name=encrypted_ova_name,
-                ovftool_path=values.ovftool_path,
-                metavisor_vmdk=values.encryptor_vmdk,
-                user_data_str=user_data_str,
-                status_port=values.status_port,
-            )
-        elif (values.source_image_path is not None):
-            # Create from MV OVF in local directory
-            update_vmdk.update_from_local_ovf(
-                vc_swc, encryptor_service.EncryptorService,
-                template_vm_name=values.template_vm_name,
-                target_path=values.target_path,
-                ovf_name=encrypted_ovf_name,
-                ova_name=encrypted_ova_name,
-                ovftool_path=values.ovftool_path,
-                source_image_path=values.source_image_path,
-                ovf_image_name=values.image_name,
-                user_data_str=user_data_str,
-                status_port=values.status_port,
-            )
-        else:
-            # Create from MV OVF in S3
-            update_vmdk.update_from_s3(
-                vc_swc, encryptor_service.EncryptorService,
-                template_vm_name=values.template_vm_name,
-                target_path=values.target_path,
-                ovf_name=encrypted_ovf_name,
-                ova_name=encrypted_ova_name,
-                ovftool_path=values.ovftool_path,
-                mv_ovf_name=ovf_name,
-                download_file_list=download_file_list,
-                user_data_str=user_data_str,
-                status_port=values.status_port,
-            )
-        return 0
-    except:
-        log.error("Failed to update encrypted VMDK");
-        return 1
-
-
-def command_encrypt_vmdk(values, parsed_config, log):
+def run_encrypt(values, parsed_config, log, use_esx=False):
     session_id = util.make_nonce()
     if values.create_ovf or values.create_ova:
         # verify we have a valid output directory
@@ -290,13 +85,16 @@ def command_encrypt_vmdk(values, parsed_config, log):
                 raise ValidationError("OVFtool not present. "
                                       "Cannot create OVA")
     else:
-        if values.esx_host is False and values.template_vm_name is None:
+        if use_esx is False and values.template_vm_name is None:
             raise ValidationError("Missing template-vm-name for the "
                                   "template VM")
     if (values.source_image_path is not None and values.image_name is None):
         raise ValidationError("Specify the Metavisor OVF file.")
-    _check_env_vars_set('VCENTER_USER_NAME')
-    vcenter_password = _get_vcenter_password()
+    if use_esx:
+        _check_env_vars_set('ESX_USER_NAME')
+    else:
+        _check_env_vars_set('VCENTER_USER_NAME')
+    vcenter_password = _get_vcenter_password(use_esx)
     brkt_cli.validate_ntp_servers(values.ntp_servers)
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
@@ -320,13 +118,13 @@ def command_encrypt_vmdk(values, parsed_config, log):
     try:
         vc_swc = esx_service.initialize_vcenter(
             host=values.vcenter_host,
-            user=os.getenv('VCENTER_USER_NAME'),
+            user=os.getenv('ESX_USER_NAME') if use_esx else os.getenv('VCENTER_USER_NAME'),
             password=vcenter_password,
             port=values.vcenter_port,
-            datacenter_name=values.vcenter_datacenter,
+            datacenter_name=None if use_esx else values.vcenter_datacenter,
             datastore_name=values.vcenter_datastore,
-            esx_host=values.esx_host,
-            cluster_name=values.vcenter_cluster,
+            esx_host=use_esx,
+            cluster_name=None if use_esx else values.vcenter_cluster,
             no_of_cpus=values.no_of_cpus,
             memory_gb=values.memory_gb,
             session_id=session_id,
@@ -414,7 +212,146 @@ def command_encrypt_vmdk(values, parsed_config, log):
         return 1
 
 
-def command_rescue_metavisor(values, parsed_config, log):
+def run_update(values, parsed_config, log, use_esx=False):
+    session_id = util.make_nonce()
+    encrypted_ovf_name = None
+    encrypted_ova_name = None
+    if values.create_ovf or values.create_ova:
+        # verify we have a valid input directory
+        if values.target_path is None:
+            raise ValidationError("Missing directory path to fetch "
+                                  "encrypted OVF/OVA images from")
+        if not os.path.exists(values.target_path):
+            raise ValidationError("Target path %s not present",
+                                  values.target_path)
+        if values.create_ovf:
+            name = os.path.join(values.target_path,
+                                values.encrypted_ovf_name + ".ovf")
+            if (os.path.exists(name) is False):
+                raise ValidationError("Encrypted OVF image not found at "
+                                      "%s", name)
+            encrypted_ovf_name = values.encrypted_ovf_name
+        else:
+            encrypted_ova_name = values.encrypted_ovf_name
+            name = os.path.join(values.target_path,
+                                values.encrypted_ovf_name + ".ova")
+            if (os.path.exists(name) is False):
+                raise ValidationError("Encrypted OVA image not found at "
+                                      "%s", name)
+            # verify ovftool is present
+            try:
+                cmd = [values.ovftool_path, '-v']
+                subprocess.check_call(cmd)
+            except:
+                raise ValidationError("OVFtool not present. "
+                                      "Cannot process OVA")
+    else:
+        if use_esx:
+            raise ValidationError("Cannot use template VMs for "
+                                  "updation on a single ESX host")
+        if (values.template_vm_name is None):
+            raise ValidationError("Encrypted image not provided")
+    if (values.source_image_path is not None and values.image_name is None):
+        raise ValidationError("Specify the Metavisor OVF file.")
+    if use_esx:
+        _check_env_vars_set('ESX_USER_NAME')
+    else:
+        _check_env_vars_set('VCENTER_USER_NAME')
+    vcenter_password = _get_vcenter_password(use_esx)
+    brkt_cli.validate_ntp_servers(values.ntp_servers)
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = parsed_config.get_current_env()
+    if not values.token:
+        raise ValidationError('Must provide a token')
+
+    # Download images from S3
+    try:
+        if (values.encryptor_vmdk is None and
+            values.source_image_path is None):
+            (ovf_name, download_file_list) = \
+                esx_service.download_ovf_from_s3(
+                    values.bucket_name,
+                    image_name=values.image_name
+                )
+            if ovf_name is None:
+                raise ValidationError("Did not find MV OVF images")
+    except Exception as e:
+        raise ValidationError("Failed to download MV image from S3: ", e)
+    # Connect to vCenter
+    try:
+        vc_swc = esx_service.initialize_vcenter(
+            host=values.vcenter_host,
+            user=os.getenv('ESX_USER_NAME') if use_esx else os.getenv('VCENTER_USER_NAME'),
+            password=vcenter_password,
+            port=values.vcenter_port,
+            datacenter_name=None if use_esx else values.vcenter_datacenter,
+            datastore_name=values.vcenter_datastore,
+            esx_host=use_esx,
+            cluster_name=None if use_esx else values.vcenter_cluster,
+            no_of_cpus=values.no_of_cpus,
+            memory_gb=values.memory_gb,
+            session_id=session_id,
+        )
+    except Exception as e:
+        raise ValidationError("Failed to connect to vCenter: ", e)
+    if values.template_vm_name:
+        if vc_swc.find_vm(values.template_vm_name) is None:
+            raise ValidationError("Template VM %s not found" %
+                                  values.template_vm_name)
+    try:
+        instance_config = instance_config_from_values(
+            values, mode=INSTANCE_UPDATER_MODE, cli_config=parsed_config)
+        user_data_str = vc_swc.create_userdata_str(instance_config,
+            update=True, ssh_key_file=values.ssh_public_key_file)
+        if (values.encryptor_vmdk is not None):
+            # Create from MV VMDK
+            update_vmdk.update_from_vmdk(
+                vc_swc, encryptor_service.EncryptorService,
+                template_vm_name=values.template_vm_name,
+                target_path=values.target_path,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
+                ovftool_path=values.ovftool_path,
+                metavisor_vmdk=values.encryptor_vmdk,
+                user_data_str=user_data_str,
+                status_port=values.status_port,
+            )
+        elif (values.source_image_path is not None):
+            # Create from MV OVF in local directory
+            update_vmdk.update_from_local_ovf(
+                vc_swc, encryptor_service.EncryptorService,
+                template_vm_name=values.template_vm_name,
+                target_path=values.target_path,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
+                ovftool_path=values.ovftool_path,
+                source_image_path=values.source_image_path,
+                ovf_image_name=values.image_name,
+                user_data_str=user_data_str,
+                status_port=values.status_port,
+            )
+        else:
+            # Create from MV OVF in S3
+            update_vmdk.update_from_s3(
+                vc_swc, encryptor_service.EncryptorService,
+                template_vm_name=values.template_vm_name,
+                target_path=values.target_path,
+                ovf_name=encrypted_ovf_name,
+                ova_name=encrypted_ova_name,
+                ovftool_path=values.ovftool_path,
+                mv_ovf_name=ovf_name,
+                download_file_list=download_file_list,
+                user_data_str=user_data_str,
+                status_port=values.status_port,
+            )
+        return 0
+    except:
+        log.error("Failed to update encrypted VMDK");
+        return 1
+
+
+def run_rescue_metavisor(values, parsed_config, log):
     session_id = util.make_nonce()
     if values.protocol != 'http':
         raise ValidationError("Unsupported rescue protocol %s",
@@ -449,3 +386,182 @@ def command_rescue_metavisor(values, parsed_config, log):
     except Exception as e:
         log.exception("Failed to put Metavisor in rescue mode %s", e)
         return 1
+
+
+class VMWareSubcommand(Subcommand):
+
+    def name(self):
+        return 'vmware'
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+        vmware_parser = subparsers.add_parser(
+            self.name(),
+            description='VMWare Operations',
+            help='VMWare Operations',
+        )
+
+        vmware_subparsers = vmware_parser.add_subparsers(
+            dest='vmware_subcommand'
+        )
+
+        encrypt_with_vcenter_parser = vmware_subparsers.add_parser(
+            'encrypt-with-vcenter',
+            description=(
+                'Create an encrypted VMDK from an existing VMDK using vCenter'
+            ),
+            help='Encrypt a VMDK using vCenter',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        encrypt_vmdk_args.setup_encrypt_vmdk_args(
+            encrypt_with_vcenter_parser)
+        setup_instance_config_args(encrypt_with_vcenter_parser, parsed_config)
+
+        encrypt_with_esx_parser = vmware_subparsers.add_parser(
+            'encrypt-with-esx-host',
+            description=(
+                'Create an encrypted VMDK from an existing VMDK on an ESX host'
+            ),
+            help='Encrypt a VMDK on a ESX host',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        encrypt_with_esx_host_args.setup_encrypt_with_esx_host_args(
+            encrypt_with_esx_parser)
+        setup_instance_config_args(encrypt_with_esx_parser, parsed_config)
+
+        update_with_vcenter_parser = vmware_subparsers.add_parser(
+            'update-with-vcenter',
+            description=(
+                'Update an encrypted VMDK with the latest Metavisor using vCenter'
+            ),
+            help='Update an encrypted VMDK using vCenter',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        update_encrypted_vmdk_args.setup_update_vmdk_args(
+            update_with_vcenter_parser)
+        setup_instance_config_args(update_with_vcenter_parser, parsed_config)
+
+        update_with_esx_parser = vmware_subparsers.add_parser(
+            'update-with-esx-host',
+            description=(
+                'Update an encrypted VMDK with the latest Metavisor on an ESX host'
+            ),
+            help='Update an encrypted VMDK on an ESX host',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        encrypt_with_esx_host_args.setup_encrypt_with_esx_host_args(
+            update_with_esx_parser)
+        setup_instance_config_args(update_with_esx_parser, parsed_config)
+
+        rescue_metavisor_parser = vmware_subparsers.add_parser(
+            'rescue-metavisor',
+            description=(
+                'Upload a Metavisor VM cores and diagnostics to a URL'
+            ),
+            help='Upload Metavisor VM and cores to URL',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        rescue_metavisor_args.setup_rescue_metavisor_args(
+            rescue_metavisor_parser)
+        setup_instance_config_args(rescue_metavisor_parser, parsed_config)
+
+    def run(self, values):
+        if values.vmware_subcommand == 'encrypt-with-vcenter':
+            return run_encrypt(values, self.config, log)
+        if values.vmware_subcommand == 'encrypt-with-esx-host':
+            return run_encrypt(values, self.config, log, use_esx=True)
+        if values.vmware_subcommand == 'update-with-vcenter':
+            return run_update(values, self.config, log)
+        if values.vmware_subcommand == 'update-with-esx-host':
+            return run_update(values, self.config, log, use_esx=True)
+        if values.vmware_subcommand == 'rescue-metavisor':
+            return run_rescue_metavisor(values, self.config, log)
+
+
+class EncryptVMDKSubcommand(Subcommand):
+
+    def name(self):
+        return 'encrypt-vmdk'
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+        encrypt_vmdk_parser = subparsers.add_parser(
+            'encrypt-vmdk',
+            description='Create an encrypted VMDK from an existing VMDK',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        encrypt_vmdk_args.setup_encrypt_vmdk_args(
+            encrypt_vmdk_parser)
+        setup_instance_config_args(encrypt_vmdk_parser, parsed_config)
+
+    def exposed(self):
+        return False
+
+    def run(self, values):
+        log.warn(
+            'This command syntax has been deprecated. Please use \"brkt vmware '
+            'encrypt-with-vcenter\" or \"brkt vmware encrypt-with-esx-host '
+            'instead'
+        )
+        return run_encrypt(values, self.config, log, values.esx_host)
+
+
+class UpdateVMDKSubcommand(Subcommand):
+
+    def name(self):
+        return 'update-vmdk'
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+        update_encrypted_vmdk_parser = subparsers.add_parser(
+            'update-vmdk',
+            description='Update an encrypted VMDK with the latest Metavisor',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        update_encrypted_vmdk_args.setup_update_vmdk_args(
+            update_encrypted_vmdk_parser)
+        setup_instance_config_args(update_encrypted_vmdk_parser, parsed_config)
+
+    def exposed(self):
+        return False
+
+    def run(self, values):
+        log.warn(
+            'This command syntax has been deprecated. Please use \"brkt vmware '
+            'update-with-vcenter\" or \"brkt vmware udpate-with-esx-host\" '
+            'instead'
+        )
+        return run_update(values, self.config, log, values.esx_host)
+
+class RescueMetavisorSubcommand(Subcommand):
+
+    def name(self):
+        return 'rescue-metavisor'
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+        rescue_metavisor_parser = subparsers.add_parser(
+            'rescue-metavisor',
+            description=(
+                'Upload a Metavisor VM cores and diagonstics to an URL'
+            ),
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        rescue_metavisor_args.setup_rescue_metavisor_args(rescue_metavisor_parser)
+
+    def exposed(self):
+        return False
+
+    def run(self, values):
+        log.warn(
+            'This command syntax has been deprecated. Please use brkt vmware '
+            'rescue-metavisor instead'
+        )
+        return rescue_metavisor(values, self.config, log)
+
+
+def get_subcommands():
+    return [VMWareSubcommand(),
+            EncryptVMDKSubcommand(),
+            UpdateVMDKSubcommand(),
+            RescueMetavisorSubcommand()]

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -14,43 +14,29 @@
 import argparse
 
 
-def setup_encrypt_vmdk_args(parser):
+def setup_encrypt_with_esx_host_args(parser):
     parser.add_argument(
         'vmdk',
         metavar='VMDK-NAME',
         help='The Guest VMDK that will be encrypted'
     )
     parser.add_argument(
-        "--vcenter-host",
-        help="IP address/DNS Name of the vCenter host",
+        "--esx-host",
+        help="IP address/DNS Name of the ESX host",
         dest="vcenter_host",
         metavar='DNS_NAME',
         required=True)
     parser.add_argument(
-        "--vcenter-port",
-        help="Port Number of the vCenter Server",
+        "--esx-port",
+        help="Port Number of the ESX Server",
         metavar='N',
         dest="vcenter_port",
         default="443",
         required=False)
     parser.add_argument(
-        "--vcenter-datacenter",
-        help="vCenter Datacenter to use",
-        dest="vcenter_datacenter",
-        metavar='NAME',
-        default=None,
-        required=False)
-    parser.add_argument(
-        "--vcenter-datastore",
-        help="vCenter datastore to use",
+        "--esx-datastore",
+        help="ESX datastore to use",
         dest="vcenter_datastore",
-        metavar='NAME',
-        default=None,
-        required=False)
-    parser.add_argument(
-        "--vcenter-cluster",
-        help="vCenter cluster to use",
-        dest="vcenter_cluster",
         metavar='NAME',
         default=None,
         required=False)
@@ -153,15 +139,6 @@ def setup_encrypt_vmdk_args(parser):
         required=False
     )
 
-    # Hide this argument as this is no longer required with the new command
-    # syntax. Leaving it around for backwards compatibility.
-    parser.add_argument(
-        '--use-esx-host',
-        dest='esx_host',
-        action='store_true',
-        default=False,
-        help=argparse.SUPPRESS
-    )
     # Optional VMDK that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(


### PR DESCRIPTION
Update the VMWare command line spec to follow our new convention. Move the following commands:

 - encrypt-vmdk (without --use-esx) -> vmware encrypt-with-vcenter
 - encrypt-vmdk (with --use-esx) -> vmware encrypt-with-esx-host
 - update-vmdk (without --user-esx) -> vmware update-with-vcenter
 - update-vmdk (with --use-esx) -> vmware encrypt-with-esx-host
 - rescue-metavisor -> vmware rescue-metavisor

Introduced 2 new environment variables:
 - ESX_USER_NAME to specify the username for the ESX Host
 - ESX_PASSWORD (Optional) to specify the password for the ESX Host.
    If not specified, the user will be prompted for the same.

Hide the old commands and log a deprecation warning when they are used.
Refactor the ESX module so that the run() functions in both the old
and new commands call the same code.

The AWS and GCE commands will be updated in separate commits