### PR TITLE
Download artifacts from S3 only if required

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -225,6 +225,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
                 user_data_str=user_data_str,
                 serial_port_file_name=values.serial_port_file_name,
                 status_port=values.status_port,
+                cleanup=values.cleanup,
             )
         return 0
     except Exception as e:
@@ -371,6 +372,7 @@ def run_update(values, parsed_config, log, use_esx=False):
                 download_file_list=download_file_list,
                 user_data_str=user_data_str,
                 status_port=values.status_port,
+                cleanup=values.cleanup,
             )
         return 0
     except:

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -159,7 +159,7 @@ def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
                     target_path=None, image_name=None, ovftool_path=None,
                     ovf_name=None, download_file_list=None,
                     user_data_str=None, serial_port_file_name=None,
-                    status_port=ENCRYPTOR_STATUS_PORT):
+                    status_port=ENCRYPTOR_STATUS_PORT, cleanup=True):
     vm = None
     try:
         if (ovf_name is None or download_file_list is None):
@@ -169,7 +169,8 @@ def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
         if vc_swc.is_esx_host() is True:
             mv_vm_name = vm_name
         vm = launch_mv_vm_from_s3(vc_swc, ovf_name,
-                                  download_file_list, mv_vm_name)
+                                  download_file_list, mv_vm_name,
+                                  cleanup)
     except Exception as e:
         log.exception("Failed to launch metavisor OVF from S3 (%s)", e)
         if (vm is not None):

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -238,3 +238,13 @@ def setup_encrypt_vmdk_args(parser):
         help=argparse.SUPPRESS,
         default=None
     )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -208,3 +208,13 @@ def setup_encrypt_with_esx_host_args(parser):
         help=argparse.SUPPRESS,
         default=None
     )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -951,6 +951,37 @@ def initialize_vcenter(host, user, password, port,
     return vc_swc
 
 
+def need_to_download_from_s3(file_list):
+    """ Checks if the necessary files are already downloaded
+       
+        Returns: True or False to indicate whether the download
+        is required or not and an OVF image name when download
+        is not required
+    """
+    ovf_image = None
+    for item in file_list:
+        file_name = item[item.rfind('/')+1:]
+        if not os.path.exists(file_name):
+            return ovf_image, True
+        if '.mf' in file_name:
+            with open(file_name) as manifest_data:
+                manifest = json.load(manifest_data)
+        if '.vmdk' in file_name:
+            with open(file_name) as f:
+                data = f.read()
+                f.close()
+            vmdk_sha = hashlib.sha1(data).hexdigest()
+        if '.ovf' in file_name:
+            ovf_image = file_name
+            with open(file_name) as f:
+                data = f.read()
+                f.close()
+            ovf_sha = hashlib.sha1(data).hexdigest()
+    if vmdk_sha in manifest.values() and ovf_sha in manifest.values():
+        return ovf_image, False
+    return ovf_image, True
+
+
 def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
     logging.getLogger('boto').setLevel(logging.FATAL)
     log.info("Fetching Metavisor OVF from S3")
@@ -990,15 +1021,19 @@ def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
         file_list = []
         for content in file_list_obj:
             file_list.append(str(content.name))
-        for file in file_list:
-            file_name = file[file.rfind('/')+1:]
-            target_file = os.path.join("./", file_name)
-            certificate = Key(bucket)
-            certificate.key = file
-            certificate.get_contents_to_filename(target_file)
-            if (".ovf" in file_name):
-                ovf_name = target_file
-            download_file_list.append(target_file)
+        ovf_name, download_required = need_to_download_from_s3(file_list)
+        if download_required:
+            for item in file_list:
+                file_name = item[item.rfind('/')+1:]
+                target_file = os.path.join("./", file_name)
+                certificate = Key(bucket)
+                certificate.key = item
+                certificate.get_contents_to_filename(target_file)
+                if (".ovf" in file_name):
+                    ovf_name = target_file
+                download_file_list.append(target_file)
+        else:
+            log.info("Using previously downloaded OVF image")
         if ovf_name is None:
             log.error("No OVF file in directory %s in bucket "
                      "%s" % (image_name, bucket_name))
@@ -1009,13 +1044,17 @@ def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
         raise
 
 
-def launch_mv_vm_from_s3(vc_swc, ovf_name, download_file_list, vm_name=None):
+def launch_mv_vm_from_s3(vc_swc, ovf_name, download_file_list,
+                         vm_name=None, cleanup=True):
     # Launch OVF
     log.info("Launching VM from OVF %s", ovf_name)
     vm = vc_swc.upload_ovf_to_vcenter("./", ovf_name, vm_name)
     # Clean up the downloaded files
-    for file_name in download_file_list:
-        os.remove(file_name)
+    if cleanup:
+        for file_name in download_file_list:
+            os.remove(file_name)
+    else:
+        log.info("Keeping the downloaded OVF files")
     return vm
 
 

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -188,3 +188,13 @@ def setup_update_vmdk_args(parser):
         help=argparse.SUPPRESS,
         default="Port"
     )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -131,7 +131,7 @@ def update_from_s3(vc_swc, enc_svc_cls, template_vm_name=None,
                    target_path=None, ovf_name=None, ova_name=None,
                    ovftool_path=None, mv_ovf_name=None,
                    download_file_list=None, user_data_str=None,
-                   status_port=ENCRYPTOR_STATUS_PORT):
+                   status_port=ENCRYPTOR_STATUS_PORT, cleanup=True):
     guest_vm = None
     mv_vm = None
     try:
@@ -146,7 +146,8 @@ def update_from_s3(vc_swc, enc_svc_cls, template_vm_name=None,
         if (mv_ovf_name is None or download_file_list is None):
             log.error("Cannot get metavisor OVF from S3")
             raise Exception("Invalid MV OVF")
-        mv_vm = launch_mv_vm_from_s3(vc_swc, mv_ovf_name, download_file_list)
+        mv_vm = launch_mv_vm_from_s3(vc_swc, mv_ovf_name,
+                                     download_file_list, cleanup)
     except Exception as e:
         log.exception("Failed to launch metavisor OVF from S3 (%s)", e)
         if (mv_vm is not None):

--- a/brkt_cli/esx/update_with_esx_host_args.py
+++ b/brkt_cli/esx/update_with_esx_host_args.py
@@ -189,3 +189,13 @@ def setup_update_with_esx_host_args(parser):
         default=None,
         help=argparse.SUPPRESS
     )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )


### PR DESCRIPTION
Previously the brkt-cli would always try to download the Metavisor
artifacts from S3 everytime an encrypt/update command is run, even
if the command fails subsequently do to issues with the vCenter/ESX
server and/or the specified parameters. With this change, we:
 - Check if artifacts were already downloaded
 - Check if the VMDK hash matches the manifest file
Only when one or more of the files are not found or the manifest hash
does not match the VMDK, do we try to download the artifacts from S3.

Additionally a hidden --no-cleanup option has been provided which can
be used in case the user does not want the downloaded artifacts to be
deleted after the encryption/update completes successfully. This is
especially useful in the case where the same artifact is required to
encrypt/update multiple images and eliminates the need to download
the artifacts from S3 for each of the encrypt/update operations.