### PR TITLE
Enable SSL cert validation for vCenter

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -129,6 +129,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             no_of_cpus=values.no_of_cpus,
             memory_gb=values.memory_gb,
             session_id=session_id,
+            verify=False if use_esx else values.validate,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -293,6 +294,7 @@ def run_update(values, parsed_config, log, use_esx=False):
             no_of_cpus=values.no_of_cpus,
             memory_gb=values.memory_gb,
             session_id=session_id,
+            verify=False if use_esx else values.validate,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -373,6 +375,7 @@ def run_rescue_metavisor(values, parsed_config, log):
             no_of_cpus=None,
             memory_gb=None,
             session_id=session_id,
+            verify=values.validate,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter ", e)

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -83,11 +83,11 @@ def setup_encrypt_vmdk_args(parser):
         required=False
     )
     parser.add_argument(
-        '--no-validate',
+        '--no-verify-cert',
         dest='validate',
         action='store_false',
         default=True,
-        help="Don't validate VMDKs and vCenter credentials"
+        help="Don't validate vCenter certificate"
     )
     parser.add_argument(
         '--create-ovf',

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -69,13 +69,6 @@ def setup_encrypt_with_esx_host_args(parser):
         required=False
     )
     parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate VMDKs and vCenter credentials"
-    )
-    parser.add_argument(
         '--create-ovf',
         dest='create_ovf',
         action='store_true',

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -76,7 +76,8 @@ class BaseVCenterService(object):
 
     def __init__(self, host, user, password, port,
                  datacenter_name, datastore_name, esx_host,
-                 cluster_name, no_of_cpus, memoryGB, session_id):
+                 cluster_name, no_of_cpus, memoryGB, session_id,
+                 verify=True):
         self.host = host
         self.user = user
         self.password = password
@@ -93,6 +94,7 @@ class BaseVCenterService(object):
         self.si = None
         self.thindisk = True
         self.eagerscrub = False
+        self.verify = verify
 
     def is_esx_host(self):
         return self.esx_host
@@ -264,7 +266,8 @@ class VCenterService(BaseVCenterService):
         if context:
             # Change ssl context due to bug in pyvmomi
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-            context.verify_mode = ssl.CERT_NONE
+            if not self.verify:
+                context.verify_mode = ssl.CERT_NONE
             self.si = connect.SmartConnect(host=self.host,
                                            user=self.user,
                                            pwd=self.password,
@@ -897,10 +900,12 @@ class VCenterService(BaseVCenterService):
 
 def initialize_vcenter(host, user, password, port,
                        datacenter_name, datastore_name, esx_host,
-                       cluster_name, no_of_cpus, memory_gb, session_id):
+                       cluster_name, no_of_cpus, memory_gb, session_id,
+                       verify=True):
     vc_swc = VCenterService(host, user, password, port,
                             datacenter_name, datastore_name, esx_host,
-                            cluster_name, no_of_cpus, memory_gb, session_id)
+                            cluster_name, no_of_cpus, memory_gb, session_id,
+                            verify=True)
     vc_swc.connect()
     return vc_swc
 

--- a/brkt_cli/esx/rescue_metavisor_args.py
+++ b/brkt_cli/esx/rescue_metavisor_args.py
@@ -31,6 +31,13 @@ def setup_rescue_metavisor_args(parser):
         metavar='NAME',
         required=True)
     parser.add_argument(
+        '--no-verify-cert',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate vCenter certificate"
+    )
+    parser.add_argument(
         'vm_name',
         metavar='VM-NAME',
         help='Specify the name of the metavisor VM'

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -106,11 +106,11 @@ def setup_update_vmdk_args(parser):
         help="Update OVA package"
     )
     parser.add_argument(
-        '--no-validate',
+        '--no-verify-cert',
         dest='validate',
         action='store_false',
         default=True,
-        help="Don't validate VMDKs and vCenter credentials"
+        help="Don't validate vCenter certificate"
     )
     parser.add_argument(
         '--ovf-source-directory',

--- a/brkt_cli/esx/update_with_esx_host_args.py
+++ b/brkt_cli/esx/update_with_esx_host_args.py
@@ -64,13 +64,6 @@ def setup_update_with_esx_host_args(parser):
         required=False
     )
     parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate VMDKs and vCenter credentials"
-    )
-    parser.add_argument(
         '--update-ovf',
         dest='create_ovf',
         action='store_true',


### PR DESCRIPTION
Enable SSL cert validation for vCenter
    
 - Changed the no-validate argument to no-verify-cert to reflect the correct usage
 - Use the no-verify-cert flag to control SSL cert validation with vCenter
 - Remove unused no-validate flag for encrypt/update with-esx-host subcommand