### PR TITLE
Remove support for PV Metavisor

### DIFF
--- a/brkt_cli/aws/diag.py
+++ b/brkt_cli/aws/diag.py
@@ -125,4 +125,4 @@ def diag(aws_svc=None, region='us-west-2',
         print "Private IP address: %s" % diag_instance.private_ip_address
     print "User: root"
     print "SSH Keypair: %s" % ssh_keypair
-    print "Log volume mountpoint: /dev/xbd2a for PV, /dev/xbd2e for HVM"
+    print "Log volume mountpoint: /dev/xbd2e"

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -38,12 +38,6 @@ def setup_encrypt_ami_args(parser):
         default='m3.medium'
     )
     parser.add_argument(
-        '--pv',
-        action='store_true',
-        help='Use the PV encryptor',
-        dest='pv'
-    )
-    parser.add_argument(
         '--no-validate',
         dest='validate',
         action='store_false',

--- a/brkt_cli/aws/test_aws.py
+++ b/brkt_cli/aws/test_aws.py
@@ -42,7 +42,6 @@ class DummyValues(object):
         self.proxies = []
         self.proxy_config_file = None
         self.status_port = None
-        self.pv = None
 
 
 class TestValidation(unittest.TestCase):
@@ -258,29 +257,6 @@ class TestValidation(unittest.TestCase):
         # Bogus region.
         with self.assertRaises(ValidationError):
             brkt_cli.aws._validate_region(aws_svc, 'foobar')
-
-
-class TestVirtualizationType(unittest.TestCase):
-
-    def test_use_pv_metavisor(self):
-        values = DummyValues()
-
-        guest_image = Image()
-
-        values.pv = None
-        guest_image.virtualization_type = 'paravirtual'
-        self.assertTrue(brkt_cli.aws._use_pv_metavisor(values, guest_image))
-
-        values.pv = True
-        self.assertTrue(brkt_cli.aws._use_pv_metavisor(values, guest_image))
-
-        values.pv = None
-        guest_image.virtualization_type = 'hvm'
-        self.assertFalse(brkt_cli.aws._use_pv_metavisor(values, guest_image))
-
-        values.pv = True
-        guest_image.virtualizaiton_type = 'hvm'
-        self.assertTrue(brkt_cli.aws._use_pv_metavisor(values, guest_image))
 
 
 class TestEncryptAMIBackwardsCompatibility(unittest.TestCase):

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -47,12 +47,6 @@ def setup_update_encrypted_ami(parser):
         default='m3.medium'
     )
     parser.add_argument(
-        '--pv',
-        action='store_true',
-        help='Use the PV encryptor',
-        dest='pv'
-    )
-    parser.add_argument(
         '--no-validate',
         dest='validate',
         action='store_false',


### PR DESCRIPTION
We no longer support the paravirtual version of Metavisor.  Remove the
--pv option and related code.