### PR TITLE
Clean up make-user-data arguments and usage

### DIFF
--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -47,8 +47,8 @@ def setup_instance_config_args(parser, parsed_config,
         dest='ntp_servers',
         action='append',
         help=(
-            'Optional NTP server to sync Metavisor clock. '
-            'May be specified multiple times.'
+            'NTP server to sync Metavisor clock. May be specified multiple '
+            'times.'
         )
     )
 
@@ -56,17 +56,15 @@ def setup_instance_config_args(parser, parsed_config,
     proxy_group.add_argument(
         '--proxy',
         metavar='HOST:PORT',
-        help=(
-            'Use this HTTPS proxy during encryption.  '
-            'May be specified multiple times.'
-        ),
+        help='Proxy that Metavisor uses to talk to the Bracket service',
         dest='proxies',
         action='append'
     )
     proxy_group.add_argument(
         '--proxy-config-file',
         metavar='PATH',
-        help='Path to proxy.yaml file that will be used during encryption',
+        help='proxy.yaml file that defines the proxy configuration '
+             'that metavisor uses to talk to the Bracket service',
         dest='proxy_config_file'
     )
 
@@ -125,9 +123,9 @@ def setup_instance_config_args(parser, parsed_config,
     parser.add_argument(
         '--token',
         help=(
-            'Token that the encrypted instance will use to '
-            'authenticate with the Bracket service.  Use the make-token '
-            'subcommand to generate a token.'
+            'Token (JWT) that Metavisor uses to authenticate with the '
+            'Bracket service.  Use the make-token subcommand to generate a '
+            'token.'
         ),
         metavar='TOKEN',
         dest='token',

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -68,7 +68,8 @@ class MakeUserDataSubcommand(Subcommand):
             formatter_class=brkt_cli.SortingHelpFormatter
         )
 
-        setup_instance_config_args(parser, parsed_config)
+        setup_instance_config_args(
+            parser, parsed_config, mode=INSTANCE_METAVISOR_MODE)
 
         parser.add_argument(
             '-v',
@@ -86,11 +87,12 @@ class MakeUserDataSubcommand(Subcommand):
         )
         parser.add_argument(
             '--guest-user-data-file',
-            metavar='FILENAME:TYPE',
+            metavar='PATH:TYPE',
             dest='make_user_data_guest_files',
             action='append',
-            help=('User-data file and MIME contents type to be passed to the '
-                  'guest instance. Can be specified multiple times.')
+            help=('User-data file and MIME content type to be passed to '
+                  'cloud-init on the guest instance. Can be specified '
+                  'multiple times.')
         )
         # Certain customers need to set the FQDN of the guest instance, which
         # is used by Metavisor as the CN field of the Subject DN in the cert


### PR DESCRIPTION
Remove the following options from the make-user-data command:

--status-port
--brkt-env
--service-domain

The status port is only used during encryption.  brkt-env and service-
domain shouldn't be used when launching an instance, since we don't want
the same Metavisor talking to two different services.

Clean up the wording for several command line options, to make the
description clearer.

--------------
~~~~
$ ./brkt make-user-data -h
usage: brkt make-user-data [-h] [--ntp-server DNS_NAME]
                           [--proxy HOST:PORT | --proxy-config-file PATH]
                           [--token TOKEN] [-v]
                           [--guest-user-data-file PATH:TYPE]

Generate MIME multipart user-data that is passed to Metavisor and cloud-init
when running an instance.

optional arguments:
  --guest-user-data-file PATH:TYPE
                        User-data file and MIME content type to be passed to
                        cloud-init on the guest instance. Can be specified
                        multiple times. (default: None)
  --ntp-server DNS_NAME
                        NTP server to sync Metavisor clock. May be specified
                        multiple times. (default: None)
  --proxy HOST:PORT     Proxy that Metavisor uses to talk to the Bracket
                        service (default: None)
  --proxy-config-file PATH
                        proxy.yaml file that defines the proxy configuration
                        that metavisor uses to talk to the Bracket service
                        (default: None)
  --token TOKEN         Token (JWT) that Metavisor uses to authenticate with
                        the Bracket service. Use the make-token subcommand to
                        generate a token. (default: None)
  -h, --help            show this help message and exit
  -v, --verbose         Print status information to the console (default:
                        False)
~~~~