### PR TITLE
Get launch token from Bracket service during encryption

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -19,6 +19,7 @@ import urllib2
 
 import boto
 from boto.exception import EC2ResponseError, NoAuthHandlerFound
+from brkt_cli import instance_config_args
 
 import brkt_cli
 from brkt_cli import encryptor_service, util
@@ -250,8 +251,13 @@ def run_encrypt(values, config, verbose=False):
                 crypto_policy, mv_image.name
             )
 
+    lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_CREATOR_MODE, cli_config=config)
+        values,
+        mode=INSTANCE_CREATOR_MODE,
+        cli_config=config,
+        launch_token=lt)
+
     if verbose:
         with tempfile.NamedTemporaryFile(
             prefix='user-data-',
@@ -352,8 +358,13 @@ def run_update(values, config, verbose=False):
         encrypted_image.id, encryptor_ami
     )
 
+    lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_UPDATER_MODE, cli_config=config)
+        values,
+        mode=INSTANCE_UPDATER_MODE,
+        cli_config=config,
+        launch_token=lt
+    )
     if verbose:
         with tempfile.NamedTemporaryFile(
             prefix='user-data-',

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -142,7 +142,7 @@ class MakeTokenSubcommand(Subcommand):
             # New workflow: get a launch token from Yeti.
             yeti = config.get_yeti_service(self.config)
             tags = _brkt_tags_from_name_value_list(values.brkt_tags)
-            jwt_string = yeti.get_token(tags=tags)
+            jwt_string = yeti.get_launch_token(tags=tags)
 
         log.debug('Header: %s', json.dumps(get_header(jwt_string)))
         log.debug('Payload: %s', json.dumps(get_payload(jwt_string)))

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -23,6 +23,7 @@ from brkt_cli.subcommand import Subcommand
 
 from brkt_cli import (
     encryptor_service,
+    instance_config_args,
     util
 )
 from brkt_cli.instance_config import (
@@ -170,8 +171,13 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
+        lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
-            values, mode=INSTANCE_CREATOR_MODE, cli_config=parsed_config)
+            values,
+            mode=INSTANCE_CREATOR_MODE,
+            cli_config=parsed_config,
+            launch_token=lt
+        )
         crypto_policy = values.crypto
         if crypto_policy is None:
             crypto_policy = CRYPTO_XTS
@@ -332,8 +338,13 @@ def run_update(values, parsed_config, log, use_esx=False):
             raise ValidationError("Template VM %s not found" %
                                   values.template_vm_name)
     try:
+        lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
-            values, mode=INSTANCE_UPDATER_MODE, cli_config=parsed_config)
+            values,
+            mode=INSTANCE_UPDATER_MODE,
+            cli_config=parsed_config,
+            launch_token=lt
+        )
         user_data_str = vc_swc.create_userdata_str(instance_config,
             update=True, ssh_key_file=values.ssh_public_key_file)
         if (values.encryptor_vmdk is not None):

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 from brkt_cli.subcommand import Subcommand
 
-from brkt_cli import encryptor_service, util
+from brkt_cli import encryptor_service, instance_config_args, util
 from brkt_cli.instance_config import (
     INSTANCE_CREATOR_MODE,
     INSTANCE_METAVISOR_MODE,
@@ -50,6 +50,13 @@ def run_encrypt(values, config):
 
     log.info('Starting encryptor session %s', gcp_svc.get_session_id())
 
+    lt = instance_config_args.get_launch_token(values, config)
+    ic = instance_config_from_values(
+        values,
+        mode=INSTANCE_CREATOR_MODE,
+        cli_config=config,
+        launch_token=lt
+    )
     encrypted_image_id = encrypt_gcp_image.encrypt(
         gcp_svc=gcp_svc,
         enc_svc_cls=encryptor_service.EncryptorService,
@@ -57,8 +64,7 @@ def run_encrypt(values, config):
         encryptor_image=values.encryptor_image,
         encrypted_image_name=encrypted_image_name,
         zone=values.zone,
-        instance_config=instance_config_from_values(
-            values, mode=INSTANCE_CREATOR_MODE, cli_config=config),
+        instance_config=ic,
         crypto_policy=values.crypto,
         image_project=values.image_project,
         keep_encryptor=values.keep_encryptor,
@@ -96,6 +102,13 @@ def run_update(values, config):
 
     log.info('Starting updater session %s', gcp_svc.get_session_id())
 
+    lt = instance_config_args.get_launch_token(values, config)
+    ic = instance_config_from_values(
+        values,
+        mode=INSTANCE_UPDATER_MODE,
+        cli_config=config,
+        launch_token=lt
+    )
     updated_image_id = update_gcp_image.update_gcp_image(
         gcp_svc=gcp_svc,
         enc_svc_cls=encryptor_service.EncryptorService,
@@ -103,9 +116,7 @@ def run_update(values, config):
         encryptor_image=values.encryptor_image,
         encrypted_image_name=encrypted_image_name,
         zone=values.zone,
-        instance_config=instance_config_from_values(
-            values, mode=INSTANCE_UPDATER_MODE,
-            cli_config=config),
+        instance_config=ic,
         keep_encryptor=values.keep_encryptor,
         image_file=values.image_file,
         image_bucket=values.bucket,

--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -145,7 +145,7 @@ class YetiService(object):
             email=d['email']
         )
 
-    def get_token(self, tags=None):
+    def get_launch_token(self, tags=None):
         """ Return a Metavisor launch token (JWT).
 
         :param tags a string map that specifies Bracket tags that will be


### PR DESCRIPTION
Update the encrypt and update commands to get the Metavisor launch token
from the Bracket service if it's not specified on the command line.

With this change, the CLI will always send a launch token to Metavisor
when encrypting or updating.  If the launch token is not specified with
the --token option, we will now require that the $BRKT_API_TOKEN
environment variable be set.  This allows the CLI to authenticate and
get a launch token from the Bracket service.