### PR TITLE
Clean up --out option description

### DIFF
--- a/brkt_cli/argutil.py
+++ b/brkt_cli/argutil.py
@@ -21,8 +21,7 @@ def add_out(parser):
         '--out',
         metavar='PATH',
         help=(
-            'Write the private key to a file instead of stdout.  This '
-            'can be used to avoid character encoding issues when '
-            'redirecting output on Windows.'
+            'Write to a file instead of stdout.  This can be used to avoid '
+            'character encoding issues when redirecting output on Windows.'
         )
     )


### PR DESCRIPTION
Update the help wording, so that we don't assume that --out is only used
for private keys.