### PR TITLE
Don't validate the launch token

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -212,9 +212,6 @@ def run_encrypt(values, config, verbose=False):
         # Validate the region before connecting.
         _validate_region(aws_svc, values.region)
 
-        if values.token:
-            brkt_cli.check_jwt_auth(brkt_env, values.token)
-
     aws_svc.connect(values.region, key_name=values.key_name)
 
     if values.validate:
@@ -305,9 +302,6 @@ def run_update(values, config, verbose=False):
     if values.validate:
         # Validate the region before connecting.
         _validate_region(aws_svc, values.region)
-
-        if values.token:
-            brkt_cli.check_jwt_auth(brkt_env, values.token)
 
     aws_svc.connect(values.region, key_name=values.key_name)
     encrypted_image = _validate_ami(aws_svc, values.ami)

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -378,7 +378,6 @@ def check_args(values, gcp_svc, cli_config):
         brkt_env = brkt_cli.brkt_env_from_values(values)
         if brkt_env is None:
             _, brkt_env = cli_config.get_current_env()
-        brkt_cli.check_jwt_auth(brkt_env, values.token)
 
 
 def validate_tags(tags):


### PR DESCRIPTION
Remove the code that validates a launch token by using it to
authenticate with the Bracket service.  This validation will break once
we decouple API tokens and launch tokens.