### PR TITLE
Traceback error when running rescue-metavisor

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -357,7 +357,7 @@ def run_rescue_metavisor(values, parsed_config, log):
         raise ValidationError("Unsupported rescue protocol %s",
                               values.protocol)
     _check_env_vars_set('VCENTER_USER_NAME')
-    vcenter_password = _get_vcenter_password()
+    vcenter_password = _get_vcenter_password(False)
     # Connect to vCenter
     try:
         vc_swc = esx_service.initialize_vcenter(


### PR DESCRIPTION
Traceback error reported when running rescue-metavisor. The _get_vcenter_password
method had been updated to accept one argument, but the invocation from the
rescue-metavisor method was not updated to reflect this change.