### PR TITLE
Fix typos in docs and command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZC...
 
 ## Encrypting an image
 
-See the [AWS](aws.md), [GCE](gce.md) or [VMWare](esx.md) pages for 
+See the [AWS](aws.md), [GCE](gce.md) or [VMware](esx.md) pages for
 platform-specific documentation on encrypting and updating an image.
 
 ## <a name="docker"/>Running in a Docker container

--- a/aws.md
+++ b/aws.md
@@ -1,4 +1,4 @@
-# AWS Operations
+# AWS operations
 
 The `aws` subcommand provides all AWS related operations for encrypting and updating images.
 

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -418,7 +418,7 @@ def run_rescue_metavisor(values, parsed_config, log):
         return 1
 
 
-class VMWareSubcommand(Subcommand):
+class VMwareSubcommand(Subcommand):
 
     def name(self):
         return 'vmware'
@@ -427,8 +427,8 @@ class VMWareSubcommand(Subcommand):
         self.config = parsed_config
         vmware_parser = subparsers.add_parser(
             self.name(),
-            description='VMWare Operations',
-            help='VMWare Operations',
+            description='VMware operations',
+            help='VMware operations',
         )
 
         vmware_subparsers = vmware_parser.add_subparsers(
@@ -591,7 +591,7 @@ class RescueMetavisorSubcommand(Subcommand):
 
 
 def get_subcommands():
-    return [VMWareSubcommand(),
+    return [VMwareSubcommand(),
             EncryptVMDKSubcommand(),
             UpdateVMDKSubcommand(),
             RescueMetavisorSubcommand()]

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -174,8 +174,8 @@ class GCESubcommand(Subcommand):
 
         gce_parser = subparsers.add_parser(
             self.name(),
-            description='GCE Operations',
-            help='GCE Operations'
+            description='GCE operations',
+            help='GCE operations'
         )
 
         gce_subparsers = gce_parser.add_subparsers(

--- a/esx.md
+++ b/esx.md
@@ -1,6 +1,6 @@
-# VMWare Operations
+# VMware operations
 
-The `vmware` subcommand provides all VMWare related operations for encrypting and updating images, with a vCenter or directly on an ESX host.
+The `vmware` subcommand provides all VMware related operations for encrypting and updating images, with a vCenter or directly on an ESX host.
 
 ```
 $ brkt vmware --help
@@ -8,7 +8,7 @@ usage: brkt vmware [-h]
                    {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,rescue-metavisor}
                    ...
 
-VMWare Operations
+VMware operations
 
 positional arguments:
   {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,rescue-metavisor}

--- a/gce.md
+++ b/gce.md
@@ -1,4 +1,4 @@
-# GCE Operations
+# GCE operations
 
 The `gce` subcommand provides all GCE related operations for encrypting, updating and launching images.
 
@@ -6,7 +6,7 @@ The `gce` subcommand provides all GCE related operations for encrypting, updatin
 $ brkt gce --help
 usage: brkt gce [-h] {encrypt,update,launch} ...
 
-GCE Operations
+GCE operations
 
 positional arguments:
   {encrypt,update,launch}


### PR DESCRIPTION
Change "VMWare" to "VMware."  Only capitalize the first word in docs and
usage sections, per current convention.