### PR TITLE
Provide ability to add SSD scratch disks with instance launch

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -113,6 +113,8 @@ def run_update(values, config):
 
 def run_launch(values, config):
     gce_svc = gce_service.GCEService(values.project, None, log)
+    if values.ssd_scratch_disks > 8:
+        raise ValidationError("Maximum of 8 SSD scratch disks are supported")
     instance_config = instance_config_from_values(
         values, mode=INSTANCE_METAVISOR_MODE, cli_config=config)
     if values.startup_script:
@@ -140,7 +142,8 @@ def run_launch(values, config):
                             values.instance_type,
                             values.network,
                             values.subnetwork,
-                            metadata)
+                            metadata,
+                            values.ssd_scratch_disks)
     print(encrypted_instance_id)
     return 0
 

--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -7,6 +7,7 @@ import re
 import socket
 import tempfile
 import time
+import uuid
 
 import brkt_cli.util
 from brkt_cli.util import (
@@ -447,6 +448,19 @@ class GCEService(BaseGCEService):
         self.compute.disks().insert(project=self.project,
                 zone=zone, body=body).execute()
         self.wait_for_disk(zone, name)
+
+    def create_ssd_disk(self, zone):
+        name = 'scratch-' + str(uuid.uuid4().hex)
+        base = "projects/%s/zones/%s" % (self.project, zone)
+        body = {
+            "deviceName": name,
+            "type": "SCRATCH",
+            "autoDelete": True,
+            "initializeParams": {
+                "diskType": base + "/diskTypes/local-ssd"
+            }
+        }
+        return body
 
     def create_gce_image_from_disk(self, zone, image_name, disk_name):
         build_disk = "projects/%s/zones/%s/disks/%s" % (self.project,

--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -7,7 +7,7 @@ from brkt_cli.util import (
 
 log = logging.getLogger(__name__)
 
-def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, subnetwork, metadata={}):
+def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, subnetwork, metadata={}, ssd_disks=0):
     if not instance_name:
         instance_name = 'brkt' + '-' + str(uuid.uuid4().hex)
 
@@ -18,10 +18,14 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_ty
     log.info("Starting instance")
     guest_disk = gce_svc.get_disk(zone, snap_name)
     guest_disk['autoDelete'] = True
+    disks = [guest_disk]
+    for x in range(ssd_disks):
+        ssd_disk = gce_svc.create_ssd_disk(zone)
+        disks.append(ssd_disk)
     gce_svc.run_instance(zone=zone,
                          name=instance_name,
                          image=image_id,
-                         disks=[guest_disk],
+                         disks=disks,
                          metadata=metadata,
                          delete_boot=delete_boot,
                          network=network,

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -68,3 +68,13 @@ def setup_launch_gce_image_args(parser):
         dest='guest_fqdn',
         help=argparse.SUPPRESS
     )
+    # Optional (number of) SSD scratch disks because these can only be attached
+    # at instance launch time, compared to the other (persistent) disks
+    parser.add_argument(
+        '--ssd-scratch-disks',
+        metavar='N',
+        type=int,
+        default=0,
+        dest='ssd_scratch_disks',
+        help='Number of SSD scratch disks to be attached (max. 8)'
+    )


### PR DESCRIPTION
GCE instances support local SSD scratch disks that are physically
attached to the server which hosts the virtual machine (similar to
instance store volumes on AWS). However unlike the persistent disks,
the SSD scratch disks can only be attached at instance launch time.
This change allows the user to specify the number of SSD scratch
disks to attach to the instance at launch time (Default: 0, Max: 8)
using the --ssd-scratch-disks option with the "gce launch" sub-command.