### PR TITLE
Support new encryptor image name format

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -234,7 +234,7 @@ def run_encrypt(values, config, verbose=False):
 
     mv_image = aws_svc.get_image(encryptor_ami)
     if values.crypto is None:
-        if mv_image.name.startswith('brkt-avatar-freebsd'):
+        if mv_image.name.startswith('metavisor'):
             crypto_policy = CRYPTO_XTS
         elif mv_image.name.startswith('brkt-avatar'):
             crypto_policy = CRYPTO_GCM
@@ -247,7 +247,7 @@ def run_encrypt(values, config, verbose=False):
             crypto_policy = CRYPTO_XTS
     else:
         crypto_policy = values.crypto
-        if crypto_policy == CRYPTO_XTS and not mv_image.name.startswith('brkt-avatar-freebsd'):
+        if crypto_policy == CRYPTO_XTS and not mv_image.name.startswith('metavisor'):
             raise ValidationError(
                 'Unsupported crypto policy %s for encryptor %s' %
                 crypto_policy, mv_image.name
@@ -606,7 +606,7 @@ def _validate_encryptor_ami(aws_svc, ami_id):
     :raise ValidationError if validation fails
     """
     image = _validate_ami(aws_svc, ami_id)
-    if 'brkt-avatar' not in image.name:
+    if 'brkt-avatar' not in image.name and 'metavisor' not in image.name:
         raise ValidationError(
             '%s (%s) is not a Bracket Encryptor image' % (ami_id, image.name)
         )

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -953,7 +953,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
         net_sriov_attr = aws_svc.get_instance_attribute(guest_instance.id,
                                                         "sriovNetSupport")
         if (guest_image.virtualization_type == 'hvm' and
-            'brkt-avatar-freebsd' not in mv_image.name):
+            'metavisor' not in mv_image.name):
             if net_sriov_attr.get("sriovNetSupport") == "simple":
                 log.warn("Guest Operating System license information will not "
                          "be preserved because guest has sriovNetSupport "
@@ -989,7 +989,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
                 vol_type=vol_type, iops=iops, legacy=legacy,
                 save_encryptor_logs=save_encryptor_logs, status_port=status_port)
 
-        if 'brkt-avatar-freebsd' in mv_image.name and \
+        if 'metavisor' in mv_image.name and \
             net_sriov_attr.get("sriovNetSupport") != "simple":
             log.info('Enabling sriovNetSupport for guest instance %s',
                       guest_instance.id)

--- a/brkt_cli/aws/test_aws.py
+++ b/brkt_cli/aws/test_aws.py
@@ -181,6 +181,10 @@ class TestValidation(unittest.TestCase):
         # Valid image.
         brkt_cli.aws._validate_encryptor_ami(aws_svc, image.id)
 
+        # Valid image.
+        image.name = 'metavisor-0-0-1234'
+        brkt_cli.aws._validate_encryptor_ami(aws_svc, image.id)
+
         # Unexpected name.
         image.name = 'foobar'
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
The encryptor image name is used to determine valid images for AWS.
The image name is also used to determine the encryptor type (NetBSD
vs. FreeBSD) to make certain decisions (for cryptor policy and
sriovNetSupport). The image name format for FreeBSD encryptor
image was changed from brkt-avatar-freebsd-<date> to
metavisor-<branch>-<hash>. This change supports the new image name
format, but ignores the ealier image name format (brkt-avatar-freebsd).