### PR TITLE
Update front page and AWS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 **brkt-cli** is a command-line interface to the
 [Bracket Computing](http://www.brkt.com) service. It produces an
-encrypted version of an operating system image in [Amazon Web Services]
-(https://aws.amazon.com/)
-(AWS) or [Google Compute Engine](https://cloud.google.com/compute/)
-(GCE). The resulting encrypted image can then be launched in the same
-manner as the original.
+encrypted version of an operating system image that runs on
+[Amazon Web Services](aws.md) (AWS), [Google Compute Engine](gce.md)
+(GCE), or [VMware ESX](vmw.md). The resulting encrypted image can then
+be launched in the same manner as the original.  Please see the
+links above for cloud-provider specific details and an overview of
+the encryption process.
+
+**brkt-cli** also has commands for managing private/public key pairs
+and generating a JSON Web Token (JWT) that is used to authenticate with
+The Bracket Computing service.
 
 The latest release of **brkt-cli** is [1.0.6]
 (https://github.com/brkt/brkt-cli/releases/tag/brkt-cli-1.0.6).
@@ -71,20 +76,6 @@ $ pip install git+https://github.com/brkt/brkt-cli.git
 ```
 
 The master branch has the latest features and bug fixes, but is not as thoroughly tested as the official release.
-
-## Networking requirements
-
-The following network connections are established during image encryption:
-
-* **brkt-cli** talks to the Encryptor instance on port 80 by default. This can
-be overridden using the --status-port flag which support any port other than port 81.
-* The Encryptor talks to the Bracket service at `yetiapi.mgmt.brkt.com`.  In
-order to do this, port 443 must be accessible on the following hosts:
-  * 52.32.38.106
-  * 52.35.101.76
-  * 52.88.55.6
-* **brkt-cli** talks to `api.mgmt.brkt.com` on port 443.
-* Both **brkt-cli** and the Encryptor also need to access Amazon S3.
 
 ## Authentication
 

--- a/aws.md
+++ b/aws.md
@@ -108,10 +108,17 @@ permissions, such as running an instance, describing an image, and
 creating snapshots.  See [brkt-cli-iam-permissions.json](https://github.com/brkt/brkt-cli/blob/master/reference_templates/brkt-cli-iam-permissions.json)
 for the complete list of required permissions.
 
+You can use the `--subnet` option to launch the Encryptor in a specific
+VPC and subnet.  Without this option, the encryptor is launched in
+your default VPC and subnet.
+
 When launching the Encryptor or Updater instance, **brkt-cli** creates
 a temporary security group that allows inbound access on port 80.
 Alternately, you can use the `--security-group` option to specify one
 or more existing security groups.
+
+If both `--subnet` and `--security-group` are specified, they must
+be in the same VPC.
 
 ## Usage
 ```


### PR DESCRIPTION
Update the description to include VMware, keys, and tokens.

Update links, so that they point to our provider-specific docs.  Chances
are that the reader already knows what AWS, GCE, and VMware are.

Move networking requirements to the AWS page, since they differ by CSP.
We will add networking requirements for GCE and VMware in a subsequent
commit.

Rearrange the AWS page so that the usage sections are at the bottom.
They're just a reference.  The shorter, descriptive sections should be
higher up.