### PR TITLE
Migrate to boto3 for retrieving S3 objects for esx_service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python: "2.7"
 install: >-
-  pip install boto cryptography google-api-python-client iso8601 oauthlib
+  pip install boto boto3 cryptography google-api-python-client iso8601 oauthlib
   pyjwt pyvmomi PyYAML pyflakes requests sshpubkeys
 script: ./test
 cache: pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto == 2.38.0
+boto3 >= 1.4.4
 cryptography < 1.5, >= 1.3.2
 google-api-python-client >= 1.5.1
 iso8601 >= 0.1.11

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     ],
     install_requires=[
         'boto>=2.38.0',
+        'boto3>=1.4.4',
         'cryptography<1.5,>=1.3.2',
         'google-api-python-client>=1.5.0',
         'iso8601>=0.1.11',


### PR DESCRIPTION
There is inconsistent behavior with boto when downloading objects
from S3 where the bucket name contains dots:

https://github.com/boto/boto/issues/2836

To address this issue, VMware operations for fetching images from S3
are now using boto3. In addition to the new dependency on boto3, the
following issues have been addressed.

- The hidden --bucket-name argument now supports s3 buckets with dots
  in the name

- The --metavisor-ovf-image argument can return the latest
  metavisor image with exact or partial matches (e.g. 0-0-964 or
  metavisor-0-0-964-g0cf0e0e62.ovf)

- If the --metavisor-ovf-image argument is _not_ provided, we
  default to retrieving the latest modified image with a *latest* or
  *release-* prefix