### PR TITLE
Close the debug log file before deleting it

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -613,6 +613,7 @@ def main():
         if debug_handler:
             logging.root.removeHandler(debug_handler)
             debug_handler.close()
+            debug_log_file.close()
 
             if result != 0 and allow_debug_log:
                 log.info('Debug log is available at %s', debug_log_file.name)


### PR DESCRIPTION
Turned out that closing the log handler was not enough.  We also have to
manually close the temporary log file that we created.  Once we do this,
Windows is able to delete the file.