### PR TITLE
Include endpoints in userdata for unencrypted-guest

### DIFF
--- a/brkt_cli/make_user_data/test_make_user_data.py
+++ b/brkt_cli/make_user_data/test_make_user_data.py
@@ -16,7 +16,11 @@ import inspect
 import os
 import unittest
 
-from brkt_cli import make_user_data
+from brkt_cli import (
+    brkt_env_from_domain,
+    make_user_data
+)
+from brkt_cli.config import CLIConfig
 from brkt_cli.instance_config_args import instance_config_args_to_values
 
 
@@ -32,7 +36,12 @@ class TestMakeUserData(unittest.TestCase):
         self.maxDiff = None # show full diff with knowngood multi-line strings
 
     def run_cmd(self, values):
-        output = make_user_data.make(values)
+        config = CLIConfig()
+        env = brkt_env_from_domain('foo.com')
+        config.set_env('test', env)
+        config.set_current_env('test')
+
+        output = make_user_data.make(values, config)
 
         knowngood_file = os.path.join(self.testdata_dir,
                                       self.test_name + ".out")

--- a/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
+++ b/brkt_cli/make_user_data/testdata/test_unencrypted_guest.out
@@ -7,5 +7,5 @@ Content-Type: text/brkt-config; charset="utf-8"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 
-{"brkt": {"allow_unencrypted_guest": true, "solo_mode": "metavisor"}}
+{"brkt": {"allow_unencrypted_guest": true, "api_host": "yetiapi.foo.com:443", "hsmproxy_host": "hsmproxy.foo.com:443", "network_host": "network.foo.com:443", "solo_mode": "metavisor"}}
 ----===============HI-20131203==----


### PR DESCRIPTION
* The userdata produced by 'make-user-data --unencrypted-guest' should have the Yeti endpoints included; the endpoints are determined by the active config (defaulting to Prod endpoints for the default 'brkt-hosted' env).

Testing:
* Ran 'brkt make-user-data' with various options, including --unencrypted-guest
* Ran unit tests.