### PR TITLE
Update help string and docs to reflect correct operation

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -132,6 +132,7 @@ def parse_brkt_env(brkt_env_string):
                 # service-domain makes. Hopefully we'll remove brkt-env
                 # soon and we can get rid of it
                 be.public_api_host = be.api_host.replace('yetiapi', 'api')
+                be.public_api_port = be.api_port
         except ValueError:
             raise ValidationError(error_msg)
 

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -7,7 +7,7 @@ def setup_launch_gce_image_args(parser):
     parser.add_argument(
         'image',
         metavar='ID',
-        help='The image that will be encrypted',
+        help='The image that will be launched',
     )
     parser.add_argument(
         '--instance-name',

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -5,7 +5,7 @@ def setup_update_gce_image_args(parser, parsed_config):
     parser.add_argument(
         'image',
         metavar='ID',
-        help='The image that will be encrypted',
+        help='The image that will be updated',
     )
     parser.add_argument(
         '--encrypted-image-name',

--- a/gce.md
+++ b/gce.md
@@ -89,7 +89,7 @@ usage: brkt gce update [-h] [--encrypted-image-name NAME] --zone ZONE
 Update an encrypted GCE image with the latest Metavisor release
 
 positional arguments:
-  ID                    The image that will be encrypted
+  ID                    The image that will be updated
 
 optional arguments:
   --encrypted-image-name NAME
@@ -136,7 +136,7 @@ usage: brkt gce launch [-h] [--instance-name NAME]
 Launch a GCE image
 
 positional arguments:
-  ID                    The image that will be encrypted
+  ID                    The image that will be launched
 
 optional arguments:
   --delete-boot         Delete boot disk when instance is deleted (default:


### PR DESCRIPTION
The update and launch operations for GCE was updated to reflect the
correct operation being performed.

Also, updated the public_api_port to use the correct port based on the
brkt_env settings instead of always defaulting to 443.