### PR TITLE
Get API token from an environment variable

### DIFF
--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -348,7 +348,10 @@ def _get_yeti_service(parsed_config):
     _, env = parsed_config.get_current_env()
     root_url = 'https://%s:%d' % (
         env.public_api_host, env.public_api_port)
-    token = parsed_config.get_option('api-token')
+    token = (
+        os.environ.get('BRKT_API_TOKEN') or
+        parsed_config.get_option('api-token')
+    )
     return YetiService(root_url, token=token)
 
 
@@ -361,14 +364,14 @@ def get_yeti_service(parsed_config):
     y = _get_yeti_service(parsed_config)
     if not y.token:
         raise ValidationError(
-            'Not logged in.  Please run brkt config login.')
+            '$BRKT_API_TOKEN is not set. Run brkt auth to get an API token.')
 
     try:
         y.get_customer()
     except YetiError as e:
         if e.http_status == 401:
             raise ValidationError(
-                'Config API token is not authorized to access %s' %
+                '$BRKT_API_TOKEN is not authorized to access %s' %
                 y.root_url)
         raise ValidationError(e.message)
     return y

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import os
 import StringIO
 import unittest
 
@@ -306,3 +307,27 @@ class ConfigCommandTestCase(unittest.TestCase):
         self.cmd._unset_env(UnsetEnvValues('test1'))
         self.cmd._list_envs()
         self.assertEqual(self.out.getvalue(), "* brkt-hosted\n")
+
+
+class YetiServiceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.original_token = os.environ.get('BRKT_API_TOKEN')
+
+    def tearDown(self):
+        if self.original_token:
+            os.environ['BRKT_API_TOKEN'] = self.original_token
+        else:
+            del os.environ['BRKT_API_TOKEN']
+
+    def test_get_yeti_service(self):
+        cfg = CLIConfig()
+        cfg.register_option('api-token', '')
+        y = brkt_cli.config._get_yeti_service(cfg)
+        self.assertEqual('https://api.mgmt.brkt.com:443', y.root_url)
+        self.assertEqual(self.original_token, y.token)
+
+        # Make sure the API token environment variable is picked up.
+        os.environ['BRKT_API_TOKEN'] = 'abc'
+        y = brkt_cli.config._get_yeti_service(cfg)
+        self.assertEqual('abc', y.token)


### PR DESCRIPTION
Update config.get_yeti_service() to get the API token from the
BRKT_API_TOKEN environment variable instead of the user's config.
Turned out that storing the API token in the config file isn't
convenient for scripting.  With an environment variable, the workflow is
the same for end users and scripts.

Update brkt auth to read the default API URL from config instead of
hardcoding to the production service.