### PR TITLE
Hide internal subcommands

### DIFF
--- a/brkt_cli/auth.py
+++ b/brkt_cli/auth.py
@@ -40,7 +40,8 @@ class AuthSubcommand(Subcommand):
                 'the JSON Web Token that can be used to make calls '
                 'to Bracket REST API endpoints.'
             ),
-            help='Authenticate with the Bracket service',
+            # Hide this command while the feature is in development.
+            # help='Authenticate with the Bracket service',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         parser.add_argument(
@@ -71,6 +72,9 @@ class AuthSubcommand(Subcommand):
         util.write_to_file_or_stdout(token, path=values.out)
 
         return 0
+
+    def exposed(self):
+        return False
 
 
 def get_subcommands():

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -406,15 +406,18 @@ class AWSSubcommand(Subcommand):
         )
 
         aws_subparsers = aws_parser.add_subparsers(
-            dest='aws_subcommand'
+            dest='aws_subcommand',
+            # Hardcode the list, so that we don't expose internal subcommands.
+            metavar='{encrypt,update}'
         )
 
         diag_parser = aws_subparsers.add_parser(
+            # Don't specify the help field.  This is an internal command
+            # which shouldn't show up in usage output.
             'diag',
             description=(
                 'Create instance to diagnose an existing encrypted instance.'
             ),
-            help='Diagnose an encrypted instance',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         diag_args.setup_diag_args(diag_parser)
@@ -432,9 +435,10 @@ class AWSSubcommand(Subcommand):
         encrypt_ami_parser.set_defaults(aws_subcommand='encrypt')
 
         share_logs_parser = aws_subparsers.add_parser(
+            # Don't specify the help field.  This is an internal command
+            # which shouldn't show up in usage output.
             'share-logs',
             description='Share logs from an existing encrypted instance.',
-            help='Share logs',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         share_logs_args.setup_share_logs_args(share_logs_parser)

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -338,7 +338,11 @@ class ConfigSubcommand(Subcommand):
         )
 
         config_subparsers = config_parser.add_subparsers(
-            dest='config_subcommand'
+            dest='config_subcommand',
+            # Hardcode the list, so that we don't expose subcommands that
+            # are still in development.
+            metavar='{list,set,get,unset,set-env,use-env,list-envs,get-env,'
+                    'unset-env}'
         )
 
         # List all options
@@ -495,7 +499,8 @@ The leading `*' indicates that the `stage' environment is currently active.
         # Log in and out.
         login_parser = config_subparsers.add_parser(
             'login',
-            help='Log into the Bracket service',
+            # Don't expose until the feature is ready.
+            # help='Log into the Bracket service',
             description=(
                 'Authenticate with the Bracket service and store the API '
                 'token in config.'
@@ -513,7 +518,8 @@ The leading `*' indicates that the `stage' environment is currently active.
 
         config_subparsers.add_parser(
             'logout',
-            help='Log out of the Bracket service',
+            # Don't expose until the feature is ready.
+            # help='Log out of the Bracket service',
             description=(
                 'Delete the API token stored in config.'
             )
@@ -521,7 +527,8 @@ The leading `*' indicates that the `stage' environment is currently active.
 
         whoami_parser = config_subparsers.add_parser(
             'whoami',
-            help='Show the current user',
+            # Don't expose until the feature is ready.
+            # help='Show the current user',
             description=(
                 'Print the email address of the user who was logged in '
                 'with the brkt config login command.'

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -432,7 +432,12 @@ class VMwareSubcommand(Subcommand):
         )
 
         vmware_subparsers = vmware_parser.add_subparsers(
-            dest='vmware_subcommand'
+            dest='vmware_subcommand',
+            # Hardcode the list, so that we don't expose internal subcommands.
+            metavar=(
+                '{encrypt-with-vcenter,encrypt-with-esx-host,'
+                'update-with-vcenter,update-with-esx-host}'
+            )
         )
 
         encrypt_with_vcenter_parser = vmware_subparsers.add_parser(
@@ -484,11 +489,12 @@ class VMwareSubcommand(Subcommand):
         setup_instance_config_args(update_with_esx_parser, parsed_config)
 
         rescue_metavisor_parser = vmware_subparsers.add_parser(
+            # Don't specify the help field.  This is an internal command
+            # which shouldn't show up in usage output.
             'rescue-metavisor',
             description=(
                 'Upload a Metavisor VM cores and diagnostics to a URL'
             ),
-            help='Upload Metavisor VM cores to URL',
             formatter_class=brkt_cli.SortingHelpFormatter
         )
         rescue_metavisor_args.setup_rescue_metavisor_args(


### PR DESCRIPTION
Hide the following subcommands from usage output:

auth
aws diag
aws share-logs
vmware rescue-metavisor
config login
config logout
config whoami

These commands are either internal or still in development.