### PR TITLE
Fix the OVF image downloads

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -980,7 +980,9 @@ def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
                 if "release" in dir_name:
                     dir_list.append(dir_name)
             image_name = (sorted(dir_list))[len(dir_list)-1]
-        file_list_obj = list(bucket.list(image_name + "/"))
+            file_list_obj = list(bucket.list(image_name))
+        else:
+            file_list_obj = list(bucket.list(image_name + "/"))
         if len(file_list_obj) is 0:
             log.error("Directory %s in bucket %s is empty." % (image_name,
                      bucket_name))


### PR DESCRIPTION
Do not add the "/" suffix to the bucket/image name unnecessarily.

If a metavisor image name is specified, then it is OK to add a "/"
suffix to it to ensure that we are not overlapping with another
bucket with a similar prefix. However if the metavisor image name
is not specified and the CLI tries to sort thru' the buckets to
identify the latest one (used for Prod and Stage published images)
then the bucket/image name already has a "/" suffixed to it and that
causes the image download to fail as we are adding an additional "/"
to it.