### PR TITLE
Fix error recovery during encryption on ESX.

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -22,7 +22,7 @@ def setup_encrypt_vmdk_args(parser):
     parser.add_argument(
         'vmdk',
         metavar='VMDK-NAME',
-        help='The Guest VMDK that will be encrypted'
+        help='The Guest VMDK path (in the datastore) that will be encrypted'
     )
     parser.add_argument(
         "--vcenter-host",
@@ -90,7 +90,7 @@ def setup_encrypt_vmdk_args(parser):
         '--template-vm-name',
         metavar='NAME',
         dest='template_vm_name',
-        help='Specify the name of the template VM',
+        help='Specify the name of the output template VM',
         required=False
     )
     parser.add_argument(

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -22,7 +22,7 @@ def setup_encrypt_with_esx_host_args(parser):
     parser.add_argument(
         'vmdk',
         metavar='VMDK-NAME',
-        help='The Guest VMDK that will be encrypted'
+        help='The Guest VMDK path (in the datastore) that will be encrypted'
     )
     parser.add_argument(
         "--esx-host",
@@ -76,7 +76,7 @@ def setup_encrypt_with_esx_host_args(parser):
         '--template-vm-name',
         metavar='NAME',
         dest='template_vm_name',
-        help='Specify the name of the template VM',
+        help='Specify the name of the output template VM',
         required=False
     )
     parser.add_argument(

--- a/test_esx.py
+++ b/test_esx.py
@@ -350,8 +350,8 @@ class TestRunEncryption(unittest.TestCase):
             )
             self.fail('Encryption should have failed')
         except Exception:
-            self.assertEqual(len(vc_swc.vms), 1)
-            self.assertEqual(len(vc_swc.disks), 4)
+            self.assertEqual(len(vc_swc.vms), 0)
+            self.assertEqual(len(vc_swc.disks), 2)
 
 
 class TestRunUpdate(unittest.TestCase):


### PR DESCRIPTION
1. Teardown the instance (unless --no-teardown is used) on encryption failure.
2. Improve help messages.