### PR TITLE
Remove unused register_image code

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -111,14 +111,6 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def register_image(self,
-                       kernel_id,
-                       block_device_map,
-                       name=None,
-                       description=None):
-        pass
-
-    @abc.abstractmethod
     def get_image(self, image_id, retry=False):
         pass
 
@@ -410,22 +402,6 @@ class AWSService(BaseAWSService):
             if e.error_code != 'InvalidVolume.NotFound':
                 raise
         return True
-
-    def register_image(self,
-                       kernel_id,
-                       block_device_map,
-                       name=None,
-                       description=None):
-        log.debug('Registering image.')
-        register_image = self.retry(self.conn.register_image)
-        return register_image(
-            name=name,
-            description=description,
-            architecture='x86_64',
-            kernel=kernel_id,
-            root_device_name='/dev/sda1',
-            virtualization_type='paravirtual'
-        )
 
     def get_images(self, filters=None, owners=None):
         get_all_images = self.retry(self.conn.get_all_images)

--- a/brkt_cli/aws/test_aws.py
+++ b/brkt_cli/aws/test_aws.py
@@ -123,7 +123,7 @@ class TestValidation(unittest.TestCase):
         bdm = BlockDeviceMapping()
         bdm['/dev/sda1'] = BlockDeviceType()
         id = aws_svc.register_image(
-            kernel_id=None, name='Guest image', block_device_map=bdm)
+            name='Guest image', block_device_map=bdm)
         guest_image = aws_svc.get_image(id)
 
         # Make the guest image look like it was already encrypted and

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -272,7 +272,6 @@ class DummyAWSService(aws_service.BaseAWSService):
         del(self.volumes[volume_id])
 
     def register_image(self,
-                       kernel_id,
                        block_device_map,
                        name=None,
                        description=None):
@@ -370,15 +369,13 @@ def build_aws_service():
     bdm = BlockDeviceMapping()
     bdm['/dev/sda1'] = BlockDeviceType()
     bdm['/dev/sdg'] = BlockDeviceType()
-    id = aws_svc.register_image(
-        kernel_id=None, name='brkt-avatar', block_device_map=bdm)
+    id = aws_svc.register_image(name='brkt-avatar', block_device_map=bdm)
     encryptor_image = aws_svc.get_image(id)
 
     # Guest image
     bdm = BlockDeviceMapping()
     bdm['/dev/sda1'] = BlockDeviceType()
-    id = aws_svc.register_image(
-        kernel_id=None, name='Guest image', block_device_map=bdm)
+    id = aws_svc.register_image(name='Guest image', block_device_map=bdm)
     guest_image = aws_svc.get_image(id)
 
     return aws_svc, encryptor_image, guest_image


### PR DESCRIPTION
We are now calling create_image() instead of register_image().  Remove
the unused application code.  We still use this function for registering
dummy images in the unit test code.