### PR TITLE
Add support for setting the network-name for the Encryptor VM

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -137,6 +137,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             no_of_cpus=values.no_of_cpus,
             memory_gb=values.memory_gb,
             session_id=session_id,
+            network_name=values.network_name,
+            nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
         )
     except Exception as e:
@@ -306,6 +308,8 @@ def run_update(values, parsed_config, log, use_esx=False):
             no_of_cpus=values.no_of_cpus,
             memory_gb=values.memory_gb,
             session_id=session_id,
+            network_name=values.network_name,
+            nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
         )
     except Exception as e:
@@ -387,6 +391,8 @@ def run_rescue_metavisor(values, parsed_config, log):
             no_of_cpus=None,
             memory_gb=None,
             session_id=session_id,
+            network_name=None,
+            nic_type=None,
             verify=values.validate,
         )
     except Exception as e:

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -55,6 +55,13 @@ def setup_encrypt_vmdk_args(parser):
         default=None,
         required=False)
     parser.add_argument(
+        "--vcenter-network-name",
+        help="vCenter network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
         "--cpu-count",
         help="Number of CPUs to assign to Encryptor VM",
         metavar='N',
@@ -207,4 +214,13 @@ def setup_encrypt_vmdk_args(parser):
         dest='bucket_name',
         help=argparse.SUPPRESS,
         default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
     )

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -41,6 +41,13 @@ def setup_encrypt_with_esx_host_args(parser):
         default=None,
         required=False)
     parser.add_argument(
+        "--esx-network-name",
+        help="ESX network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
         "--cpu-count",
         help="Number of CPUs to assign to Encryptor VM",
         metavar='N',
@@ -168,4 +175,13 @@ def setup_encrypt_with_esx_host_args(parser):
         dest='bucket_name',
         help=argparse.SUPPRESS,
         default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
     )

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -48,6 +48,13 @@ def setup_update_vmdk_args(parser):
         required=False,
         default=None)
     parser.add_argument(
+        "--vcenter-network-name",
+        help="vCenter network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
         "--cpu-count",
         help="Number of CPUs to assign to Encryptor VM",
         metavar='N',
@@ -171,4 +178,13 @@ def setup_update_vmdk_args(parser):
         dest='bucket_name',
         help=argparse.SUPPRESS,
         default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
     )

--- a/brkt_cli/esx/update_with_esx_host_args.py
+++ b/brkt_cli/esx/update_with_esx_host_args.py
@@ -36,6 +36,13 @@ def setup_update_with_esx_host_args(parser):
         default=None,
         required=False)
     parser.add_argument(
+        "--esx-network-name",
+        help="ESX network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
         "--cpu-count",
         help="Number of CPUs to assign to Encryptor VM",
         metavar='N',
@@ -163,4 +170,13 @@ def setup_update_with_esx_host_args(parser):
         dest='bucket_name',
         help=argparse.SUPPRESS,
         default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
     )

--- a/test_esx.py
+++ b/test_esx.py
@@ -57,7 +57,8 @@ class DummyVCenterService(esx_service.BaseVCenterService):
         self.connection = False
         super(DummyVCenterService, self).__init__(
             'testhost', 'testuser', 'testpass', 'testport', 'testdcname',
-            'testdsname', False, 'testclustername', 1, 1024, 123)
+            'testdsname', False, 'testclustername', 1, 1024, 123,
+            'VM Network', 'Port')
 
     def connect(self):
         self.connection = True
@@ -93,7 +94,7 @@ class DummyVCenterService(esx_service.BaseVCenterService):
     def get_ip_address(self, vm):
         return ("10.10.10.1")
 
-    def create_vm(self, memoryGB=1, numCPUs=1, network_name="VM Network"):
+    def create_vm(self, memoryGB=1, numCPUs=1):
         timestamp = datetime.datetime.utcnow().isoformat() + 'Z'
         vm_name = "VM-" + timestamp
         vm = DummyVM(vm_name, numCPUs, memoryGB)


### PR DESCRIPTION
1. Add support for changing the network name to which the
NIC in the Encryptor VM connects to.
2. Add support for allowing Encryptor VM NIC to be a
VirtualPort or a VirtualPortGroup in a VDS.