### PR TITLE
Add a config key for AWS region

### DIFF
--- a/brkt_cli/aws/aws_args.py
+++ b/brkt_cli/aws/aws_args.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+def add_region(parser, parsed_config):
+    parser.add_argument(
+        '--region',
+        metavar='NAME',
+        help='The AWS region metavisors will be launched into',
+        dest='region',
+        default=parsed_config.get_option('aws.region')
+    )

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -14,8 +14,10 @@
 
 import argparse
 
+from brkt_cli.aws import aws_args
 
-def setup_diag_args(parser):
+
+def setup_diag_args(parser, parsed_config):
     parser.add_argument(
         '--snapshot',
         metavar='ID',
@@ -43,13 +45,7 @@ def setup_diag_args(parser):
         default=True,
         help="Don't validate instances and snapshots"
     )
-    parser.add_argument(
-        '--region',
-        metavar='NAME',
-        help='AWS region (e.g. us-west-2)',
-        dest='region',
-        required=True
-    )
+    aws_args.add_region(parser, parsed_config)
     parser.add_argument(
         '--security-group',
         metavar='ID',

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -17,9 +17,10 @@ from brkt_cli.util import (
     CRYPTO_GCM,
     CRYPTO_XTS
 )
+from brkt_cli.aws import aws_args
 
 
-def setup_encrypt_ami_args(parser):
+def setup_encrypt_ami_args(parser, parsed_config):
     parser.add_argument(
         'ami',
         metavar='ID',
@@ -48,13 +49,7 @@ def setup_encrypt_ami_args(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
-    parser.add_argument(
-        '--region',
-        metavar='NAME',
-        help='AWS region (e.g. us-west-2)',
-        dest='region',
-        required=True
-    )
+    aws_args.add_region(parser, parsed_config)
     parser.add_argument(
         '--security-group',
         metavar='ID',

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 import argparse
 
+from brkt_cli.aws import aws_args
 
-def setup_share_logs_args(parser):
+
+def setup_share_logs_args(parser, parsed_config):
     parser.add_argument(
         '--snapshot',
         metavar='ID',
@@ -34,13 +36,7 @@ def setup_share_logs_args(parser):
         default=True,
         help="Don't validate instance has AMI with Bracket tags"
     )
-    parser.add_argument(
-        '--region',
-        metavar='NAME',
-        help='AWS region (e.g. us-west-2)',
-        dest='region',
-        required=True
-    )
+    aws_args.add_region(parser, parsed_config)
     parser.add_argument(
         '-v',
         '--verbose',

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -14,8 +14,10 @@
 
 import argparse
 
+from brkt_cli.aws import aws_args
 
-def setup_update_encrypted_ami(parser):
+
+def setup_update_encrypted_ami(parser, parsed_config):
     parser.add_argument(
         'ami',
         metavar='ID',
@@ -53,13 +55,7 @@ def setup_update_encrypted_ami(parser):
         default=True,
         help="Don't validate AMIs, subnet, and security groups"
     )
-    parser.add_argument(
-        '--region',
-        metavar='REGION',
-        help='AWS region (e.g. us-west-2)',
-        dest='region',
-        required=True
-    )
+    aws_args.add_region(parser, parsed_config)
     parser.add_argument(
         '--security-group',
         metavar='ID',


### PR DESCRIPTION
Add a new aws.region config key.  Update command line parsing to use
that value as the default.  Move the code that adds the --region option
into a new aws_args module, to avoid duplication.  Remove "(e.g.
us-west-2)" from the option description, to avoid "(e.g. us-west-2)
(default: us-east-1)".  Manually check that the region is set, now that
--region is no longer required.