### PR TITLE
Fix error when no S3 Proxy is specified

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -117,7 +117,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
                     image_name=values.image_name,
-                    proxy=proxies[0]
+                    proxy=proxies[0] if proxies else None
                 )
             if ovf is None:
                 raise ValidationError("Did not find MV OVF images")


### PR DESCRIPTION
If the http-s3-proxy argument is not defined when encrypting or
updating a vmware image, then the command was failing with an
object attribute error. The change ensures that the proxy
elements are passed only if they are specified, else it is
skipped.