### PR TITLE
Fix error handling when parsing proxy.yaml

### DIFF
--- a/brkt_cli/proxy.py
+++ b/brkt_cli/proxy.py
@@ -54,7 +54,7 @@ def validate_proxy_config(proxy_yaml):
     try:
         d = yaml.safe_load(proxy_yaml)
     except yaml.YAMLError as e:
-        raise ValidationError('Unable to parse proxy config: %s', e.message)
+        raise ValidationError('Unable to parse proxy config: %s' % e)
 
     if 'proxies' not in d:
         raise ValidationError('Could not find "proxies" section')


### PR DESCRIPTION
If the proxy config file is malformed (not YAML), make sure that the
ValidationError has the message from the exception that was thrown.