### PR TITLE
Clean up endpoint parsing

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -125,11 +125,11 @@ def parse_brkt_env(brkt_env_string):
     names = ('api', 'hsmproxy', 'network')
     for name, endpoint in zip(names, endpoints):
         try:
-            parts = util.parse_endpoint(endpoint)
-            if 'port' not in parts:
+            host, port = util.parse_endpoint(endpoint)
+            if not port:
                 raise ValidationError(error_msg)
-            setattr(be, name + '_host', parts['host'])
-            setattr(be, name + '_port', parts['port'])
+            setattr(be, name + '_host', host)
+            setattr(be, name + '_port', port)
             if name == 'api':
                 # set public api host based on the same prefix assumption
                 # service-domain makes. Hopefully we'll remove brkt-env

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -568,11 +568,12 @@ The leading `*' indicates that the `stage' environment is currently active.
             if endpoint is None:
                 continue
             try:
-                parts = parse_endpoint(endpoint)
+                host, port = parse_endpoint(endpoint)
             except ValueError:
                 raise ValidationError('Error: Invalid value for option --' + k + '-server')
-            setattr(env, opt_attr[k] + '_host', parts['host'])
-            setattr(env, opt_attr[k] + '_port', parts.get('port', 443))
+            port = port or 443
+            setattr(env, opt_attr[k] + '_host', host)
+            setattr(env, opt_attr[k] + '_port', port)
         if values.service_domain is not None:
             env = brkt_cli.brkt_env_from_domain(values.service_domain)
         self.parsed_config.set_env(values.env_name, env)

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -47,6 +47,25 @@ class TestUtil(unittest.TestCase):
         with self.assertRaises(ValidationError):
             util.parse_name_value('abc')
 
+    def test_parse_endpoint(self):
+        self.assertEqual(
+            ('example.com', 80),
+            util.parse_endpoint('example.com:80')
+        )
+        self.assertEqual(
+            ('example.com', None),
+            util.parse_endpoint('example.com')
+        )
+        invalid = [
+            '!@#$:80',
+            'a:b',
+            'example.com:example.com:80',
+            'example.com:80:'
+        ]
+        for e in invalid:
+            with self.assertRaises(ValidationError):
+                util.parse_endpoint(e)
+
 
 class TestBase64(unittest.TestCase):
     """ Test that our encoding code follows the spec used by JWT.  The

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -264,27 +264,24 @@ def parse_endpoint(endpoint):
     """Parse a <host>[:<port>] string into its constituent parts.
 
     :param endpoint a string of the form <host>[:<port>]
-
-    :return a dictionary of the form {"hostname": <hostname>, "port": <port>}
-        The "port" key will only exist if it is parsed from endpoint.
-
-    :raises ValueError if an invalid string is supplied.
-
+    :return a tuple of (host, port).  port is None if not specified.
+    :raises ValidationError if an invalid string is supplied.
     """
 
-    host_port_pattern = r'([^:]+)(:\d+)?$'
-    m = re.match(host_port_pattern, endpoint)
-    if not m:
-        raise ValueError('Invalid endpoint: ' + endpoint)
-    elif not validate_dns_name_ip_address(m.group(1)):
-        raise ValidationError('Invalid hostname: ' + m.group(1))
-    groups = m.groups()
-    ret = {
-        'host': groups[0],
-    }
-    if groups[1] is not None:
-        ret['port'] = int(groups[1][1:])
-    return ret
+    parts = endpoint.split(':')
+    if len(parts) > 2:
+        raise ValidationError(endpoint + ' must be in the form host[:port]')
+    host = parts[0]
+    port = None
+    if len(parts) == 2:
+        try:
+            port = int(parts[1])
+        except ValueError:
+            raise ValidationError('Invalid port: %s' % parts[1])
+    if not validate_dns_name_ip_address(host):
+        raise ValidationError('Invalid hostname: ' + host)
+
+    return host, port
 
 
 def write_to_file_or_stdout(content, path=None):


### PR DESCRIPTION
Clean up and unit test the code that parses an endpoint string.  Update
the function to return a tuple of (host, port) instead of a dictionary.
This is more intuitive, since the function will always return exactly
two values.  Update the parsing logic to be more rigorous about catching
edge cases.  Raise ValidationError in all cases where the string is
invalid, so that behavior is consistent.  Add unit tests.