### PR TITLE
Clean up the version check error

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -281,7 +281,8 @@ def _check_version():
         # and return true.  We don't want the version check to block people
         # from getting their work done.
         log.debug('', exc_info=1)
-        log.info('Unable to load brkt-cli versions from PyPI: %s', e)
+        msg = e.message or type(e).__name__
+        log.info('Unable to load brkt-cli versions from PyPI: %s', msg)
         return True
 
     if not _is_version_supported(VERSION, supported_versions):


### PR DESCRIPTION
If an exception is raised during the version check and the exception
doesn't have a message, use the class name as the message.