### PR TITLE
Use the template-vm-name argument when launch VM instance

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -200,7 +200,9 @@ def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
         log.info("Launching VM from local OVF")
         ovf_image_name = ovf_image_name + ".ovf"
         validate_local_mv_ovf(source_image_path, ovf_image_name)
-        vm = vc_swc.upload_ovf_to_vcenter(source_image_path, ovf_image_name)
+        vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
+                                          ovf_image_name,
+                                          vm_name=vm_name)
     except Exception as e:
         log.exception("Failed to launch from metavisor OVF (%s)", e)
         if (vm is not None):


### PR DESCRIPTION
When encrypting an image based off a local Metavisor/encryptor image,
the template-vm-name argument was being ignored and hence the VM
instance was always getting launched with the name as
'Encryptor-VM-<Date>'. This specifically causes problems when creating
encrypted ESX instances as it would be harder to identify the encrypted
instance when it does not use the user specified name.