### PR TITLE
Default guest root crypto mode to XTS for GCE

### DIFF
--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -12,10 +12,7 @@ from brkt_cli.encryptor_service import (
 from brkt_cli.gce.gce_service import gce_metadata_from_userdata
 from brkt_cli.util import Deadline, retry, append_suffix
 from googleapiclient import errors
-from brkt_cli.util import (
-    CRYPTO_XTS,
-    CRYPTO_GCM
-)
+from brkt_cli.util import CRYPTO_XTS
 
 
 log = logging.getLogger(__name__)
@@ -143,9 +140,9 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
             keep_encryptor = True
 
         # For GCE there is no way to identify the encryptor type
-        # Default to GCM
+        # Default to XTS
         if crypto_policy is None:
-            crypto_policy = CRYPTO_GCM
+            crypto_policy = CRYPTO_XTS
 
         instance_name = 'brkt-guest-' + gce_svc.get_session_id()
         encryptor = instance_name + '-encryptor'


### PR DESCRIPTION
Default the guest root volume crypto mode for GCE to XTS. This keeps
it consistent with the AWS encryption process.