### PR TITLE
Use shutil.move() to move config file

### DIFF
--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -17,6 +17,7 @@ import errno
 import logging
 import os
 import os.path
+import shutil
 import sys
 import tempfile
 import yaml
@@ -310,7 +311,7 @@ class CLIConfig(object):
         yaml.dump(self._config, f)
         f.close()
         try:
-            os.rename(f.name, CONFIG_PATH)
+            shutil.move(f.name, CONFIG_PATH)
         except:
             _unlink_noraise(f.name)
             raise
@@ -505,7 +506,7 @@ The leading `*' indicates that the `stage' environment is currently active.
             _unlink_noraise(f.name)
             raise
         try:
-            os.rename(f.name, CONFIG_PATH)
+            shutil.move(f.name, CONFIG_PATH)
         except:
             _unlink_noraise(f.name)
             raise


### PR DESCRIPTION
Use shutil.move() instead of os.rename() to move the config file.  This
handles the case where the user's temp directory and home directory are
on different volumes.