### PR TITLE
Add auth command

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -31,12 +31,14 @@ from brkt_cli.config import CLIConfig, CONFIG_PATH
 from brkt_cli.proxy import Proxy, generate_proxy_config, validate_proxy_config
 from brkt_cli.util import validate_dns_name_ip_address
 from brkt_cli.validation import ValidationError
+from brkt_cli.yeti import YetiService, YetiError
 
 VERSION = '1.0.7pre1'
 
 # The list of modules that may be loaded.  Modules contain subcommands of
 # the brkt command and CSP-specific code.
 SUBCOMMAND_MODULE_PATHS = [
+    'brkt_cli.auth',
     'brkt_cli.aws',
     'brkt_cli.brkt_jwt',
     'brkt_cli.config',
@@ -350,44 +352,39 @@ def check_jwt_auth(brkt_env, jwt):
     registered with the given account
     """
     validate_jwt(jwt)
-
-    uri = 'https://%s:%d/api/v1/customer/self' % (
+    root_url = 'https://%s:%d' % (
         brkt_env.public_api_host,
         brkt_env.public_api_port
     )
-    log.debug('Validating token against %s', uri)
-    request = urllib2.Request(
-        uri,
-        headers={'Authorization': 'Bearer %s' % jwt}
-    )
+    y = YetiService(root_url, token=jwt)
     try:
-        response = urllib2.urlopen(request, timeout=10.0)
-        log.debug('Server returned %d', response.getcode())
-    except urllib2.HTTPError as e:
-        if e.code == 401:
+        y.get_customer()
+    except YetiError as e:
+        if e.http_status == 401:
             raise ValidationError(
                 'Token is not authorized to access %s' %
                 brkt_env.public_api_host
             )
-        elif e.code == 400:
-            payload = e.read()
-            if payload:
-                log.error(payload)
-            raise ValidationError('Invalid token.')
+        elif e.http_status == 400:
+            message = 'Invalid token'
+            if e.message:
+                message += ': ' % e.message
+            raise ValidationError(message)
         else:
             # Unexpected server response.  Log a warning and continue, so
             # that we don't unnecessarily interrupt the encryption process.
-            log.debug('Server response: %s', e.msg)
             log.warn(
-                'Unable to validate token.  Server returned error %d.  '
-                'Use --no-validate to disable validation.' % e.code
+                'Unable to validate token.  Server returned error %d %s.  '
+                'Use --no-validate to disable validation.',
+                e.http_status,
+                e.message
             )
     except IOError:
         log.debug('', exc_info=1)
         log.warn(
             'Unable to validate token against %s.  Use --no-validate to '
             'disable validation.',
-            uri
+            root_url
         )
 
 
@@ -586,6 +583,9 @@ def main():
         debug_handler.setFormatter(formatter)
         debug_handler.setLevel(logging.DEBUG)
         logging.root.addHandler(debug_handler)
+
+    # Turn off unnecessary logging from known libraries.
+    logging.getLogger('requests').setLevel(logging.WARNING)
 
     # Write messages that were logged before logging was initialized.
     for msg in subcommand_load_messages:

--- a/brkt_cli/auth.py
+++ b/brkt_cli/auth.py
@@ -1,0 +1,77 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import getpass
+import logging
+
+import brkt_cli
+from brkt_cli import ValidationError
+from brkt_cli import argutil
+from brkt_cli import util
+from brkt_cli.subcommand import Subcommand
+from brkt_cli.yeti import YetiService, YetiError
+
+log = logging.getLogger(__name__)
+
+
+SUBCOMMAND_NAME = 'auth'
+
+
+class AuthSubcommand(Subcommand):
+
+    def name(self):
+        return SUBCOMMAND_NAME
+
+    def register(self, subparsers, parsed_config):
+        parser = subparsers.add_parser(
+            self.name(),
+            description=(
+                'Authenticate with the Bracket service. On success, print '
+                'the JSON Web Token that can be used to make calls '
+                'to Bracket REST API endpoints.'
+            ),
+            help='Authenticate with the Bracket service',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        parser.add_argument(
+            '--email',
+            metavar='ADDRESS',
+            help='If not specified, show a prompt.'
+        )
+        parser.add_argument(
+            '--password',
+            help='If not specified, show a prompt.'
+        )
+        parser.add_argument(
+            '--root-url',
+            metavar='URL',
+            default='https://api.mgmt.brkt.com',
+            help='Bracket service root URL'
+        )
+        argutil.add_out(parser)
+
+    def run(self, values):
+        email = values.email or raw_input('Email: ')
+        password = values.password or getpass.getpass('Password: ')
+        y = YetiService(values.root_url)
+        try:
+            token = y.auth(email, password)
+        except YetiError as e:
+            raise ValidationError(e.message)
+        util.write_to_file_or_stdout(token, path=values.out)
+
+        return 0
+
+
+def get_subcommands():
+    return [AuthSubcommand()]

--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -1,0 +1,138 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import httplib
+import logging
+
+import requests
+
+log = logging.getLogger(__name__)
+
+
+class Customer(object):
+    def __init__(self, uuid=None, name=None, email=None):
+        self.uuid = uuid
+        self.name = name
+        self.email = email
+
+
+class YetiError(Exception):
+    def __init__(self, http_status, message=None):
+        if not message:
+            if http_status == 401:
+                message = httplib.responses[http_status]
+
+        super(YetiError, self).__init__(message)
+        self.http_status = http_status
+
+
+def make_json_headers(token=None):
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+    if token:
+        headers['Authorization'] = 'Bearer %s' % token
+    return headers
+
+
+def _get_reason(d):
+    reason = None
+    if 'reason' in d:
+        reason = d['reason']
+    if 'error_description' in d:
+        reason = d['error_description']
+    return reason
+
+
+def get_json(url, token=None, timeout=10.0):
+    """ Send an HTTP GET to the given endpoint and return the response
+    payload as a dictionary.
+
+    :param token the API token (JWT)
+    :raise YetiError if the endpoint returns an HTTP error status
+    :raise IOError if a network error or timeout occurred
+    """
+    log.debug('Sending HTTP GET to %s', url)
+
+    headers = make_json_headers(token=token)
+    r = requests.get(url, headers=headers, timeout=timeout)
+    if r.status_code / 100 != 2:
+        msg = None
+        if r.status_code == 400:
+            msg = _get_reason(r.json())
+        raise YetiError(http_status=r.status_code, message=msg)
+
+    return r.json()
+
+
+def post_json(url, token=None, json=None, timeout=10.0):
+    """ Send an HTTP POST to the given endpoint and return the response
+    payload as a dictionary.
+
+    :param token the API token (JWT)
+    :param json an optional dictionary to post as JSON
+    :raise YetiError if the endpoint returns an HTTP error status
+    :raise IOError if a network error or timeout occurred
+    """
+    log.debug('Sending HTTP POST to %s', url)
+
+    headers = make_json_headers(token=token)
+
+    r = requests.post(url, headers=headers, json=json, timeout=timeout)
+    if r.status_code / 100 != 2:
+        msg = None
+        if r.status_code == 400:
+            msg = _get_reason(r.json())
+        raise YetiError(http_status=r.status_code, message=msg)
+
+    return r.json()
+
+
+class YetiService(object):
+
+    def __init__(self, root_url, token=None):
+        self.root_url = root_url
+        self.token = token
+
+    def auth(self, email, password):
+        """ Authenticate with the Yeti service.
+
+        :return the API token (JWT)
+        :raise YetiError if authentication failed
+        :raise IOError if a network error or timeout occurred
+        """
+        payload = {
+            'username': email,
+            'password': password,
+            'grant_type': 'password'
+        }
+        d = post_json(
+            self.root_url + '/oauth/credentials',
+            json=payload
+        )
+        self.token = d['id_token']
+
+    def get_customer(self):
+        """ Return the Customer object.
+
+        :raise YetiError if Yeti returns an HTTP error status.
+        """
+        d = get_json(
+            self.root_url + '/api/v1/customer/self',
+            token=self.token)
+        return Customer(
+            uuid=d['uuid'],
+            name=d['name'],
+            email=d['email']
+        )


### PR DESCRIPTION
Add a top-level auth command that authenticates with the Bracket service
and prints an API auth token.  This command can be used by developers
and scripts that need to make calls to the Bracket REST API.  Update the
existing token validation code to use the same yeti module.

The next step will be to add login/logout commands (probably under
config), which use the yeti module to authenticate and stores the API
token in the user's config file.

---------------
```
$ ./brkt auth -h
usage: brkt auth [-h] [--email ADDRESS] [--password PASSWORD] [--root-url URL]
                 [--out PATH]

Authenticate with the Bracket service. On success, print the JSON Web Token
that can be used to make calls to Bracket REST API endpoints.

optional arguments:
  --email ADDRESS      If not specified, show a prompt.
  --out PATH           Write to a file instead of stdout. This can be used to
                       avoid character encoding issues when redirecting output
                       on Windows.
  --password PASSWORD  If not specified, show a prompt.
  --root-url URL       Bracket service root URL (default:
                       https://api.mgmt.brkt.com)
  -h, --help           show this help message and exit
```