### PR TITLE
Add option to write to file instead of stdout

### DIFF
--- a/brkt_cli/argutil.py
+++ b/brkt_cli/argutil.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+def add_out(parser):
+    """ Add the --out argument, for writing command output to a file instead
+    of stdout.
+    """
+    parser.add_argument(
+        '--out',
+        metavar='PATH',
+        help=(
+            'Write the private key to a file instead of stdout.  This '
+            'can be used to avoid character encoding issues when '
+            'redirecting output on Windows.'
+        )
+    )

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -25,6 +25,7 @@ import iso8601
 import jwt
 
 import brkt_cli
+from brkt_cli import argutil
 from brkt_cli import util
 from brkt_cli.brkt_jwt import jwk
 from brkt_cli.subcommand import Subcommand
@@ -88,7 +89,7 @@ class MakeTokenSubcommand(Subcommand):
         log.debug(jwt_string)
         log.debug('Header: %s', json.dumps(get_header(jwt_string)))
         log.debug('Payload: %s', json.dumps(get_payload(jwt_string)))
-        print(jwt_string)
+        util.write_to_file_or_stdout(jwt_string, path=values.out)
 
         return 0
 
@@ -269,6 +270,7 @@ def setup_make_jwt_args(subparsers):
         metavar='TIMESTAMP',
         help='Token is not valid before this time'
     )
+    argutil.add_out(parser)
     parser.add_argument(
         '-v',
         '--verbose',

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -14,6 +14,7 @@
 import logging
 
 import brkt_cli.crypto
+from brkt_cli import argutil
 from brkt_cli import util
 from brkt_cli.subcommand import Subcommand
 
@@ -39,6 +40,7 @@ class GetPublicKeySubcommand(Subcommand):
             help='Print the public part of a private key',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
+        argutil.add_out(parser)
         parser.add_argument(
             'private_key_path',
             metavar='PATH',
@@ -60,7 +62,7 @@ class GetPublicKeySubcommand(Subcommand):
 
     def run(self, values):
         crypto = util.read_private_key(values.private_key_path)
-        print crypto.public_key_pem
+        util.write_to_file_or_stdout(crypto.public_key_pem, values.out)
         return 0
 
 

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -14,6 +14,8 @@
 import getpass
 import logging
 
+from brkt_cli import argutil
+from brkt_cli import util
 from brkt_cli.validation import ValidationError
 
 from brkt_cli.subcommand import Subcommand
@@ -58,6 +60,7 @@ class MakeKeySubcommand(Subcommand):
                 "passphrase."
             )
         )
+        argutil.add_out(parser)
         parser.add_argument(
             '--public-out',
             metavar='PATH',
@@ -83,7 +86,10 @@ class MakeKeySubcommand(Subcommand):
                 raise ValidationError('Passphrases do not match')
 
         crypto = brkt_cli.crypto.new()
-        print crypto.get_private_key_pem(passphrase)
+
+        util.write_to_file_or_stdout(
+            crypto.get_private_key_pem(passphrase),
+            path=values.out)
         if values.public_out:
             _write_file(values.public_out, crypto.public_key_pem)
 

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -17,6 +17,8 @@ import os
 import re
 
 import brkt_cli
+from brkt_cli import argutil
+from brkt_cli import util
 from brkt_cli.instance_config import GuestFile
 from brkt_cli.instance_config import INSTANCE_METAVISOR_MODE
 from brkt_cli.instance_config_args import (
@@ -133,12 +135,14 @@ class MakeUserDataSubcommand(Subcommand):
             dest='make_user_data_guest_fqdn',
             help=argparse.SUPPRESS
         )
+        argutil.add_out(parser)
 
     def verbose(self, values):
         return values.make_user_data_verbose
 
     def run(self, values):
-        print make(values)
+        mime = make(values)
+        util.write_to_file_or_stdout(mime, values.out)
         return 0
 
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -285,3 +285,18 @@ def parse_endpoint(endpoint):
     if groups[1] is not None:
         ret['port'] = int(groups[1][1:])
     return ret
+
+
+def write_to_file_or_stdout(content, path=None):
+    """ Write a content to either the given path, or stdout if path is None.
+    :raise ValidationError if the file can't be written
+    """
+    if not path:
+        print content
+        return
+
+    try:
+        with open(path, 'w') as f:
+            f.write(content)
+    except IOError as e:
+        raise ValidationError('Unable to write to %s: %s' % (path, e))


### PR DESCRIPTION
Add an --out option to the make-key, get-public-key, make-token, and
make-user-data commands, which causes output to be written to a file
instead of stdout.

This option is necessary on Windows, because PowerShell writes
redirected output as UTF-16.  Python is unable to make sense of UTF-16.
   For example, if you redirect the output of make-key to a file,
make-token will not recognize the file format.

Add a new argutil module, which will contain common command line
options.  Add a new function to util for writing output to either a file
or stdout.