### PR TITLE
Don't log user-data unless --verbose was specified

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -439,6 +439,9 @@ class SortingHelpFormatter(argparse.HelpFormatter):
         return help
 
 
+def is_verbose(values, subcommand):
+    return values.verbose or subcommand.verbose(values)
+
 def main():
     parser = argparse.ArgumentParser(
         description='Command-line interface to the Bracket Computing service.',
@@ -542,9 +545,7 @@ def main():
     # the top-level "brkt" command or one of the subcommands.  We support
     # both because users got confused when "brkt encrypt-ami -v" didn't work.
     log_level = logging.INFO
-    verbose = values.verbose
-    if subcommand.verbose(values):
-        verbose = True
+    verbose = is_verbose(values, subcommand)
     subcommand.init_logging(verbose)
     if verbose:
         log_level = logging.DEBUG

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import abc
+import logging
 import re
 import ssl
-import tempfile
 
 import boto
 import boto.sts
 import boto.vpc
-import logging
 from boto.exception import EC2ResponseError, BotoServerError
 
 from brkt_cli import util
@@ -292,13 +291,6 @@ class AWSService(BaseAWSService):
             'type=%s',
             image_id, security_group_ids, subnet_id, instance_type
         )
-        if user_data and log.isEnabledFor(logging.DEBUG):
-            with tempfile.NamedTemporaryFile(
-                prefix='user-data-',
-                delete=False
-            ) as f:
-                log.debug('Writing instance user data to %s', f.name)
-                f.write(user_data)
 
         try:
             run_instances = self.retry(self.conn.run_instances)


### PR DESCRIPTION
Check the state of the --verbose option instead of the log level before
writing user-data to a temp file.

With commit 9b4a6538d256602d8d5b885441858e6e8f6bc4d6, we started writing
the debug log to a temp file.  This caused
log.isEnabledFor(logging.DEBUG) to always return true.  The side effect
is that we started always writing user-data to a temp file.