### PR TITLE
Provide ability to tag GCE instances

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -162,8 +162,8 @@ optional arguments:
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
   --subnet ID           Launch instances in this subnet (default: None)
-  --tag KEY=VALUE       Custom tag for resources created during encryption.
-                        May be specified multiple times. (default: None)
+  --tag KEY=VALUE       Set an AWS tag on resources created during encryption.
+                        May be specified multiple times.
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)
@@ -218,8 +218,8 @@ optional arguments:
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
   --subnet ID           Launch instances in this subnet (default: None)
-  --tag KEY=VALUE       Custom tag for resources created during encryption.
-                        May be specified multiple times. (default: None)
+  --tag KEY=VALUE       Set an AWS tag on resources created during update. May
+                        be specified multiple times.
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)

--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -41,6 +41,8 @@ def run_encrypt(values, config):
                                     values.encryptor_image,
                                     values.image,
                                     values.image_project)
+        if values.gce_tags:
+            validate_tags(values.gce_tags)
 
     if not values.verbose:
         logging.getLogger('googleapiclient').setLevel(logging.ERROR)
@@ -64,7 +66,8 @@ def run_encrypt(values, config):
         network=values.network,
         subnetwork=values.subnetwork,
         status_port=values.status_port,
-        cleanup=values.cleanup
+        cleanup=values.cleanup,
+        gce_tags=values.gce_tags
     )
     # Print the image name to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
@@ -85,6 +88,8 @@ def run_update(values, config):
                                     encrypted_image_name,
                                     values.encryptor_image,
                                     values.image)
+        if values.gce_tags:
+            validate_tags(values.gce_tags)
     if not values.verbose:
         logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 
@@ -106,7 +111,8 @@ def run_update(values, config):
         network=values.network,
         subnetwork=values.subnetwork,
         status_port=values.status_port,
-        cleanup=values.cleanup
+        cleanup=values.cleanup,
+        gce_tags=values.gce_tags
     )
 
     print(updated_image_id)
@@ -135,6 +141,9 @@ def run_launch(values, config):
     if values.instance_name:
         gce_service.validate_image_name(values.instance_name)
 
+    if values.gce_tags:
+        validate_tags(values.gce_tags)
+
     encrypted_instance_id = launch_gce_image.launch(log,
                             gce_svc,
                             values.image,
@@ -145,7 +154,8 @@ def run_launch(values, config):
                             values.network,
                             values.subnetwork,
                             metadata,
-                            values.ssd_scratch_disks)
+                            values.ssd_scratch_disks,
+                            values.gce_tags)
     print(encrypted_instance_id)
     return 0
 
@@ -379,3 +389,7 @@ def check_args(values, gce_svc, cli_config):
         if brkt_env is None:
             _, brkt_env = cli_config.get_current_env()
         brkt_cli.check_jwt_auth(brkt_env, values.token)
+
+def validate_tags(tags):
+    for tag in tags:
+        gce_service.validate_image_name(tag)

--- a/brkt_cli/gce/encrypt_gce_image.py
+++ b/brkt_cli/gce/encrypt_gce_image.py
@@ -65,7 +65,8 @@ def do_encryption(gce_svc,
                   crypto_policy,
                   network,
                   subnetwork,
-                  status_port=ENCRYPTOR_STATUS_PORT):
+                  status_port=ENCRYPTOR_STATUS_PORT,
+                  gce_tags=None):
     instance_config.brkt_config['crypto_policy_type'] = crypto_policy
     metadata = gce_metadata_from_userdata(instance_config.make_userdata())
     log.info('Launching encryptor instance')
@@ -79,7 +80,8 @@ def do_encryption(gce_svc,
                                 gce_svc.get_disk(zone, encrypted_image_disk),
                                 gce_svc.get_disk(zone, dummy_name)],
                          delete_boot=False,
-                         metadata=metadata)
+                         metadata=metadata,
+                         tags=gce_tags)
 
     try:
         ip = gce_svc.get_instance_ip(encryptor, zone)
@@ -123,7 +125,7 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
             encrypted_image_name, zone, instance_config, crypto_policy,
             image_project=None, keep_encryptor=False, image_file=None,
             image_bucket=None, network=None, subnetwork=None,
-            status_port=ENCRYPTOR_STATUS_PORT, cleanup=True):
+            status_port=ENCRYPTOR_STATUS_PORT, cleanup=True, gce_tags=None):
     try:
         # create metavisor image from file in GCS bucket
         log.info('Retrieving encryptor image from GCS bucket')
@@ -156,7 +158,8 @@ def encrypt(gce_svc, enc_svc_cls, image_id, encryptor_image,
         # customer image and blank disk
         do_encryption(gce_svc, enc_svc_cls, zone, encryptor, encryptor_image,
                       instance_name, instance_config, encrypted_image_disk,
-                      crypto_policy, network, subnetwork, status_port=status_port)
+                      crypto_policy, network, subnetwork, status_port=status_port,
+                      gce_tags=gce_tags)
 
         # create image
         create_image(gce_svc, zone, encrypted_image_disk, encrypted_image_name, encryptor)

--- a/brkt_cli/gce/encrypt_gce_image_args.py
+++ b/brkt_cli/gce/encrypt_gce_image_args.py
@@ -72,6 +72,16 @@ def setup_encrypt_gce_image_args(parser, parsed_config):
         default=parsed_config.get_option('gce.subnetwork', None),
         required=False
     )
+    parser.add_argument(
+        '--gce-tag',
+        metavar='VALUE',
+        dest='gce_tags',
+        action='append',
+        help=(
+              'Set a GCE tag on the encryptor instance. May be specified'
+              ' multiple times.'
+        )
+    )
     # Optional Image Name that's used to launch the encryptor instance. This
     # argument is hidden because it's only used for development.
     parser.add_argument(

--- a/brkt_cli/gce/launch_gce_image.py
+++ b/brkt_cli/gce/launch_gce_image.py
@@ -7,7 +7,7 @@ from brkt_cli.util import (
 
 log = logging.getLogger(__name__)
 
-def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, subnetwork, metadata={}, ssd_disks=0):
+def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_type, network, subnetwork, metadata={}, ssd_disks=0, gce_tags=None):
     if not instance_name:
         instance_name = 'brkt' + '-' + str(uuid.uuid4().hex)
 
@@ -30,7 +30,8 @@ def launch(log, gce_svc, image_id, instance_name, zone, delete_boot, instance_ty
                          delete_boot=delete_boot,
                          network=network,
                          subnet=subnetwork,
-                         instance_type=instance_type)
+                         instance_type=instance_type,
+                         tags=gce_tags)
     gce_svc.wait_instance(instance_name, zone)
     log.info("Instance %s (%s) launched successfully" % (instance_name,
              gce_svc.get_instance_ip(instance_name, zone)))

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -46,6 +46,16 @@ def setup_launch_gce_image_args(parser):
         default='default',
         required=False
     )
+    parser.add_argument(
+        '--gce-tag',
+        dest='gce_tags',
+        action='append',
+        metavar='VALUE',
+        help=(
+              'Set a GCE tag on the encrypted instance being launched. May be '
+              'specified multiple times.'
+        )
+    )
 
     # Optional startup script. Hidden because it is only used for development
     # and testing. It should be passed as a string containing a multi-line

--- a/brkt_cli/gce/update_encrypted_gce_image_args.py
+++ b/brkt_cli/gce/update_encrypted_gce_image_args.py
@@ -54,6 +54,16 @@ def setup_update_gce_image_args(parser, parsed_config):
         default=parsed_config.get_option('gce.subnetwork', None),
         required=False
     )
+    parser.add_argument(
+        '--gce-tag',
+        dest='gce_tags',
+        action='append',
+        metavar='VALUE',
+        help=(
+              'Set a GCE tag on the updater instance. May be specified '
+              'multiple times.'
+        )
+    )
     # Optional arg <image name>.image.tar.gz for specifying metavisor
     # image file if you don't want to use the latest image
     parser.add_argument(

--- a/brkt_cli/gce/update_gce_image.py
+++ b/brkt_cli/gce/update_gce_image.py
@@ -35,7 +35,7 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
                      keep_encryptor=False, image_file=None,
                      image_bucket=None, network=None,
                      subnetwork=None, status_port=ENCRYPTOR_STATUS_PORT,
-                     cleanup=True):
+                     cleanup=True, gce_tags=None):
     snap_created = None
     instance_name = 'brkt-updater-' + gce_svc.get_session_id()
     updater = instance_name + '-metavisor'
@@ -70,7 +70,8 @@ def update_gce_image(gce_svc, enc_svc_cls, image_id, encryptor_image,
                              subnet=subnetwork,
                              disks=[],
                              delete_boot=False,
-                             metadata=user_data)
+                             metadata=user_data,
+                             tags=gce_tags)
         ip = gce_svc.get_instance_ip(updater, zone)
         updater_launched = True
         enc_svc = enc_svc_cls([ip], port=status_port)

--- a/gce.md
+++ b/gce.md
@@ -60,11 +60,11 @@ image.
 ```
 $ brkt gce encrypt --help
 usage: brkt gce encrypt [-h] [--encrypted-image-name NAME] --zone ZONE
-                        [--encryptor-image-bucket BUCKET] [--no-validate]
-                        --project PROJECT [--image-project NAME]
+                        [--no-validate] --project PROJECT
+                        [--image-project NAME]
                         [--encryptor-image ENCRYPTOR_IMAGE]
                         [--network NETWORK] [--subnetwork SUBNETWORK]
-                        [--ntp-server DNS_NAME]
+                        [--gce-tag VALUE] [--ntp-server DNS_NAME]
                         [--proxy HOST:PORT | --proxy-config-file PATH]
                         [--status-port PORT] [--token TOKEN]
                         ID
@@ -79,11 +79,10 @@ optional arguments:
                         Specify the name of the generated encrypted image
                         (default: None)
   --encryptor-image ENCRYPTOR_IMAGE
-  --encryptor-image-bucket BUCKET
-                        Bucket to retrieve encryptor image from (prod, stage,
-                        shared, <custom>) (default: prod)
+  --gce-tag             Set a GCE tag on the encryptor instance. May be
+                        specified multiple times.
   --image-project NAME  GCE project name which owns the image (e.g. centos-
-                        cloud) (default: None
+                        cloud) (default: None)
   --network NETWORK
   --no-validate         Don't validate images or token (default: True)
   --ntp-server DNS_NAME
@@ -112,9 +111,9 @@ image with the latest version of the Metavisor code.
 ```
 $ brkt gce update --help
 usage: brkt gce update [-h] [--encrypted-image-name NAME] --zone ZONE
-                       [--encryptor-image-bucket BUCKET] --project PROJECT
-                       [--no-validate] [--encryptor-image ENCRYPTOR_IMAGE]
-                       [--network NETWORK] [--subnetwork SUBNETWORK]
+                       --project PROJECT [--no-validate]
+                       [--encryptor-image ENCRYPTOR_IMAGE] [--network NETWORK]
+                       [--subnetwork SUBNETWORK] [--gce-tag VALUE]
                        [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--status-port PORT] [--token TOKEN]
@@ -130,9 +129,8 @@ optional arguments:
                         Specify the name of the generated encrypted Image
                         (default: None)
   --encryptor-image ENCRYPTOR_IMAGE
-  --encryptor-image-bucket BUCKET
-                        Bucket to retrieve encryptor image from (prod, stage,
-                        shared, <custom>) (default: prod)
+  --gce-tag             Set a GCE tag on the updater instance. May be
+                        specified multiple times.
   --network NETWORK
   --no-validate         Don't validate images or token (default: True)
   --ntp-server DNS Name
@@ -161,8 +159,10 @@ The `gce launch` subcommand launches an encrypted GCE image.
 $ brkt gce launch --help
 usage: brkt gce launch [-h] [--instance-name NAME]
                        [--instance-type INSTANCE_TYPE] [--zone ZONE]
-                       [--delete-boot] --project PROJECT [--network NETWORK]
-                       [--subnetwork NAME] [--ntp-server DNS_NAME]
+                       [--no-delete-boot] --project PROJECT
+                       [--network NETWORK] [--gce-tag VALUE]
+                       [--subnetwork NAME] [--ssd-scracth-disks N]
+                       [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--token TOKEN]
                        ID
@@ -173,12 +173,14 @@ positional arguments:
   ID                    The image that will be launched
 
 optional arguments:
-  --delete-boot         Delete boot disk when instance is deleted (default:
-                        False)
-  --instance-name NAME  Name of the instance (default: None)
+  --gce-tag             Set a GCE tag on the encrypted instance being
+                        launched. May be specified multiple times.
+  --instance-name NAME  Name of the instance
   --instance-type INSTANCE_TYPE
                         Instance type (default: n1-standard-1)
   --network NETWORK
+  --no-delete-boot      Delete boot disk when instance is deleted (default:
+                        False)
   --ntp-server DNS_NAME
                         Optional NTP server to sync Metavisor clock. May be
                         specified multiple times. (default: None)
@@ -188,6 +190,9 @@ optional arguments:
   --proxy-config-file PATH
                         Path to proxy.yaml file that will be used during
                         encryption (default: None)
+  --ssd-scratch-disks N
+                        Number of SSD scratch disks to be attached (max. 8)
+                        (default: 0)
   --subnetwork NAME     Launch instance in this subnetwork (default: None)
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-

--- a/test_gce.py
+++ b/test_gce.py
@@ -173,7 +173,8 @@ class DummyGCEService(gce_service.BaseGCEService):
                      delete_boot=False,
                      block_project_ssh_keys=False,
                      instance_type='n1-standard-4',
-                     image_project=None):
+                     image_project=None,
+                     tags=None):
         self.instances.append(name)
         if not delete_boot:
             self.disks.append(name)
@@ -185,6 +186,12 @@ class DummyGCEService(gce_service.BaseGCEService):
             'autoDelete': False,
             'source': self.gce_res_uri + source_disk,
         }
+
+    def set_tags(self, zone, instance, tags):
+        return
+
+    def get_tags_fingerprint(self, instance, zone):
+        return 'fingerprint'
 
 
 class TestEncryptedImageName(unittest.TestCase):


### PR DESCRIPTION
GCE provides ability to tag instances and subsequently these tags
can be used in the network/firewall rules. Hence firewall rules
can be specified based on specific instance tags, which can be
assigned at launch time to control the network communication(s)
required by the specific GCE instance.
Online docs hace also been updated to reflect the new arguments/
usage.