### PR TITLE
Refactor make-user-data

### DIFF
--- a/brkt_cli/make_user_data/test_make_user_data.py
+++ b/brkt_cli/make_user_data/test_make_user_data.py
@@ -14,10 +14,9 @@
 
 import inspect
 import os
-import StringIO
 import unittest
 
-from brkt_cli.make_user_data import MakeUserDataSubcommand
+from brkt_cli import make_user_data
 from brkt_cli.instance_config_args import instance_config_args_to_values
 
 
@@ -33,10 +32,7 @@ class TestMakeUserData(unittest.TestCase):
         self.maxDiff = None # show full diff with knowngood multi-line strings
 
     def run_cmd(self, values):
-        muds = MakeUserDataSubcommand()
-        outstream = StringIO.StringIO()
-        muds.run(values, out=outstream)
-        output = outstream.getvalue()
+        output = make_user_data.make(values)
 
         knowngood_file = os.path.join(self.testdata_dir,
                                       self.test_name + ".out")


### PR DESCRIPTION
Update the make-user-data command, so that it's a bit easier to test.
The work is now done by make_user_data.make() instead of the run()
method of the subcommand.

This change will be needed by upcoming change to all commands that print
formatted output to stdout.  make-user-data, make-key, make-token, and
get-public-key will all need a new option to print content to a file, so
that it doesn't get mangled by file redirection on Windows.