### PR TITLE
Add HTTP(s) proxy for S3 connections

### DIFF
--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -185,3 +185,12 @@ def setup_encrypt_with_esx_host_args(parser):
         help=argparse.SUPPRESS,
         default="Port"
     )
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='HOST:PORT',
+        default=None,
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/esx/update_with_esx_host_args.py
+++ b/brkt_cli/esx/update_with_esx_host_args.py
@@ -180,3 +180,12 @@ def setup_update_with_esx_host_args(parser):
         help=argparse.SUPPRESS,
         default="Port"
     )
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='HOST:PORT',
+        default=None,
+        help=argparse.SUPPRESS
+    )


### PR DESCRIPTION
This change allows the user to specify a HTTP(s) proxy and port to allow the brkt-cli to
use it for outbound connections to S3 when encrypting or updating images directly against
an ESX host. This is to bring it on par to when performing similar operations using a
vCenter host.

A customer wants to use a proxy to connect to the internet from the host which is running
the brkt-cli, while all other (internal) connections do not require the proxy. The outside
(internet) connection is to S3 while the internal connections goes to the local vCenter or
ESX host (which at most times has a well known host name).