### PR TITLE
Add HTTP(s) proxy for S3 connections

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -17,6 +17,8 @@ import os
 import subprocess
 import getpass
 
+from brkt_cli import _parse_proxies
+
 from brkt_cli.subcommand import Subcommand
 
 from brkt_cli import (
@@ -102,6 +104,11 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
         _, brkt_env = parsed_config.get_current_env()
     if not values.token:
         raise ValidationError('Must provide a token')
+
+    proxies = None
+    if values.http_proxy:
+        proxies = _parse_proxies(values.http_proxy)
+
     # Download images from S3
     try:
         if (values.encryptor_vmdk is None and
@@ -109,7 +116,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             (ovf, file_list) = \
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
-                    image_name=values.image_name
+                    image_name=values.image_name,
+                    proxy=proxies[0]
                 )
             if ovf is None:
                 raise ValidationError("Did not find MV OVF images")
@@ -267,6 +275,9 @@ def run_update(values, parsed_config, log, use_esx=False):
     if not values.token:
         raise ValidationError('Must provide a token')
 
+    proxies = None
+    if values.http_proxy:
+        proxies = _parse_proxies(values.http_proxy)
     # Download images from S3
     try:
         if (values.encryptor_vmdk is None and
@@ -274,7 +285,8 @@ def run_update(values, parsed_config, log, use_esx=False):
             (ovf_name, download_file_list) = \
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
-                    image_name=values.image_name
+                    image_name=values.image_name,
+                    proxy=proxies[0]
                 )
             if ovf_name is None:
                 raise ValidationError("Did not find MV OVF images")

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -162,6 +162,15 @@ def setup_encrypt_vmdk_args(parser):
         default=False,
         help=argparse.SUPPRESS
     )
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='HOST:PORT',
+        default=None,
+        help=argparse.SUPPRESS
+    )
     # Optional VMDK that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -920,7 +920,7 @@ def initialize_vcenter(host, user, password, port,
     return vc_swc
 
 
-def download_ovf_from_s3(bucket_name, image_name=None):
+def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
     logging.getLogger('boto').setLevel(logging.FATAL)
     log.info("Fetching Metavisor OVF from S3")
     if bucket_name is None:
@@ -930,7 +930,12 @@ def download_ovf_from_s3(bucket_name, image_name=None):
     download_file_list = []
     try:
         anon = not (set(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']) <= set(os.environ))
-        conn = boto.connect_s3(None, None, anon=anon, host="s3.amazonaws.com")
+        if proxy:
+            conn = boto.connect_s3(None, None, anon=anon,
+                                   host="s3.amazonaws.com",
+                                   proxy=proxy.host, proxy_port=proxy.port)
+        else:
+            conn = boto.connect_s3(None, None, anon=anon, host="s3.amazonaws.com")
         bucket = boto.s3.bucket.Bucket(connection=conn, name=bucket_name)
         if (image_name is None):
             # Get the last one

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -137,6 +137,15 @@ def setup_update_vmdk_args(parser):
         default=False,
         help=argparse.SUPPRESS
     )
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='DNS_NAME',
+        default=None,
+        help=argparse.SUPPRESS
+    )
     # Optional MV VMDK that's used to launch the updator instance.  This
     # argument is hidden because it's only used for development.
     parser.add_argument(


### PR DESCRIPTION
A user may want to use a proxy to connect to the internet
from the host which is running the brkt-cli, while all other
(internal) connections do not require the proxy. The outside
(internet) connection is to S3 while the internal connections
goes to the local vCenter (which at most times has a well known
host name), to an ESX host on which the encryptor/updater VM
is deployed (whose IP most times is not known, but the list
of ESX hosts may available)  and to the encryptor VM itself
(whose IP comes from DHCP, hence is definitely not known
beforehand). This change allows the user to specify a HTTP(s)
proxy and port to allow the brkt-cli to use it for the
outbound connection to S3.