### PR TITLE
Check supported versions only once per day

### DIFF
--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -25,8 +25,7 @@ import iso8601
 import jwt
 
 import brkt_cli
-from brkt_cli import argutil
-from brkt_cli import util
+from brkt_cli import argutil, util, version
 from brkt_cli.brkt_jwt import jwk
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.validation import ValidationError
@@ -159,7 +158,7 @@ def make_jwt(crypto, exp=None, nbf=None, claims=None, customer=None):
 
     payload = {
         'jti': util.make_nonce(),
-        'iss': 'brkt-cli-' + brkt_cli.VERSION,
+        'iss': 'brkt-cli-' + version.VERSION,
         'iat': int(time.time())
     }
     if claims:

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -75,6 +75,30 @@ def noop():
     pass
 
 
+class InternalOptionTestCase(unittest.TestCase):
+
+    def test_internal_option(self):
+        cfg = CLIConfig()
+
+        # Not set.
+        self.assertIsNone(cfg.get_internal_option('test'))
+        self.assertEqual(
+            'abc', cfg.get_internal_option('test', default='abc'))
+
+        # Set.
+        cfg.set_internal_option('test', 'abc')
+        self.assertEqual('abc', cfg.get_internal_option('test'))
+
+        # Save, reread, and make sure that the internal option is still set.
+        f = StringIO.StringIO()
+        cfg.write(f)
+        yaml = f.getvalue()
+
+        cfg = CLIConfig()
+        cfg.read(StringIO.StringIO(yaml))
+        self.assertEqual('abc', cfg.get_internal_option('test'))
+
+
 class ConfigCommandTestCase(unittest.TestCase):
     def setUp(self):
         self.out = StringIO.StringIO()

--- a/brkt_cli/test_version.py
+++ b/brkt_cli/test_version.py
@@ -1,0 +1,90 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import datetime
+
+import iso8601
+
+from brkt_cli import CLIConfig
+from brkt_cli import version
+
+
+class TestVersionCheck(unittest.TestCase):
+
+    def test_is_version_supported(self):
+        supported = [
+            '0.9.8', '0.9.9', '0.9.9.1', '0.9.10', '0.9.11', '0.9.12'
+        ]
+        self.assertFalse(
+            version._is_version_supported('0.9.7', supported)
+        )
+        self.assertTrue(
+            version._is_version_supported('0.9.8', supported)
+        )
+        self.assertTrue(
+            version._is_version_supported('0.9.12', supported)
+        )
+        self.assertTrue(
+            version._is_version_supported('0.9.13pre1', supported)
+        )
+        self.assertTrue(
+            version._is_version_supported('0.9.13', supported)
+        )
+
+    def test_is_later_version_available(self):
+        supported = [
+            '0.9.8', '0.9.9', '0.9.9.1', '0.9.10', '0.9.11', '0.9.12'
+        ]
+        self.assertTrue(
+            version._is_later_version_available('0.9.11', supported)
+        )
+        self.assertFalse(
+            version._is_later_version_available('0.9.12', supported)
+        )
+        self.assertFalse(
+            version._is_later_version_available('0.9.13pre1', supported)
+        )
+
+    def test_version_check_time(self):
+        cfg = CLIConfig()
+
+        # Not set.
+        self.assertIsNone(version.get_last_version_check_time(cfg))
+
+        # Set.
+        before = datetime.datetime.now(tz=iso8601.UTC)
+        version.set_last_version_check_time(cfg)
+        t = version.get_last_version_check_time(cfg)
+        self.assertIsNotNone(t)
+        after = datetime.datetime.now(tz=iso8601.UTC)
+
+        self.assertTrue(before <= t <= after)
+
+    def test_is_version_check_needed(self):
+        cfg = CLIConfig()
+
+        # Not set.
+        self.assertTrue(version.is_version_check_needed(cfg))
+
+        # Set to 25 hours ago.
+        now = datetime.datetime.now(tz=iso8601.UTC)
+        dt = now - datetime.timedelta(hours=25)
+        version.set_last_version_check_time(cfg, dt=dt)
+        self.assertTrue(version.is_version_check_needed(cfg))
+
+        # Set to 23 hours ago.
+        dt = now - datetime.timedelta(hours=23)
+        version.set_last_version_check_time(cfg, dt=dt)
+        self.assertFalse(version.is_version_check_needed(cfg))

--- a/brkt_cli/version.py
+++ b/brkt_cli/version.py
@@ -1,0 +1,138 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import urllib2
+from distutils.version import LooseVersion
+
+import logging
+
+import datetime
+
+import iso8601
+
+log = logging.getLogger(__name__)
+
+VERSION = '1.0.8pre1'
+
+
+def _is_version_supported(version, supported_versions):
+    """ Return True if the given version string is at least as high as
+    the earliest version string in supported_versions.
+    """
+    # We use LooseVersion because StrictVersion can't deal with patch
+    # releases like 0.9.9.1.
+    sorted_versions = sorted(
+        supported_versions,
+        key=lambda v: LooseVersion(v)
+    )
+    return LooseVersion(version) >= LooseVersion(sorted_versions[0])
+
+
+def _is_later_version_available(version, supported_versions):
+    """ Return True if the given version string is the latest supported
+    version.
+    """
+    # We use LooseVersion because StrictVersion can't deal with patch
+    # releases like 0.9.9.1.
+    sorted_versions = sorted(
+        supported_versions,
+        key=lambda v: LooseVersion(v)
+    )
+    return LooseVersion(version) < LooseVersion(sorted_versions[-1])
+
+
+def check_version():
+    """ Check if this version of brkt-cli is still supported by checking
+    our version against the versions available on PyPI.  If a
+    later version is available, print a message to the console.
+
+    :return True if this version is still supported
+    """
+    url = 'http://pypi.python.org/pypi/brkt-cli/json'
+    log.debug('Getting supported brkt-cli versions from %s', url)
+
+    try:
+        resp = urllib2.urlopen(url, timeout=5.0)
+        code = resp.getcode()
+        if code / 100 != 2:
+            raise Exception(
+                'Error %d when opening %s' % (code, url))
+        d = json.loads(resp.read())
+        supported_versions = d['releases'].keys()
+    except Exception as e:
+        # If we can't get the list of versions from PyPI, print the error
+        # and return true.  We don't want the version check to block people
+        # from getting their work done.
+        log.debug('', exc_info=1)
+        msg = e.message or type(e).__name__
+        log.info('Unable to load brkt-cli versions from PyPI: %s', msg)
+        return True
+
+    if not _is_version_supported(VERSION, supported_versions):
+        log.error(
+            'Version %s is no longer supported. '
+            'Run "pip install --upgrade brkt-cli" to upgrade to the '
+            'latest version.',
+            VERSION
+        )
+        return False
+    if _is_later_version_available(VERSION, supported_versions):
+        log.info(
+            'A new release of brkt-cli is available. '
+            'Run "pip install --upgrade brkt-cli" to upgrade to the '
+            'latest version.'
+        )
+
+    return True
+
+
+def set_last_version_check_time(cfg, dt=None):
+    """ Save the last version check date in config.
+    :param dt a datetime object.  If None, use the current timestamp
+    """
+    if not dt:
+        dt = datetime.datetime.now(tz=iso8601.UTC)
+    cfg.set_internal_option('last-version-check-time', dt.isoformat())
+
+
+def get_last_version_check_time(cfg):
+    """ Return the timestamp of the last version check as a datetime, or
+    None if it has not been saved in config.
+    """
+    s = cfg.get_internal_option('last-version-check-time')
+    if not s:
+        return None
+
+    try:
+        return iso8601.parse_date(s)
+    except iso8601.ParseError as e:
+        log.warn(
+            'Unable to parse version check date "%s": %s',
+            s, e.message)
+
+
+def is_version_check_needed(cfg):
+    """ Return True if the last version check stored in config is over a
+    day ago.
+
+    :param cfg a CLIConfig object
+    """
+    t = get_last_version_check_time(cfg)
+    if not t:
+        return True
+
+    now = datetime.datetime.now(tz=iso8601.UTC)
+    if now - t >= datetime.timedelta(days=1):
+        return True

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if python_version != '2.7':
         python_version)
 
 version = ''
-with open('brkt_cli/__init__.py', 'r') as fd:
+with open('brkt_cli/version.py', 'r') as fd:
     version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 

--- a/test.py
+++ b/test.py
@@ -21,46 +21,9 @@ import yaml
 
 import brkt_cli
 import brkt_cli.util
-from brkt_cli import proxy
+from brkt_cli import proxy, version
 from brkt_cli.proxy import Proxy
 from brkt_cli.validation import ValidationError
-
-
-class TestVersionCheck(unittest.TestCase):
-
-    def test_is_version_supported(self):
-        supported = [
-            '0.9.8', '0.9.9', '0.9.9.1', '0.9.10', '0.9.11', '0.9.12'
-        ]
-        self.assertFalse(
-            brkt_cli._is_version_supported('0.9.7', supported)
-        )
-        self.assertTrue(
-            brkt_cli._is_version_supported('0.9.8', supported)
-        )
-        self.assertTrue(
-            brkt_cli._is_version_supported('0.9.12', supported)
-        )
-        self.assertTrue(
-            brkt_cli._is_version_supported('0.9.13pre1', supported)
-        )
-        self.assertTrue(
-            brkt_cli._is_version_supported('0.9.13', supported)
-        )
-
-    def test_is_later_version_available(self):
-        supported = [
-            '0.9.8', '0.9.9', '0.9.9.1', '0.9.10', '0.9.11', '0.9.12'
-        ]
-        self.assertTrue(
-            brkt_cli._is_later_version_available('0.9.11', supported)
-        )
-        self.assertFalse(
-            brkt_cli._is_later_version_available('0.9.12', supported)
-        )
-        self.assertFalse(
-            brkt_cli._is_later_version_available('0.9.13pre1', supported)
-        )
 
 
 class TestProxy(unittest.TestCase):
@@ -238,7 +201,7 @@ class TestJWT(unittest.TestCase):
         header = {'typ': 'JWT', 'alg': 'ES384', 'kid': 'abc'}
         payload = {
             'jti': brkt_cli.util.make_nonce(),
-            'iss': 'brkt-cli-' + brkt_cli.VERSION,
+            'iss': 'brkt-cli-' + version.VERSION,
             'iat': int(time.time())
         }
         signature = 'Signed, sealed, delivered'


### PR DESCRIPTION
Check whether the version of brkt-cli is supported once a day, instead
of checking every time the command runs.  This avoids an unnecessary
network round trip.  It also makes it less likely that users will see
warnings in the command output when the PyPI REST API is not responding.

Add support for internal options to CLIConfig.  These options are used
by brkt-cli application code and not exposed to end users.  Store the
last version check timestamp as an internal option.

Move version-related code to a new module, to make the main brkt_cli
module more concise.

Add the ability to read CLIConfig from any file, instead of hardcoding
CONFIG_PATH.  This allows us to write unit tests that use StringIO.