### PR TITLE
Don't auto-delete boot disk for encryptor/updater

### DIFF
--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -71,6 +71,7 @@ def do_encryption(gce_svc,
                          disks=[gce_svc.get_disk(zone, instance_name),
                                 gce_svc.get_disk(zone, encrypted_image_disk),
                                 gce_svc.get_disk(zone, dummy_name)],
+                         delete_boot=False,
                          metadata=metadata)
 
     try:

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -70,6 +70,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
                              network=network,
                              subnet=subnetwork,
                              disks=[],
+                             delete_boot=False,
                              metadata=user_data)
         ip = gce_svc.get_instance_ip(updater, zone)
         updater_launched = True
@@ -89,6 +90,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
         # delete updater instance
         log.info('Deleting updater instance')
         gce_svc.delete_instance(zone, updater)
+        updater_launched = False
 
         # wait for updater root disk
         gce_svc.wait_for_detach(zone, updater)


### PR DESCRIPTION
The orchestration relies on the boot disk being around after
the updater/encryptor has terminated.

Minor fix to avoid getting console output after updater
has terminated.