### PR TITLE
Log tracebacks at debug level

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -280,8 +280,7 @@ def _check_version():
         # If we can't get the list of versions from PyPI, print the error
         # and return true.  We don't want the version check to block people
         # from getting their work done.
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('')
+        log.debug('', exc_info=1)
         log.info('Unable to load brkt-cli versions from PyPI: %s', e)
         return True
 
@@ -382,8 +381,7 @@ def check_jwt_auth(brkt_env, jwt):
                 'Use --no-validate to disable validation.' % e.code
             )
     except IOError:
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('')
+        log.debug('', exc_info=1)
         log.warn(
             'Unable to validate token against %s.  Use --no-validate to '
             'disable validation.',
@@ -577,16 +575,12 @@ def main():
         allow_debug_log = False
         print(e, file=sys.stderr)
     except util.BracketError as e:
-        if values.verbose:
-            log.exception(e.message)
-        else:
-            log.error(e.message)
+        log.debug('', exc_info=1)
+        log.error(e.message)
     except KeyboardInterrupt:
         allow_debug_log = False
-        if values.verbose:
-            log.exception('Interrupted by user')
-        else:
-            log.error('Interrupted by user')
+        log.debug('', exc_info=1)
+        log.error('Interrupted by user')
     finally:
         if debug_handler:
             if result != 0 and allow_debug_log:

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -67,35 +67,27 @@ def _handle_aws_errors(func):
                 'Unable to connect to AWS.  Are your AWS_ACCESS_KEY_ID and '
                 'AWS_SECRET_ACCESS_KEY environment variables set?'
             )
-            if log.isEnabledFor(logging.DEBUG):
-                log.exception(msg)
-            else:
-                log.error(msg)
+            log.debug('', exc_info=1)
+            log.error(msg)
         except EC2ResponseError as e:
             if e.error_code == 'AuthFailure':
                 msg = 'Check your AWS login credentials and permissions'
-                if log.isEnabledFor(logging.DEBUG):
-                    log.exception(msg)
-                else:
-                    log.error(msg + ': ' + e.error_message)
+                log.debug('', exc_info=1)
+                log.error(msg + ': ' + e.error_message)
             elif e.error_code in (
                     'InvalidKeyPair.NotFound',
                     'InvalidSubnetID.NotFound',
                     'InvalidGroup.NotFound'
             ):
-                if log.isEnabledFor(logging.DEBUG):
-                    log.exception(e.error_message)
-                else:
-                    log.error(e.error_message)
+                log.debug('', exc_info=1)
+                log.error(e.error_message)
             elif e.error_code == 'UnauthorizedOperation':
-                if log.isEnabledFor(logging.DEBUG):
-                    log.exception(e.error_message)
-                else:
-                    log.error(e.error_message)
-                    log.error(
-                        'Unauthorized operation.  Check the IAM policy for your '
-                        'AWS account.'
-                    )
+                log.debug('', exc_info=1)
+                log.error(e.error_message)
+                log.error(
+                    'Unauthorized operation.  Check the IAM policy for your '
+                    'AWS account.'
+                )
             else:
                 raise
         return 1

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -172,8 +172,7 @@ def get_header(jwt_string):
     try:
         return jwt.get_unverified_header(jwt_string)
     except jwt.InvalidTokenError as e:
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('')
+        log.debug('', exc_info=1)
         raise ValidationError('Unable to decode token: %s' % e)
 
 
@@ -185,8 +184,7 @@ def get_payload(jwt_string):
     try:
         return jwt.decode(jwt_string, verify=False)
     except jwt.InvalidTokenError as e:
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('')
+        log.debug('', exc_info=1)
         raise ValidationError('Unable to decode token: %s' % e)
 
 

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -28,8 +28,7 @@ def _write_file(path, content):
         with open(path, 'w') as f:
             f.write(content)
     except IOError as e:
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('Unable to write to %s', path)
+        log.debug('Unable to write to %s', path, exc_info=1)
         raise ValidationError('Unable to write to %s: %s' % (path, e))
 
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -208,8 +208,7 @@ def read_private_key(pem_path):
             password = getpass.getpass('Encrypted private key password: ')
         crypto = brkt_cli.crypto.from_private_key_pem(pem, password=password)
     except (ValueError, IOError) as e:
-        if log.isEnabledFor(logging.DEBUG):
-            log.exception('Unable to load signing key from %s', pem_path)
+        log.debug('Unable to load signing key from %s', pem_path, exc_info=1)
         raise ValidationError(
             'Unable to load signing key: %s' % e)
 


### PR DESCRIPTION
In some cases, we log tracebacks only when verbose logging is enabled.
We used to log the exception if log.isEnabledFor(logging.DEBUG) returned
True.

This code broke when we started writing debug log output to a temp file
(commit 9b4a6538d256602d8d5b885441858e6e8f6bc4d6).  After the logging
change, the call to log.isEnabledFor(logging.DEBUG) always returned
True.

With this commit, we fix all of the callsites, so that they log the
traceback with log.debug(..., exc_info=1).  This has the desired effect
of always writing tracebacks to the temp file, while only writing it to
stderr when the verbose logging flag is set.