### PR TITLE
Add ability to provide host instead of cluster.

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -166,7 +166,7 @@ def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
             log.error("Cannot get metavisor OVF from S3")
             raise Exception("Invalid MV OVF")
         mv_vm_name = None
-        if vc_swc.is_esx_host() is True:
+        if vc_swc.is_esx_host():
             mv_vm_name = vm_name
         vm = launch_mv_vm_from_s3(vc_swc, ovf_name,
                                   download_file_list, mv_vm_name)
@@ -198,9 +198,12 @@ def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
         log.info("Launching VM from local OVF")
         ovf_image_name = ovf_image_name + ".ovf"
         validate_local_mv_ovf(source_image_path, ovf_image_name)
+        mv_vm_name = None
+        if vc_swc.is_esx_host():
+            mv_vm_name = vm_name
         vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
                                           ovf_image_name,
-                                          vm_name=vm_name)
+                                          vm_name=mv_vm_name)
     except Exception as e:
         log.exception("Failed to launch from metavisor OVF (%s)", e)
         if (vm is not None):

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -88,6 +88,8 @@ class BaseVCenterService(object):
         self.datastore_path = "[" + datastore_name + "] "
         self.esx_host = esx_host
         self.cluster_name = cluster_name
+        if self.esx_host:
+            self.cluster_name = None
         self.no_of_cpus = no_of_cpus
         self.memoryGB = memoryGB
         self.session_id = session_id
@@ -420,11 +422,8 @@ class VCenterService(BaseVCenterService):
         datacenter = self.__get_obj(content, [vim.Datacenter],
                                     self.datacenter_name)
         vmfolder = datacenter.vmFolder
-        if self.esx_host:
-            cluster = self.__get_obj(content, [vim.ComputeResource], None)
-        else:
-            cluster = self.__get_obj(content, [vim.ClusterComputeResource],
-                                     self.cluster_name)
+        cluster = self.__get_obj(content, [vim.ComputeResource],
+                                 self.cluster_name)
         pool = cluster.resourcePool
         timestamp = datetime.datetime.utcnow().isoformat() + 'Z'
         vm_name = "VM-" + timestamp
@@ -562,7 +561,7 @@ class VCenterService(BaseVCenterService):
                 if (device.unitNumber == unit_number):
                     delete_device = device
         if (delete_device is None):
-            log.error("No disk found at %d in VM to detach",
+            log.error("No disk found at %d in VM %d to detach",
                       unit_number, vm.config.name)
             return
         spec = vim.vm.ConfigSpec()
@@ -639,7 +638,7 @@ class VCenterService(BaseVCenterService):
         datacenter = self.__get_obj(content, [vim.Datacenter],
                                     self.datacenter_name)
         destfolder = datacenter.vmFolder
-        cluster = self.__get_obj(content, [vim.ClusterComputeResource],
+        cluster = self.__get_obj(content, [vim.ComputeResource],
                                  self.cluster_name)
         pool = cluster.resourcePool
         datastore = self.__get_obj(content, [vim.Datastore],
@@ -828,11 +827,8 @@ class VCenterService(BaseVCenterService):
                                     self.datacenter_name)
         datastore = self.__get_obj(content, [vim.Datastore],
                                    self.datastore_name)
-        if self.esx_host:
-            cluster = self.__get_obj(content, [vim.ComputeResource], None)
-        else:
-            cluster = self.__get_obj(content, [vim.ClusterComputeResource],
-                                     self.cluster_name)
+        cluster = self.__get_obj(content, [vim.ComputeResource],
+                                 self.cluster_name)
         resource_pool = cluster.resourcePool
         destfolder = datacenter.vmFolder
         import_spec = manager.CreateImportSpec(ovfd,


### PR DESCRIPTION
1. If there are no clusters in a datacenter, provide the ability to let
customers provide a host name to --vcenter-cluster.
2. Change the encryptor VM name to template name only if
the encryption is happening on esx host.
3. Fix error in detach disk.