### PR TITLE
Be more selective when printing default values in usage

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -409,10 +409,35 @@ def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
         brkt_config['network_host'] = network_host_port
 
 
-class SortingHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
+class SortingHelpFormatter(argparse.HelpFormatter):
     def add_arguments(self, actions):
         actions = sorted(actions, key=attrgetter('option_strings'))
         super(SortingHelpFormatter, self).add_arguments(actions)
+
+    def _get_help_string(self, action):
+        """ Append the default value to the argument description.  This code
+        is inspired by argparse.ArgumentDefaultsHelpFormatter, with the
+        following differences:
+
+        1. Don't print "default: None".  The behavior for options that don't
+        have defaults is already clear from the usage output.
+
+        2. Don't print the default for boolean options.  Behavior for boolean
+        options is also already clear.  Printing a default for 'store_false'
+        results in confusing usage output for options with negative names,
+        like --no-validate.
+        """
+        help = action.help
+
+        if action.default is None or type(action.default) == bool:
+            return help
+
+        if '%(default)' not in action.help:
+            if action.default is not argparse.SUPPRESS:
+                defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
+                if action.option_strings or action.nargs in defaulting_nargs:
+                    help += ' (default: %(default)s)'
+        return help
 
 
 def main():


### PR DESCRIPTION
Don't print the default value when it is None or a boolean.  These cases
are already clear in the usage output.  The default value ends up being
either gratuitous, or confusing for options with negative names, like
--no-validate.

To do this, we copy the code from argparse.ArgumentDefaultsHelpFormatter
and do nothing if we detect either case.

```text
$ ./brkt aws encrypt -h
usage: brkt aws encrypt [-h] [--encrypted-ami-name NAME]
                        [--guest-instance-type TYPE] [--pv] [--no-validate]
                        --region NAME [--security-group ID] [--subnet ID]
                        [--tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--status-port PORT] [--token TOKEN]
                        ID

Create an encrypted AMI from an existing AMI.

positional arguments:
  ID                    The guest AMI that will be encrypted

optional arguments:
  --encrypted-ami-name NAME
                        Specify the name of the generated encrypted AMI
  --guest-instance-type TYPE
                        The instance type to use when running the unencrypted
                        guest instance (default: m3.medium)
  --no-validate         Don't validate AMIs, subnet, and security groups
  --ntp-server DNS_NAME
                        Optional NTP server to sync Metavisor clock. May be
                        specified multiple times.
  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
                        specified multiple times.
  --proxy-config-file PATH
                        Path to proxy.yaml file that will be used during
                        encryption
  --pv                  Use the PV encryptor
  --region NAME         AWS region (e.g. us-west-2)
  --security-group ID   Use this security group when running the encryptor
                        instance. May be specified multiple times.
  --status-port PORT    Specify the port to receive http status of encryptor.
                        Any port in range 1-65535 can be used except for port
                        81. (default: 80)
  --subnet ID           Launch instances in this subnet
  --tag KEY=VALUE       Set an AWS tag on resources created during encryption.
                        May be specified multiple times.
  --token TOKEN         Token that the encrypted instance will use to
                        authenticate with the Bracket service. Use the make-
                        token subcommand to generate a token.
  -h, --help            show this help message and exit
  -v, --verbose         Print status information to the console
```