### PR TITLE
Parse GCE config options correctly

### DIFF
--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -17,7 +17,7 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
     zone_kwargs = {
         'help': 'GCE zone to operate in',
         'dest': 'zone',
-        'default': parsed_config.get_option('encrypt-gce-image.zone'),
+        'default': parsed_config.get_option('gce.zone'),
         'required': False,
     }
     if zone_kwargs['default'] is None:
@@ -43,7 +43,7 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
     proj_kwargs = {
         'help': 'GCE project name',
         'dest': 'project',
-        'default': parsed_config.get_option('encrypt-gce-image.project'),
+        'default': parsed_config.get_option('gce.project'),
         'required': False,
     }
     if proj_kwargs['default'] is None:
@@ -66,13 +66,13 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
     parser.add_argument(
         '--network',
         dest='network',
-        default=parsed_config.get_option('encrypt-gce-image.network', 'default'),
+        default=parsed_config.get_option('gce.network', 'default'),
         required=False
     )
     parser.add_argument(
         '--subnetwork',
         dest='subnetwork',
-        default=parsed_config.get_option('encrypt-gce-image.subnetwork', None),
+        default=parsed_config.get_option('gce.subnetwork', None),
         required=False
     )
     # Optional Image Name that's used to launch the encryptor instance. This

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -14,7 +14,7 @@ def setup_update_gce_image_args(parser, parsed_config):
         help='Specify the name of the generated encrypted image',
         required=False
     )
-    required_zone = parsed_config.get_option('encrypt-gce-image.zone', None)
+    required_zone = parsed_config.get_option('gce.zone', None)
     parser.add_argument(
         '--zone',
         help='GCE zone to operate in',
@@ -29,7 +29,7 @@ def setup_update_gce_image_args(parser, parsed_config):
         default='prod',
         required=False
     )
-    required_project = parsed_config.get_option('encrypt-gce-image.project', None)
+    required_project = parsed_config.get_option('gce.project', None)
     parser.add_argument(
         '--project',
         help='GCE project name',
@@ -52,13 +52,13 @@ def setup_update_gce_image_args(parser, parsed_config):
     parser.add_argument(
         '--network',
         dest='network',
-        default=parsed_config.get_option('encrypt-gce-image.network', 'default'),
+        default=parsed_config.get_option('gce.network', 'default'),
         required=False
     )
     parser.add_argument(
         '--subnetwork',
         dest='subnetwork',
-        default=parsed_config.get_option('encrypt-gce-image.subnetwork', None),
+        default=parsed_config.get_option('gce.subnetwork', None),
         required=False
     )
     # Optional arg <image name>.image.tar.gz for specifying metavisor


### PR DESCRIPTION
The GCE config options were being references using the old names
because of which they were not being parsed (and utilized) correctly
with the GCE specific brkt-cli commands. With this change, even after
the config options are migrated to the new format, the config
options would be utilized both with the new command syntax (for
e.g. *brkt gce encrypt*) as well as the old command syntax (for
e.g. *brkt encrypt-gce-image*)