### PR TITLE
Ensure cryptography version is compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto == 2.38.0
-cryptography >= 1.3.2
+cryptography < 1.5, >= 1.3.2
 google-api-python-client >= 1.5.1
 iso8601 >= 0.1.11
 oauth2client < 3, >= 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     ],
     install_requires=[
         'boto>=2.38.0',
-        'cryptography>=1.3.2',
+        'cryptography<1.5,>=1.3.2',
         'google-api-python-client>=1.5.0',
         'iso8601>=0.1.11',
         'oauth2client<3,>= 2.0.0',


### PR DESCRIPTION
1.5.x doesnt work on linux. This ensures
a compatible version of the python cryptography
library is installed