### PR TITLE
Add login, logout, whoami commands

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -483,6 +483,11 @@ def main():
         'token',
         'The default token to use when encrypting, updating, or launching'
         ' images')
+    config.register_option(
+        'api-token',
+        'The token that brkt-cli uses to communicate with the Bracket '
+        'service (set by the config login command)'
+    )
 
     # Dynamically load subcommands from modules.
     subcommands = []

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -14,19 +14,22 @@
 import argparse
 import collections
 import errno
+import getpass
 import logging
 import os
 import os.path
 import shutil
 import sys
 import tempfile
+
 import yaml
 
 import brkt_cli
-
+from brkt_cli import util
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.util import parse_endpoint, render_table_rows
 from brkt_cli.validation import ValidationError
+from brkt_cli.yeti import YetiError, YetiService
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +127,7 @@ def _unlink_noraise(path):
 
 
 class CLIConfig(object):
-    """CLIConfig exposes an interface that subcommands can use to retrive
+    """CLIConfig exposes an interface that subcommands can use to retrieve
     persistent configuration options.
     """
 
@@ -489,6 +492,47 @@ The leading `*' indicates that the `stage' environment is currently active.
             'env_name',
             help='The environment name')
 
+        # Log in and out.
+        login_parser = config_subparsers.add_parser(
+            'login',
+            help='Log into the Bracket service',
+            description=(
+                'Authenticate with the Bracket service and store the API '
+                'token in config.'
+            )
+        )
+        login_parser.add_argument(
+            '--email',
+            metavar='ADDRESS',
+            help='If not specified, show a prompt'
+        )
+        login_parser.add_argument(
+            '--password',
+            help='If not specified, show a prompt'
+        )
+
+        config_subparsers.add_parser(
+            'logout',
+            help='Log out of the Bracket service',
+            description=(
+                'Delete the API token stored in config.'
+            )
+        )
+
+        whoami_parser = config_subparsers.add_parser(
+            'whoami',
+            help='Show the current user',
+            description=(
+                'Print the email address of the user who was logged in '
+                'with the brkt config login command.'
+            )
+        )
+        whoami_parser.add_argument(
+            '--json',
+            action='store_true',
+            help='Print all user properties in JSON format'
+        )
+
     def _write_config(self):
         """Create ~/.brkt if it doesn't exist and safely write out a
         new config.
@@ -641,6 +685,57 @@ The leading `*' indicates that the `stage' environment is currently active.
             raise ValidationError('Error: unknown environment ' + values.env_name)
         self._write_config()
 
+    def _get_yeti_service(self):
+        """Return the YetiService object for the current environment."""
+        _, env = self.parsed_config.get_current_env()
+        root_url = 'https://%s:%d' % (
+            env.public_api_host, env.public_api_port)
+        token = self.parsed_config.get_option('api-token')
+        return YetiService(root_url, token=token)
+
+    def _login(self, values):
+        """ Authenticate with Yeti and store the API token in config. """
+        email = values.email or raw_input('Email: ')
+        password = values.password or getpass.getpass('Password: ')
+        y = self._get_yeti_service()
+
+        try:
+            token = y.auth(email, password)
+        except YetiError as e:
+            raise ValidationError(e.message)
+
+        self.parsed_config.set_option('api-token', token)
+        self._write_config()
+
+        env_name, _ = self.parsed_config.get_current_env()
+        print 'Logged into %s as %s' % (env_name, email)
+
+    def _logout(self):
+        self.parsed_config.unset_option('api-token')
+        self._write_config()
+
+    def _whoami(self, values):
+        env_name, _ = self.parsed_config.get_current_env()
+        log.debug('Current environment: %s', env_name)
+
+        y = self._get_yeti_service()
+        if not y.token:
+            raise ValidationError(
+                'Not logged in.  Please run brkt config login.')
+        try:
+            if values.json:
+                d = y.get_customer_json()
+                print util.pretty_print_json(d)
+            else:
+                cust = y.get_customer()
+                print cust.email
+        except YetiError as e:
+            if e.http_status == 401:
+                raise ValidationError(
+                    'Config API token is not authorized to access %s' %
+                    y.root_url)
+            raise ValidationError(e.message)
+
     def run(self, values):
         subcommand = values.config_subcommand
         if subcommand == 'list':
@@ -661,6 +756,12 @@ The leading `*' indicates that the `stage' environment is currently active.
             self._get_env(values)
         elif subcommand == 'unset-env':
             self._unset_env(values)
+        elif subcommand == 'login':
+            self._login(values)
+        elif subcommand == 'logout':
+            self._logout()
+        elif subcommand == 'whoami':
+            self._whoami(values)
         return 0
 
 

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -14,6 +14,7 @@
 import abc
 import base64
 import getpass
+import json
 import logging
 import re
 import time
@@ -300,3 +301,10 @@ def write_to_file_or_stdout(content, path=None):
             f.write(content)
     except IOError as e:
         raise ValidationError('Unable to write to %s: %s' % (path, e))
+
+
+def pretty_print_json(d, indent=4):
+    """ Format the given dictionary as a JSON string.
+    """
+    return json.dumps(
+        d, sort_keys=True, indent=indent, separators=(',', ': '))

--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -121,16 +121,24 @@ class YetiService(object):
             self.root_url + '/oauth/credentials',
             json=payload
         )
-        self.token = d['id_token']
+        self.token = str(d['id_token'])  # Convert Unicode to ASCII
+        return self.token
+
+    def get_customer_json(self):
+        """ Return the Customer object response from the server as a
+        dictionary.
+        """
+        return get_json(
+            self.root_url + '/api/v1/customer/self',
+            token=self.token
+        )
 
     def get_customer(self):
         """ Return the Customer object.
 
         :raise YetiError if Yeti returns an HTTP error status.
         """
-        d = get_json(
-            self.root_url + '/api/v1/customer/self',
-            token=self.token)
+        d = self.get_customer_json()
         return Customer(
             uuid=d['uuid'],
             name=d['name'],


### PR DESCRIPTION
Add new commmands for logging in and out, and showing the current user.
The login command stores the user's API token in the config file and
logout unsets it.  logout is effectively an alias for "brkt config unset
api-token".

-------------

```
$ ./brkt config login --email me@example.com --password xxxxx
Logged into stage as me@example.com
$ ./brkt config list
api-token=eyJ0eXAi...
$ ./brkt config whoami
me@example.com
$ ./brkt config whoami --json
{
    "email": "me@example.com",
    "eula_accepted": true,
    "eula_accepted_ts": 18446744011573954816,
    "name": "Me Too",
    "uuid": "ac5be98d-021a-4c31-8aee-0d90825102aa"
}
$ ./brkt config logout
$ ./brkt config whoami
Not logged in.  Please run brkt config login.
```
----------------
```
$ ./brkt config login -h
usage: brkt config login [-h] [--email ADDRESS] [--password PASSWORD]

Authenticate with the Bracket service and store the API token in config.

optional arguments:
-h, --help           show this help message and exit
--email ADDRESS      If not specified, show a prompt
--password PASSWORD  If not specified, show a prompt
```
```
$ ./brkt config logout -h
usage: brkt config logout [-h]

Delete the API token stored in config.

optional arguments:
-h, --help  show this help message and exit
```
```
$ ./brkt config whoami -h
usage: brkt config whoami [-h] [--json]

Print the email address of the user who was logged in with the brkt
config
login command.

optional arguments:
-h, --help  show this help message and exit
--json      Print all user properties in JSON format
```