### PR TITLE
Read config variables for GCE Launch command

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -221,7 +221,7 @@ class GCESubcommand(Subcommand):
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         launch_gce_image_args.setup_launch_gce_image_args(
-            launch_gce_image_parser)
+            launch_gce_image_parser, parsed_config)
         setup_instance_config_args(launch_gce_image_parser, parsed_config,
                                    mode=INSTANCE_METAVISOR_MODE)
 
@@ -351,7 +351,7 @@ class LaunchGCEImageSubcommand(Subcommand):
             description='Launch a GCE image',
         )
         launch_gce_image_args.setup_launch_gce_image_args(
-            launch_gce_image_parser)
+            launch_gce_image_parser, parsed_config)
         setup_instance_config_args(launch_gce_image_parser, parsed_config,
                                    mode=INSTANCE_METAVISOR_MODE)
 

--- a/brkt_cli/gce/launch_gce_image_args.py
+++ b/brkt_cli/gce/launch_gce_image_args.py
@@ -3,7 +3,7 @@ import argparse
 
 # VERY EXPERIMENTAL FEATURE
 # It will not work for you
-def setup_launch_gce_image_args(parser):
+def setup_launch_gce_image_args(parser, parsed_config):
     parser.add_argument(
         'image',
         metavar='ID',
@@ -21,11 +21,17 @@ def setup_launch_gce_image_args(parser):
         dest='instance_type',
         default='n1-standard-1'
     )
+    zone_kwargs = {
+        'help': 'GCE zone to operate in',
+        'dest': 'zone',
+        'default': parsed_config.get_option('gce.zone'),
+        'required': False,
+    }
+    if zone_kwargs['default'] is None:
+        zone_kwargs['required'] = True
     parser.add_argument(
         '--zone',
-        help='GCE zone to operate in',
-        dest='zone',
-        default='us-central1-a'
+        **zone_kwargs
     )
     parser.add_argument(
         '--no-delete-boot',
@@ -34,16 +40,22 @@ def setup_launch_gce_image_args(parser):
         default=True,
         action='store_false'
     )
+    proj_kwargs = {
+        'help': 'GCE project name',
+        'dest': 'project',
+        'default': parsed_config.get_option('gce.project'),
+        'required': False,
+    }
+    if proj_kwargs['default'] is None:
+        proj_kwargs['required'] = True
     parser.add_argument(
         '--project',
-        help='GCE project name',
-        dest='project',
-        required=True
+        **proj_kwargs
     )
     parser.add_argument(
         '--network',
         dest='network',
-        default='default',
+        default=parsed_config.get_option('gce.network', 'default'),
         required=False
     )
     parser.add_argument(
@@ -71,6 +83,7 @@ def setup_launch_gce_image_args(parser):
         metavar='NAME',
         help='Launch instance in this subnetwork',
         dest='subnetwork',
+        default=parsed_config.get_option('gce.subnetwork', None),
         required=False
     )
     parser.add_argument(


### PR DESCRIPTION
The `brkt gce launch` command was not reading the brkt config
settings for some of the attributes. This update ensures that
the launch command is on par with the encrypt and update GCE
commands for reading the config settings.