### PR TITLE
Handle omitted file ending

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -806,7 +806,10 @@ class VCenterService(BaseVCenterService):
         if validate_mf:
             # Load checksums for each file
             mf_checksum = None
-            mf_file_name = ovf_name[:ovf_name.find(".ovf")] + ".mf"
+            if ovf_name.endswith('.ovf'):
+                mf_file_name = ovf_name[:ovf_name.find(".ovf")] + ".mf"
+            else:
+                mf_file_name = ovf_name + '.mf'
             mf_path = os.path.join(target_path, mf_file_name)
             with open(mf_path, 'r') as mf_file:
                 mf_checksum = json.load(mf_file)


### PR DESCRIPTION
If you supplied an encryptor ovf image without the .ovf file ending it
chopped off the last characters and you ended up with an invalid file
name. We now handle both cases.