### PR TITLE
Deprecate -v at the subcommand level

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -124,9 +124,9 @@ be in the same VPC.
 ```
 $ brkt aws encrypt --help
 usage: brkt aws encrypt [-h] [--encrypted-ami-name NAME]
-                        [--guest-instance-type TYPE] [--pv] [--no-validate]
-                        --region NAME [--security-group ID] [--subnet ID]
-                        [--aws-tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
+                        [--guest-instance-type TYPE] [--no-validate] --region
+                        NAME [--security-group ID] [--subnet ID]
+                        [--aws-tag KEY=VALUE] [--ntp-server DNS_NAME]
                         [--proxy HOST:PORT | --proxy-config-file PATH]
                         [--status-port PORT] [--token TOKEN]
                         ID
@@ -137,51 +137,44 @@ positional arguments:
   ID                    The guest AMI that will be encrypted
 
 optional arguments:
+  --aws-tag KEY=VALUE   Set an AWS tag on resources created during encryption.
+                        May be specified multiple times.
   --encrypted-ami-name NAME
                         Specify the name of the generated encrypted AMI
-                        (default: None)
   --guest-instance-type TYPE
                         The instance type to use when running the unencrypted
                         guest instance (default: m3.medium)
   --no-validate         Don't validate AMIs, subnet, and security groups
-                        (default: True)
-  --ntp-server DNS Name
-                        Optional NTP server to sync Metavisor clock. May be
-                        specified multiple times. (default: None)
-  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
-                        specified multiple times. (default: None)
+  --ntp-server DNS_NAME
+                        NTP server to sync Metavisor clock. May be specified
+                        multiple times.
+  --proxy HOST:PORT     Proxy that Metavisor uses to talk to the Bracket
+                        service
   --proxy-config-file PATH
-                        Path to proxy.yaml file that will be used during
-                        encryption (default: None)
-  --pv                  Use the PV encryptor (default: False)
-  --region NAME         AWS region (e.g. us-west-2) (default: None)
+                        proxy.yaml file that defines the proxy configuration
+                        that metavisor uses to talk to the Bracket service
+  --region NAME         AWS region (e.g. us-west-2)
   --security-group ID   Use this security group when running the encryptor
-                        instance. May be specified multiple times. (default:
-                        None)
+                        instance. May be specified multiple times.
   --status-port PORT    Specify the port to receive http status of encryptor.
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
-  --subnet ID           Launch instances in this subnet (default: None)
-  --aws-tag KEY=VALUE   Set an AWS tag on resources created during encryption.
-                        May be specified multiple times.
-  --token TOKEN         Token that the encrypted instance will use to
-                        authenticate with the Bracket service. Use the make-
-                        token subcommand to generate a token. (default: None)
+  --subnet ID           Launch instances in this subnet
+  --token TOKEN         Token (JWT) that Metavisor uses to authenticate with
+                        the Bracket service. Use the make-token subcommand to
+                        generate a token.
   -h, --help            show this help message and exit
-  -v, --verbose         Print status information to the console (default:
-                        False)
 ```
 
 The `aws update` subcommand updates an encrypted AMI with the latest
 version of the Metavisor code.
 
 ```
-$ brkt aws update --help
 usage: brkt aws update [-h] [--encrypted-ami-name NAME]
                        [--guest-instance-type TYPE]
-                       [--updater-instance-type TYPE] [--pv] [--no-validate]
-                       --region REGION [--security-group ID] [--subnet ID]
-                       [--aws-tag KEY=VALUE] [-v] [--ntp-server DNS_NAME]
+                       [--updater-instance-type TYPE] [--no-validate] --region
+                       REGION [--security-group ID] [--subnet ID]
+                       [--aws-tag KEY=VALUE] [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--status-port PORT] [--token TOKEN]
                        ID
@@ -192,41 +185,35 @@ positional arguments:
   ID                    The encrypted AMI that will be updated
 
 optional arguments:
+  --aws-tag KEY=VALUE   Set an AWS tag on resources created during update. May
+                        be specified multiple times.
   --encrypted-ami-name NAME
                         Specify the name of the generated encrypted AMI
-                        (default: None)
   --guest-instance-type TYPE
                         The instance type to use when running the encrypted
                         guest instance. Default: m3.medium (default:
                         m3.medium)
   --no-validate         Don't validate AMIs, subnet, and security groups
-                        (default: True)
-  --ntp-server DNS Name
-                        Optional NTP server to sync Metavisor clock. May be
-                        specified multiple times. (default: None)
-  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
-                        specified multiple times. (default: None)
+  --ntp-server DNS_NAME
+                        NTP server to sync Metavisor clock. May be specified
+                        multiple times.
+  --proxy HOST:PORT     Proxy that Metavisor uses to talk to the Bracket
+                        service
   --proxy-config-file PATH
-                        Path to proxy.yaml file that will be used during
-                        encryption (default: None)
-  --pv                  Use the PV encryptor (default: False)
-  --region REGION       AWS region (e.g. us-west-2) (default: us-west-2)
+                        proxy.yaml file that defines the proxy configuration
+                        that metavisor uses to talk to the Bracket service
+  --region REGION       AWS region (e.g. us-west-2)
   --security-group ID   Use this security group when running the encryptor
-                        instance. May be specified multiple times. (default:
-                        None)
+                        instance. May be specified multiple times.
   --status-port PORT    Specify the port to receive http status of encryptor.
                         Any port in range 1-65535 can be used except for port
                         81. (default: 80)
-  --subnet ID           Launch instances in this subnet (default: None)
-  --aws-tag KEY=VALUE   Set an AWS tag on resources created during update. May
-                        be specified multiple times.
-  --token TOKEN         Token that the encrypted instance will use to
-                        authenticate with the Bracket service. Use the make-
-                        token subcommand to generate a token. (default: None)
+  --subnet ID           Launch instances in this subnet
+  --token TOKEN         Token (JWT) that Metavisor uses to authenticate with
+                        the Bracket service. Use the make-token subcommand to
+                        generate a token.
   --updater-instance-type TYPE
                         The instance type to use when running the updater
                         instance. Default: m3.medium (default: m3.medium)
   -h, --help            show this help message and exit
-  -v, --verbose         Print status information to the console (default:
-                        False)
 ```

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -441,7 +441,13 @@ class SortingHelpFormatter(argparse.HelpFormatter):
 
 
 def is_verbose(values, subcommand):
+    if subcommand.verbose(values):
+        print(
+            '%s --verbose is deprecated. Please use brkt --verbose '
+            'instead.' % subcommand.name(), file=sys.stderr)
+
     return values.verbose or subcommand.verbose(values)
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -81,7 +81,7 @@ def setup_diag_args(parser):
         '--verbose',
         dest='aws_verbose',
         action='store_true',
-        help='Print status information to the console'
+        help=argparse.SUPPRESS
     )
     parser.add_argument(
         '--key',

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -86,7 +86,7 @@ def setup_encrypt_ami_args(parser):
         '--verbose',
         dest='aws_verbose',
         action='store_true',
-        help='Print status information to the console'
+        help=argparse.SUPPRESS
     )
     # Hide deprecated --tag argument
     parser.add_argument(

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -46,7 +46,7 @@ def setup_share_logs_args(parser):
         '--verbose',
         dest='aws_verbose',
         action='store_true',
-        help='Print status information to the console'
+        help=argparse.SUPPRESS
     )
     # Hidden argument to specify AWS account to share account with - used
     # for developer testing

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -100,7 +100,7 @@ def setup_update_encrypted_ami(parser):
         '--verbose',
         dest='aws_verbose',
         action='store_true',
-        help='Print status information to the console'
+        help=argparse.SUPPRESS
     )
     # Hide deprecated --tag argument
     parser.add_argument(

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -276,7 +276,7 @@ def setup_make_jwt_args(subparsers):
         '--verbose',
         dest='make_jwt_verbose',
         action='store_true',
-        help='Print status information to the console'
+        help=argparse.SUPPRESS
     )
 
     # The signing key is now passed as a positional argument.  This option

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -11,6 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import logging
 
 import brkt_cli.crypto
@@ -54,7 +55,7 @@ class GetPublicKeySubcommand(Subcommand):
             '--verbose',
             dest='make_private_key_verbose',
             action='store_true',
-            help='Print status information to the console'
+            help=argparse.SUPPRESS
         )
 
     def verbose(self, values):

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -11,6 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import getpass
 import logging
 
@@ -71,7 +72,7 @@ class MakeKeySubcommand(Subcommand):
             '--verbose',
             dest='make_private_key_verbose',
             action='store_true',
-            help='Print status information to the console'
+            help=argparse.SUPPRESS
         )
 
     def verbose(self, values):

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -111,7 +111,7 @@ class MakeUserDataSubcommand(Subcommand):
             '--verbose',
             dest='make_user_data_verbose',
             action='store_true',
-            help='Print status information to the console'
+            help=argparse.SUPPRESS
         )
         parser.add_argument(
             '--unencrypted-guest',


### PR DESCRIPTION
Suppress the -v option from subcommand usage output and log a warning
when the option is used.  Also update sample usage in AWS docs.

Back story: some of our subcommands support the -v (--verbose) option
and others don't.  It's more consistent to just have it at the brkt
command level than to make sure that every subcommand implements it.