### PR TITLE
Enable SRIOV supprot by default

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -174,6 +174,11 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
+    def modify_instance_attribute(self, instance_id, attribute,
+                               value, dry_run=False):
+        pass
+
+    @abc.abstractmethod
     def retry(self, function, error_code_regexp=None, timeout=None):
         pass
 
@@ -500,6 +505,16 @@ class AWSService(BaseAWSService):
         return get_instance_attribute(
             instance_id,
             attribute,
+            dry_run=dry_run
+        )
+
+    def modify_instance_attribute(self, instance_id, attribute,
+                                  value, dry_run=False):
+        modify_instance_attribute = self.retry(self.conn.modify_instance_attribute)
+        return modify_instance_attribute(
+            instance_id,
+            attribute,
+            value,
             dry_run=dry_run
         )
 

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -355,6 +355,11 @@ class DummyAWSService(aws_service.BaseAWSService):
             return dict()
         return None
 
+    def modify_instance_attribute(self, instance_id, attribute, value, dry_run=False):
+        if attribute == 'sriovNetSupport':
+            return dict()
+        return None
+
     def retry(self, function, error_code_regexp=None, timeout=None):
         return aws_service.retry_boto(
             function,


### PR DESCRIPTION
Enable SRIOV support by default
 - Irrespective of whether the guest image supports SRIOV or not
   Bracket supports it and hence should be enabled on all images
   encrypted using the new NetBSD Bracket encryptor