### PR TITLE
Rename AWS tag argument

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -126,7 +126,7 @@ $ brkt aws encrypt --help
 usage: brkt aws encrypt [-h] [--encrypted-ami-name NAME]
                         [--guest-instance-type TYPE] [--pv] [--no-validate]
                         --region NAME [--security-group ID] [--subnet ID]
-                        [--tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
+                        [--aws-tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
                         [--proxy HOST:PORT | --proxy-config-file PATH]
                         [--status-port PORT] [--token TOKEN]
                         ID
@@ -162,7 +162,7 @@ optional arguments:
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
   --subnet ID           Launch instances in this subnet (default: None)
-  --tag KEY=VALUE       Set an AWS tag on resources created during encryption.
+  --aws-tag KEY=VALUE   Set an AWS tag on resources created during encryption.
                         May be specified multiple times.
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
@@ -181,7 +181,7 @@ usage: brkt aws update [-h] [--encrypted-ami-name NAME]
                        [--guest-instance-type TYPE]
                        [--updater-instance-type TYPE] [--pv] [--no-validate]
                        --region REGION [--security-group ID] [--subnet ID]
-                       [--tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
+                       [--aws-tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--status-port PORT] [--token TOKEN]
                        ID
@@ -218,7 +218,7 @@ optional arguments:
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
   --subnet ID           Launch instances in this subnet (default: None)
-  --tag KEY=VALUE       Set an AWS tag on resources created during update. May
+  --aws-tag KEY=VALUE   Set an AWS tag on resources created during update. May
                         be specified multiple times.
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -130,7 +130,8 @@ def run_diag(values):
 
     aws_svc.connect(values.region, key_name=values.key_name)
     default_tags = {}
-    default_tags.update(brkt_cli.parse_tags(values.tags))
+    tags = merge_aws_tags(values.tags, values.aws_tags)
+    default_tags.update(brkt_cli.parse_tags(tags))
     aws_svc.default_tags = default_tags
 
     if values.validate:
@@ -223,7 +224,8 @@ def run_encrypt(values, config, verbose=False):
 
     encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
     default_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
-    default_tags.update(brkt_cli.parse_tags(values.tags))
+    tags = merge_aws_tags(values.tags, values.aws_tags)
+    default_tags.update(brkt_cli.parse_tags(tags))
     aws_svc.default_tags = default_tags
 
     if values.validate:
@@ -311,7 +313,8 @@ def run_update(values, config, verbose=False):
     encrypted_image = _validate_ami(aws_svc, values.ami)
     encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
     default_tags = encrypt_ami.get_default_tags(nonce, encryptor_ami)
-    default_tags.update(brkt_cli.parse_tags(values.tags))
+    tags = merge_aws_tags(values.tags, values.aws_tags)
+    default_tags.update(brkt_cli.parse_tags(tags))
     aws_svc.default_tags = default_tags
 
     if values.validate:
@@ -840,3 +843,24 @@ def _get_updated_image_name(image_name, session_id):
         encrypted_ami_name = util.append_suffix(
             image_name, suffix, max_length=128)
     return encrypted_ami_name
+
+
+def merge_aws_tags(old_tags, new_tags):
+    """ Merge the attribute values for the old and new tag arguments to a
+    single attribute list.
+
+    : return the merged attribute list or None
+    """
+    if old_tags:
+        log.warn(
+                 'The "--tag" argument has been deprecated. Please use '
+                 '"--aws-tag" instead.'
+        )
+        if new_tags:
+            return set(old_tags + new_tags)
+        else:
+            return old_tags
+    elif new_tags:
+        return new_tags
+    else:
+        return None

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -67,9 +67,9 @@ def setup_diag_args(parser):
         help='Launch instances in this subnet'
     )
     parser.add_argument(
-        '--tag',
+        '--aws-tag',
         metavar='KEY=VALUE',
-        dest='tags',
+        dest='aws_tags',
         action='append',
         help=(
             'Custom tag for resources created during encryption. '
@@ -89,6 +89,14 @@ def setup_diag_args(parser):
         help='ssh keypair name to be used to connect to diag instance.',
         required=True,
         dest='key_name'
+    )
+    # Hide deprecated --tags argument
+    parser.add_argument(
+        '--tag',
+        metavar='KEY=VALUE',
+        dest='tags',
+        action='append',
+        help=argparse.SUPPRESS
     )
     # Optional arguments for changing the behavior of our retry logic.  We
     # use these options internally, to avoid intermittent AWS service failures

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -72,9 +72,9 @@ def setup_encrypt_ami_args(parser):
         help='Launch instances in this subnet'
     )
     parser.add_argument(
-        '--tag',
+        '--aws-tag',
         metavar='KEY=VALUE',
-        dest='tags',
+        dest='aws_tags',
         action='append',
         help=(
             'Set an AWS tag on resources created during encryption. '
@@ -87,6 +87,14 @@ def setup_encrypt_ami_args(parser):
         dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
+    )
+    # Hide deprecated --tag argument
+    parser.add_argument(
+        '--tag',
+        metavar='KEY=VALUE',
+        dest='tags',
+        action='append',
+        help=argparse.SUPPRESS
     )
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -86,9 +86,9 @@ def setup_update_encrypted_ami(parser):
         dest='key_name'
     )
     parser.add_argument(
-        '--tag',
+        '--aws-tag',
         metavar='KEY=VALUE',
-        dest='tags',
+        dest='aws_tags',
         action='append',
         help=(
             'Set an AWS tag on resources created during update. '
@@ -101,6 +101,14 @@ def setup_update_encrypted_ami(parser):
         dest='aws_verbose',
         action='store_true',
         help='Print status information to the console'
+    )
+    # Hide deprecated --tag argument
+    parser.add_argument(
+        '--tag',
+        metavar='KEY=VALUE',
+        dest='tags',
+        action='append',
+        help=argparse.SUPPRESS
     )
     # Optional hidden argument for specifying the metavisor AMI.  This
     # argument is hidden because it's only used for development.  It can


### PR DESCRIPTION
 - Renamed AWS tag argument to --aws-tag to eliminate any confusion
with "Bracket tags" (or claims)
 - Added a deprecation warning message if the old --tag argument
is used (that is still supported, but now is hidden)
 - Updated the docs to reflect the update argument usage information