### PR TITLE
Ignore endpoints from config for 'gce launch'

### DIFF
--- a/brkt_cli/gce/__init__.py
+++ b/brkt_cli/gce/__init__.py
@@ -124,7 +124,7 @@ def run_launch(values, config):
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_METAVISOR_MODE, cli_config=config)
+        values, mode=INSTANCE_METAVISOR_MODE)
     if values.startup_script:
         extra_items = [{
             'key': 'startup-script',


### PR DESCRIPTION
* For 'gce launch', don't try to get the brkt-env from the CLI config.
* If we factor in the CLI config when determining the brkt-env for 'gce launch' then we will always get a brkt-env from the CLI config (the endpoints may be for Prod); that makes it easy to accidentally use Prod endpoints when launching instances encrypted with other envs (when the image was encrypted using --service-domain or --brkt-env rather than using the endpoints in the current config).