### PR TITLE
Add XTS support for ESX encryption

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -33,6 +33,7 @@ from brkt_cli.instance_config_args import (
     instance_config_from_values,
     setup_instance_config_args
 )
+from brkt_cli.util import CRYPTO_XTS
 
 from brkt_cli.esx import (
     encrypt_vmdk,
@@ -169,13 +170,18 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
     try:
         instance_config = instance_config_from_values(
             values, mode=INSTANCE_CREATOR_MODE, cli_config=parsed_config)
+        crypto_policy = values.crypto
+        if crypto_policy is None:
+            crypto_policy = CRYPTO_XTS
+        instance_config['crypto_policy_type'] = crypto_policy
         user_data_str = vc_swc.create_userdata_str(instance_config,
             update=False, ssh_key_file=values.ssh_public_key_file)
         if (values.encryptor_vmdk is not None):
             # Create from MV VMDK
             encrypt_vmdk.encrypt_from_vmdk(
                 vc_swc, encryptor_service.EncryptorService,
-                values.vmdk, vm_name=values.template_vm_name,
+                values.vmdk, crypto_policy,
+                vm_name=values.template_vm_name,
                 create_ovf=values.create_ovf,
                 create_ova=values.create_ova,
                 target_path=values.target_path,
@@ -190,7 +196,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             # Create from MV OVF in local directory
             encrypt_vmdk.encrypt_from_local_ovf(
                 vc_swc, encryptor_service.EncryptorService,
-                values.vmdk, vm_name=values.template_vm_name,
+                values.vmdk, crypto_policy,
+                vm_name=values.template_vm_name,
                 create_ovf=values.create_ovf,
                 create_ova=values.create_ova,
                 target_path=values.target_path,
@@ -206,7 +213,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             # Create from MV OVF in S3
             encrypt_vmdk.encrypt_from_s3(
                 vc_swc, encryptor_service.EncryptorService,
-                values.vmdk, vm_name=values.template_vm_name,
+                values.vmdk, crypto_policy,
+                vm_name=values.template_vm_name,
                 create_ovf=values.create_ovf,
                 create_ova=values.create_ova,
                 target_path=values.target_path,

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -38,13 +38,14 @@ from brkt_cli.esx.esx_service import (
     launch_mv_vm_from_s3,
     validate_local_mv_ovf
 )
+from brkt_cli.util import CRYPTO_XTS
 
 
 log = logging.getLogger(__name__)
 
 
 def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
-                                vm_name=None, create_ovf=False,
+                                crypto_policy, vm_name=None, create_ovf=False,
                                 create_ova=False, target_path=None,
                                 image_name=None, ovftool_path=None,
                                 user_data_str=None, serial_port_file_name=None,
@@ -60,9 +61,14 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         guest_vmdk_path = vc_swc.get_datastore_path(guest_vmdk)
         # Attach guest vmdk
         vc_swc.add_disk(vm, filename=guest_vmdk_path, unit_number=2)
+        if crypto_policy is None:
+            crypto_policy = CRYPTO_XTS
         # Attach empty disk
         size = vc_swc.get_disk_size(vm, 2)
-        encrypted_guest_size = (2 * size) + (1024*1024)
+        if crypto_policy == CRYPTO_XTS:
+            encrypted_guest_size = size + (1024*1024)
+        else:
+            encrypted_guest_size = (2 * size) + (1024*1024)
         vc_swc.add_disk(vm, disk_size=encrypted_guest_size, unit_number=1)
         # Power on the VM and wait for encryption
         vc_swc.power_on(vm)
@@ -150,9 +156,9 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         log.info("Done")
 
 
-def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
-                    create_ovf=False, create_ova=False, target_path=None,
-                    image_name=None, ovftool_path=None,
+def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
+                    vm_name=None, create_ovf=False, create_ova=False,
+                    target_path=None, image_name=None, ovftool_path=None,
                     ovf_name=None, download_file_list=None,
                     user_data_str=None, serial_port_file_name=None,
                     status_port=ENCRYPTOR_STATUS_PORT):
@@ -172,15 +178,15 @@ def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
             vc_swc.destroy_vm(vm)
         raise
     create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm,
-                                guest_vmdk, vm_name,
+                                guest_vmdk, crypto_policy, vm_name,
                                 create_ovf, create_ova, target_path,
                                 image_name, ovftool_path, user_data_str,
                                 serial_port_file_name, status_port)
 
 
-def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
-                           create_ovf=False, create_ova=False, target_path=None,
-                           image_name=None, ovftool_path=None,
+def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
+                           vm_name=None, create_ovf=False, create_ova=False,
+                            target_path=None, image_name=None, ovftool_path=None,
                            source_image_path=None, ovf_image_name=None,
                            user_data_str=None, serial_port_file_name=None,
                            status_port=ENCRYPTOR_STATUS_PORT):
@@ -201,17 +207,18 @@ def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
             vc_swc.destroy_vm(vm)
         raise
     create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm,
-                                guest_vmdk, vm_name,
+                                guest_vmdk, crypto_policy, vm_name,
                                 create_ovf, create_ova, target_path,
                                 image_name, ovftool_path,
                                 user_data_str, serial_port_file_name,
                                 status_port)
 
 
-def encrypt_from_vmdk(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
-                      create_ovf=False, create_ova=False, target_path=None,
-                      image_name=None, ovftool_path=None, metavisor_vmdk=None,
-                      user_data_str=None, serial_port_file_name=None,
+def encrypt_from_vmdk(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
+                      vm_name=None, create_ovf=False, create_ova=False,
+                      target_path=None, image_name=None, ovftool_path=None,
+                      metavisor_vmdk=None, user_data_str=None,
+                      serial_port_file_name=None,
                       status_port=ENCRYPTOR_STATUS_PORT):
     try:
         vm = None
@@ -230,7 +237,7 @@ def encrypt_from_vmdk(vc_swc, enc_svc_cls, guest_vmdk, vm_name=None,
             vc_swc.destroy_vm(vm)
         raise
     create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm,
-                                guest_vmdk, vm_name,
+                                guest_vmdk, crypto_policy, vm_name,
                                 create_ovf, create_ova, target_path,
                                 image_name, ovftool_path,
                                 user_data_str, serial_port_file_name,

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -12,6 +12,10 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+from brkt_cli.util import (
+    CRYPTO_GCM,
+    CRYPTO_XTS
+)
 
 
 def setup_encrypt_with_esx_host_args(parser):
@@ -193,4 +197,14 @@ def setup_encrypt_with_esx_host_args(parser):
         metavar='HOST:PORT',
         default=None,
         help=argparse.SUPPRESS
+    )
+    # Optional argument for root disk crypto policy. The supported values
+    # currently are "gcm" and "xts" with "xts" being the default
+    parser.add_argument(
+        '--crypto-policy',
+        dest='crypto',
+        metavar='NAME',
+        choices=[CRYPTO_GCM, CRYPTO_XTS],
+        help=argparse.SUPPRESS,
+        default=None
     )


### PR DESCRIPTION
 - Add a hidden {--crypto-policy} optional argument to specify the
crypto policy for the guest root volume
 - Default the crypto policy for the guest root volume to XTS to
bring it on par with AWS and GCE
 - Updated tests