### PR TITLE
Close debug log handler before deleting the file

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -609,9 +609,10 @@ def main():
         log.error('Interrupted by user')
     finally:
         if debug_handler:
+            logging.root.removeHandler(debug_handler)
+            debug_handler.close()
+
             if result != 0 and allow_debug_log:
-                debug_handler.close()
-                logging.root.removeHandler(debug_handler)
                 log.info('Debug log is available at %s', debug_log_file.name)
             else:
                 os.remove(debug_log_file.name)


### PR DESCRIPTION
Close the debug log handler before attempting to remove the file.  This
avoids open file descriptor issues on Windows.