### PR TITLE
Use boolean for allow_unencrypted_guest

### DIFF
--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -82,7 +82,7 @@ def make(values):
         instance_cfg.add_brkt_file('vpn.yaml', vpn_config)
 
     if values.unencrypted_guest:
-        instance_cfg.brkt_config['allow_unencrypted_guest'] = 'true'
+        instance_cfg.brkt_config['allow_unencrypted_guest'] = True
 
     return instance_cfg.make_userdata()
 

--- a/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
+++ b/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
@@ -7,5 +7,5 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"allow_unencrypted_guest": "true", "solo_mode": "metavisor"}}
+{"brkt": {"allow_unencrypted_guest": true, "solo_mode": "metavisor"}}
 ----===============HI-20131203==----


### PR DESCRIPTION
* Instead of "true", use a boolean (true) for the flag to convey that it's OK to boot from an unencrypted guest.