### PR TITLE
Provide ability to specify crypto mode

### DIFF
--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 import argparse
+from brkt_cli.util import (
+    CRYPTO_GCM,
+    CRYPTO_XTS
+)
 
 
 def setup_encrypt_ami_args(parser):
@@ -135,4 +139,14 @@ def setup_encrypt_ami_args(parser):
         action='store_false',
         default=True,
         help=argparse.SUPPRESS
+    )
+    # Optional argument for root disk crypto policy. The supported values
+    # currently are "gcm" and "xts" with "gcm" being the default
+    parser.add_argument(
+        '--crypto-policy',
+        dest='crypto',
+        metavar='NAME',
+        choices=[CRYPTO_GCM, CRYPTO_XTS],
+        help=argparse.SUPPRESS,
+        default=None
     )

--- a/brkt_cli/aws/test_aws.py
+++ b/brkt_cli/aws/test_aws.py
@@ -26,6 +26,7 @@ from brkt_cli.aws import (
 )
 from brkt_cli.aws.test_aws_service import build_aws_service, new_id
 from brkt_cli.validation import ValidationError
+from brkt_cli.util import CRYPTO_GCM
 
 
 class DummyValues(object):
@@ -42,6 +43,7 @@ class DummyValues(object):
         self.proxies = []
         self.proxy_config_file = None
         self.status_port = None
+        self.crypto = CRYPTO_GCM
 
 
 class TestValidation(unittest.TestCase):

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -27,6 +27,7 @@ from brkt_cli.test_encryptor_service import (
     DummyEncryptorService,
     FailedEncryptionService
 )
+from brkt_cli.util import CRYPTO_GCM
 
 
 class TestRunUpdate(unittest.TestCase):
@@ -43,7 +44,8 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM
         )
 
         self.call_count = 0
@@ -75,7 +77,8 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM
         )
 
         def run_instance_callback(args):
@@ -102,7 +105,8 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM
         )
 
         self.call_count = 0
@@ -135,7 +139,8 @@ class TestRunUpdate(unittest.TestCase):
             aws_svc=aws_svc,
             enc_svc_cls=DummyEncryptorService,
             image_id=guest_image.id,
-            encryptor_ami=encryptor_image.id
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM
         )
 
         # Create callbacks that make sure that we stop the updater

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -7,7 +7,7 @@ from brkt_cli import encryptor_service, util
 from brkt_cli.instance_config import (
     INSTANCE_CREATOR_MODE,
     INSTANCE_METAVISOR_MODE,
-    INSTANCE_UPDATER_MODE
+    INSTANCE_UPDATER_MODE,
 )
 from brkt_cli.instance_config_args import (
     instance_config_from_values,
@@ -41,6 +41,7 @@ def run_encrypt(values, config):
                                     values.encryptor_image,
                                     values.image,
                                     values.image_project)
+
     if not values.verbose:
         logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 
@@ -55,6 +56,7 @@ def run_encrypt(values, config):
         zone=values.zone,
         instance_config=instance_config_from_values(
             values, mode=INSTANCE_CREATOR_MODE, cli_config=config),
+        crypto_policy=values.crypto,
         image_project=values.image_project,
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -1,4 +1,8 @@
 import argparse
+from brkt_cli.util import (
+    CRYPTO_GCM,
+    CRYPTO_XTS
+)
 
 
 def setup_encrypt_gce_image_args(parser, parsed_config):
@@ -98,4 +102,14 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
         dest='keep_encryptor',
         action='store_true',
         help=argparse.SUPPRESS
+    )
+    # Optional argument for root disk crypto policy. The supported values
+    # currently are "gcm" and "xts" with "gcm" being the default
+    parser.add_argument(
+        '--crypto-policy',
+        dest='crypto',
+        metavar='NAME',
+        choices=[CRYPTO_GCM, CRYPTO_XTS],
+        help=argparse.SUPPRESS,
+        default=None
     )

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -26,6 +26,10 @@ from brkt_cli.validation import ValidationError
 SLEEP_ENABLED = True
 MAX_BACKOFF_SECS = 10
 
+# Supported crypto options for the disks
+CRYPTO_GCM = 'gcm'
+CRYPTO_XTS = 'xts'
+
 
 log = logging.getLogger(__name__)
 

--- a/test_gce.py
+++ b/test_gce.py
@@ -9,6 +9,7 @@ from brkt_cli.gce import encrypt_gce_image
 from brkt_cli.gce import gce_service
 from brkt_cli.gce import update_gce_image
 from brkt_cli.instance_config import InstanceConfig
+from brkt_cli.util import CRYPTO_GCM
 from brkt_cli.test_encryptor_service import (
     DummyEncryptorService,
     FailedEncryptionService
@@ -240,6 +241,7 @@ class TestRunEncryption(unittest.TestCase):
             encryptor_image='encryptor-image',
             encrypted_image_name='ubuntu-encrypted',
             zone='us-central1-a',
+            crypto_policy=CRYPTO_GCM,
             instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertIsNotNone(encrypted_image)
@@ -255,6 +257,7 @@ class TestRunEncryption(unittest.TestCase):
             encryptor_image='encryptor-image',
             encrypted_image_name='ubuntu-encrypted',
             zone='us-central1-a',
+            crypto_policy=CRYPTO_GCM,
             instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertEqual(len(gce_svc.disks), 0)


### PR DESCRIPTION
Bracket supports GCM and XTS encryption mode for the disks. By default
the guest root volume always was encrypted using GCM. This change
adds a new (hidden) --boot-disk-crypto-policy argument which allows
the user to override the default encryption policy for the (guest)
root volume. If 'default' is specified, then the default encryption
policy is determined from the encryptor image type (NetBSD vs FreeBSD).
Note that XTS is not supported with the NetBSD encryptor.