### PR TITLE
Don't allow "any" for claim name or value

### DIFF
--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -193,15 +193,19 @@ def get_payload(jwt_string):
 def validate_name_value(name, value):
     """ Validate the format of a NAME=VALUE pair.
 
-    : return: True if valid
-    : raise: ValidationError if the format is invalid
+    :raise ValidationError if the format is invalid
     """
     if not re.match(r'[A-Za-z0-9_\-]+$', name) or \
-        not re.match(r'[A-Za-z0-9_\-]+$', value):
+            not re.match(r'[A-Za-z0-9_\-]+$', value):
         raise ValidationError(
-            'NAME=VALUE claim must only contain letters, numbers, "-" and "_"')
-    else:
-        return True
+            'Claim name and value must only contain letters, numbers, "-" '
+            'and "_"'
+        )
+    # Don't allow "any", since we treat it as a reserved word.
+    if name.lower() == 'any' or value.lower() == 'any':
+        raise ValidationError(
+            '"any" is not allowed for claim name or value'
+        )
 
 
 def setup_make_jwt_args(subparsers):

--- a/brkt_cli/brkt_jwt/test_jwt.py
+++ b/brkt_cli/brkt_jwt/test_jwt.py
@@ -107,6 +107,17 @@ class TestGenerateJWT(unittest.TestCase):
         with self.assertRaises(ValidationError):
             brkt_cli.validate_jwt(jwt)
 
+    def test_validate_name_value(self):
+        brkt_jwt.validate_name_value('abc123_-', 'abc123_-')
+        with self.assertRaises(ValidationError):
+            brkt_jwt.validate_name_value('valid', 'invalid!')
+        with self.assertRaises(ValidationError):
+            brkt_jwt.validate_name_value('invalid!', 'valid')
+        with self.assertRaises(ValidationError):
+            brkt_jwt.validate_name_value('any', 'valid')
+        with self.assertRaises(ValidationError):
+            brkt_jwt.validate_name_value('valid', 'any')
+
 
 class TestJWK(unittest.TestCase):
 


### PR DESCRIPTION
We treat "any" as a reserved word.  Don't allow it for the claim name or
value.  Stop returning True from validate_name_value(), since we throw
ValidationError when validation fails.