### PR TITLE
Delete boot disk by default for GCE instances

### DIFF
--- a/brkt_cli/gce/gce_service.py
+++ b/brkt_cli/gce/gce_service.py
@@ -540,7 +540,7 @@ class GCEService(BaseGCEService):
                      network='default',
                      disks=[],
                      metadata={},
-                     delete_boot=False,
+                     delete_boot=True,
                      block_project_ssh_keys=False,
                      instance_type='n1-standard-4',
                      image_project=None,

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -28,10 +28,11 @@ def setup_launch_gce_image_args(parser):
         default='us-central1-a'
     )
     parser.add_argument(
-        '--delete-boot',
-        help='Delete boot disk when instance is deleted',
+        '--no-delete-boot',
+        help='Do not delete boot disk when instance is deleted',
         dest='delete_boot',
-        action='store_true'
+        default=True,
+        action='store_false'
     )
     parser.add_argument(
         '--project',


### PR DESCRIPTION
By default, we were not deleting the boot disk for a GCE instance
launched using the "brkt gce launch" command, when the instance was
terminated. This change makes the boot disk deletion the default
behaviour and toggles the purpose of the --delete-boot argument.
Now if this argument is specified, then we will retain the boot
disk on instance termination.