### PR TITLE
Userdata changes for unencrypted guests

### DIFF
--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -29,7 +29,10 @@ from brkt_cli import ValidationError, encryptor_service
 from brkt_cli.aws import aws_service, encrypt_ami, update_ami
 from brkt_cli.aws import test_aws_service
 from brkt_cli.aws.test_aws_service import build_aws_service
-from brkt_cli.instance_config import BRKT_CONFIG_CONTENT_TYPE
+from brkt_cli.instance_config import (
+    BRKT_CONFIG_CONTENT_TYPE,
+    INSTANCE_UPDATER_MODE,
+)
 from brkt_cli.util import CRYPTO_GCM
 from brkt_cli.instance_config_args import (
     instance_config_args_to_values,
@@ -561,7 +564,7 @@ class TestBrktEnv(unittest.TestCase):
         cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
                                          network_host_port)
         values = instance_config_args_to_values(cli_args)
-        ic = instance_config_from_values(values)
+        ic = instance_config_from_values(values, mode=INSTANCE_UPDATER_MODE)
 
         def run_instance_callback(args):
             if args.image_id == encryptor_image.id:

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -31,7 +31,10 @@ from brkt_cli.encryptor_service import (
     wait_for_encryptor_up,
     wait_for_encryption,
 )
-from brkt_cli.instance_config import InstanceConfig
+from brkt_cli.instance_config import (
+    InstanceConfig,
+    INSTANCE_UPDATER_MODE,
+)
 from brkt_cli.user_data import gzip_user_data
 from brkt_cli.util import Deadline
 from encrypt_ami import (
@@ -63,7 +66,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
     mv_root_id = None
     temp_sg_id = None
     if instance_config is None:
-        instance_config = InstanceConfig()
+        instance_config = InstanceConfig(mode=INSTANCE_UPDATER_MODE)
 
     try:
         guest_image = aws_svc.get_image(encrypted_ami)
@@ -75,7 +78,6 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
         # information embedded in the guest AMI
         log.info("Launching encrypted guest/updater")
 
-        instance_config.brkt_config['solo_mode'] = 'updater'
         instance_config.brkt_config['status_port'] = status_port
 
         encrypted_guest = aws_svc.run_instance(

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -666,7 +666,6 @@ class VCenterService(BaseVCenterService):
             if instance_config:
                 brkt_config = instance_config.get_brkt_config()
             if update is True:
-                brkt_config['solo_mode'] = 'updater'
                 instance_config.set_mode(INSTANCE_UPDATER_MODE)
             if ssh_key_file:
                 with open(ssh_key_file, 'r') as f:

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -62,7 +62,6 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
         snap_created = True
 
         log.info("Launching encrypted updater")
-        instance_config.brkt_config['solo_mode'] = 'updater'
         user_data = gce_metadata_from_userdata(instance_config.make_userdata())
         gce_svc.run_instance(zone,
                              updater,

--- a/brkt_cli/instance_config.py
+++ b/brkt_cli/instance_config.py
@@ -35,9 +35,9 @@ GUEST_FILES_CONTENT_TYPE = 'text/brkt-guest-files'
 
 # Some instance config args are only supported when the Metavisor instance
 # is running in 'creator' mode.
-INSTANCE_METAVISOR_MODE = 1
-INSTANCE_CREATOR_MODE   = 2
-INSTANCE_UPDATER_MODE   = 3
+INSTANCE_METAVISOR_MODE = 'metavisor'
+INSTANCE_CREATOR_MODE   = 'creator'
+INSTANCE_UPDATER_MODE   = 'updater'
 
 log = logging.getLogger(__name__)
 
@@ -78,24 +78,31 @@ class InstanceConfig(object):
     def add_guest_file(self, guest_file):
         self._guest_files.append(guest_file)
 
+    def ensure_solo_mode_in_config(self):
+        if 'solo_mode' not in self.brkt_config:
+            self.brkt_config['solo_mode'] = self._mode
+
     def set_mode(self, mode=INSTANCE_CREATOR_MODE):
         self._mode = mode
         if mode is INSTANCE_METAVISOR_MODE:
             self._brkt_files_dest_dir = BRKT_FILE_INSTANCE_CONFIG
         else:
             self._brkt_files_dest_dir = BRKT_FILE_AMI_CONFIG
+        self.ensure_solo_mode_in_config()
 
     def get_brkt_config(self):
         return self.brkt_config
 
     def set_brkt_config(self, brkt_config):
         self.brkt_config = brkt_config
+        self.ensure_solo_mode_in_config()
 
     def make_brkt_config_json(self):
         brkt_config_dict = {'brkt': self.brkt_config}
         return json.dumps(brkt_config_dict, sort_keys=True)
 
     def make_userdata(self):
+        self.ensure_solo_mode_in_config()
         udc = UserDataContainer()
 
         udc.add_part(BRKT_CONFIG_CONTENT_TYPE, self.make_brkt_config_json())

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -81,6 +81,9 @@ def make(values):
         vpn_config = 'fqdn: %s\n' % (values.make_user_data_guest_fqdn,)
         instance_cfg.add_brkt_file('vpn.yaml', vpn_config)
 
+    if values.unencrypted_guest:
+        instance_cfg.brkt_config['allow_unencrypted_guest'] = 'true'
+
     return instance_cfg.make_userdata()
 
 
@@ -109,6 +112,12 @@ class MakeUserDataSubcommand(Subcommand):
             dest='make_user_data_verbose',
             action='store_true',
             help='Print status information to the console'
+        )
+        parser.add_argument(
+            '--unencrypted-guest',
+            dest='unencrypted_guest',
+            action='store_true',
+            help=argparse.SUPPRESS
         )
         parser.add_argument(
             '--brkt-file',

--- a/brkt_cli/make_user_data/test_make_user_data.py
+++ b/brkt_cli/make_user_data/test_make_user_data.py
@@ -51,6 +51,7 @@ class TestMakeUserData(unittest.TestCase):
         values.make_user_data_brkt_files = None
         values.make_user_data_guest_fqdn = None
         values.make_user_data_guest_files = None
+        values.unencrypted_guest = False
         return values
 
     def test_token_and_one_brkt_file(self):
@@ -106,4 +107,9 @@ class TestMakeUserData(unittest.TestCase):
         infile2 = os.path.join(self.testdata_dir, 'cloud-config')
         values.make_user_data_guest_files = [
             infile1 + ':x-shellscript', infile2 + ':cloud-config' ]
+        self.run_cmd(values)
+
+    def test_unencrypted_guest(self):
+        values = self._init_values()
+        values.unencrypted_guest = True
         self.run_cmd(values)

--- a/brkt_cli/make_user_data/testdata/test_add_one_binary_brkt_file.out
+++ b/brkt_cli/make_user_data/testdata/test_add_one_binary_brkt_file.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {}}
+{"brkt": {"solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/brkt-files; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_add_one_brkt_file.out
+++ b/brkt_cli/make_user_data/testdata/test_add_one_brkt_file.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {}}
+{"brkt": {"solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/brkt-files; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_add_two_brkt_files.out
+++ b/brkt_cli/make_user_data/testdata/test_add_two_brkt_files.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {}}
+{"brkt": {"solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/brkt-files; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_brkt_files_with_guest_userdata.out
+++ b/brkt_cli/make_user_data/testdata/test_brkt_files_with_guest_userdata.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"identity_token": "THIS_IS_NOT_A_JWT"}}
+{"brkt": {"identity_token": "THIS_IS_NOT_A_JWT", "solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/x-shellscript; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_guest_userdata.out
+++ b/brkt_cli/make_user_data/testdata/test_guest_userdata.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {}}
+{"brkt": {"solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/x-shellscript; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_proxy_and_one_brkt_file.out
+++ b/brkt_cli/make_user_data/testdata/test_proxy_and_one_brkt_file.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {}}
+{"brkt": {"solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/brkt-files; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_token_and_one_brkt_file.out
+++ b/brkt_cli/make_user_data/testdata/test_token_and_one_brkt_file.out
@@ -7,7 +7,7 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"identity_token": "THIS_IS_NOT_A_JWT"}}
+{"brkt": {"identity_token": "THIS_IS_NOT_A_JWT", "solo_mode": "metavisor"}}
 ----===============HI-20131203==--
 Content-Type: text/brkt-files; charset="utf-8"
 MIME-Version: 1.0

--- a/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
+++ b/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
@@ -7,14 +7,5 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"solo_mode": "metavisor"}}
-----===============HI-20131203==--
-Content-Type: text/brkt-files; charset="utf-8"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-
-/var/brkt/instance_config/vpn.yaml: {contents: 'fqdn: instance.foo.bar.com
-
-    '}
-
+{"brkt": {"allow_unencrypted_guest": "true", "solo_mode": "metavisor"}}
 ----===============HI-20131203==----

--- a/brkt_cli/test_instance_config.py
+++ b/brkt_cli/test_instance_config.py
@@ -15,7 +15,6 @@
 import inspect
 import json
 import os
-import sys
 import tempfile
 import unittest
 
@@ -81,8 +80,9 @@ class TestInstanceConfig(unittest.TestCase):
         ic = InstanceConfig(brkt_config_in)
         config_json = ic.make_brkt_config_json()
         expected_json = ('{"brkt": {"api_host": "%s", ' +
-            '"hsmproxy_host": "%s", "network_host": "%s"}}') % \
-            (api_host_port, hsmproxy_host_port, network_host_port)
+            '"hsmproxy_host": "%s", "network_host": "%s", ') % \
+            (api_host_port, hsmproxy_host_port, network_host_port) + \
+            '"solo_mode": "creator"}}'
         self.assertEqual(config_json, expected_json)
 
     def test_ntp_servers(self):
@@ -90,21 +90,24 @@ class TestInstanceConfig(unittest.TestCase):
         ic = InstanceConfig({'ntp_servers': [ntp_server1]})
 
         config_json = ic.make_brkt_config_json()
-        expected_json = '{"brkt": {"ntp_servers": ["%s"]}}' % ntp_server1
+        expected_json = '{"brkt": {"ntp_servers": ["%s"], ' % ntp_server1 + \
+                        '"solo_mode": "creator"}}'
         self.assertEqual(config_json, expected_json)
 
         # Now try two servers
         ic = InstanceConfig({'ntp_servers': [ntp_server1, ntp_server2]})
 
         config_json = ic.make_brkt_config_json()
-        expected_json = '{"brkt": {"ntp_servers": ["%s", "%s"]}}' % \
-                        (ntp_server1, ntp_server2)
+        expected_json = '{"brkt": {"ntp_servers": ["%s", "%s"], ' % \
+                        (ntp_server1, ntp_server2) + \
+                        '"solo_mode": "creator"}}'
         self.assertEqual(config_json, expected_json)
 
     def test_jwt(self):
         ic = InstanceConfig({'identity_token': test_jwt})
         config_json = ic.make_brkt_config_json()
-        expected_json = '{"brkt": {"identity_token": "%s"}}' % test_jwt
+        expected_json = '{"brkt": {"identity_token": "%s", ' % test_jwt + \
+                        '"solo_mode": "creator"}}'
         self.assertEqual(config_json, expected_json)
 
     def test_proxy_config(self):
@@ -266,25 +269,20 @@ class TestInstanceConfigFromCliArgs(unittest.TestCase):
             with self.assertRaises(ValidationError):
                 ic = instance_config_from_values(values)
 
-        # Now use endpoint args and a valid cert
+        # Now use endpoint args and a valid cert, with all three modes
         cli_args = endpoint_args + ' --ca-cert %s' % _get_ca_cert_filename()
-        values = instance_config_args_to_values(cli_args)
-        ic = instance_config_from_values(values)
-        ud = ic.make_userdata()
-        brkt_files = get_mime_part_payload(ud, BRKT_FILES_CONTENT_TYPE)
-        self.assertTrue(brkt_files.startswith(
-                        "/var/brkt/ami_config/ca_cert.pem.dummy.foo.com: " +
-                        "{contents: '-----BEGIN CERTIFICATE-----"))
-
-        # Make sure the --ca-cert arg is only recognized in 'creator' mode
-        # prevent stderr message from parse_args
-        sys.stderr = open(os.devnull, 'w')
-        try:
-            values = instance_config_args_to_values(cli_args,
-                                                    mode=INSTANCE_METAVISOR_MODE)
-        except SystemExit:
-            pass
-        else:
-            self.assertTrue(False, 'Did not get expected exception')
-        sys.stderr.close()
-        sys.stderr = sys.__stderr__
+        all_modes = [INSTANCE_METAVISOR_MODE, INSTANCE_UPDATER_MODE,
+                     INSTANCE_CREATOR_MODE]
+        for mode in all_modes:
+            values = instance_config_args_to_values(cli_args)
+            ic = instance_config_from_values(values, mode=mode)
+            ud = ic.make_userdata()
+            brkt_files = get_mime_part_payload(ud, BRKT_FILES_CONTENT_TYPE)
+            if mode is INSTANCE_METAVISOR_MODE:
+                self.assertTrue(brkt_files.startswith(
+                    "/var/brkt/instance_config/ca_cert.pem.dummy.foo.com: " +
+                    "{contents: '-----BEGIN CERTIFICATE-----"))
+            else:
+                self.assertTrue(brkt_files.startswith(
+                    "/var/brkt/ami_config/ca_cert.pem.dummy.foo.com: " +
+                    "{contents: '-----BEGIN CERTIFICATE-----"))

--- a/test_esx.py
+++ b/test_esx.py
@@ -162,7 +162,6 @@ class DummyVCenterService(esx_service.BaseVCenterService):
         if instance_config:
             brkt_config = instance_config.get_brkt_config()
         if update is True:
-            brkt_config['solo_mode'] = 'updater'
             instance_config.set_mode(INSTANCE_UPDATER_MODE)
         if ssh_key_file:
             with open(ssh_key_file, 'r') as f:


### PR DESCRIPTION
* These changes enable running MV instances (launched from the usual 'creator' images/AMIs with unencrypted guest roots attached. Such instances must have 'solo_mode: metavisor' in the userdata; they may also need Yeti endpoints and Yeti CA certs included as well.
* Adds (hidden) --unencrypted-guest arg to make-user-data to allow MV instances to be launched with unencrypted guest root disks.
* Allow brkt env and CA certs to be included in userdata for instances in 'metavisor' mode.
* Ensure the solo_mode is always included in userdata (only new for 'metavisor' mode.
* Adapted unit tests to these new behaviors.

Testing:
* Ran updated unit tests.
* Encrypted instance in GCE.
* Generated userdata manually for various CLI inputs.