### PR TITLE
Write email prompt to stderr during auth

### DIFF
--- a/brkt_cli/auth.py
+++ b/brkt_cli/auth.py
@@ -14,6 +14,8 @@
 import getpass
 import logging
 
+import sys
+
 import brkt_cli
 from brkt_cli import argutil, ValidationError, util
 from brkt_cli.subcommand import Subcommand
@@ -69,7 +71,12 @@ class AuthSubcommand(Subcommand):
         argutil.add_out(parser)
 
     def run(self, values):
-        email = values.email or raw_input('Email: ')
+        email = values.email
+        if not email:
+            # Write to stderr, so that the user doesn't see the prompt
+            # in the output file when redirecting stdout.
+            sys.stderr.write('Email: ')
+            email = raw_input()
         password = values.password or getpass.getpass('Password: ')
         y = YetiService(values.root_url)
         try:


### PR DESCRIPTION
When --email is not specified, write the prompt to stderr instead of
stdout.  This allows the user to redirect auth output without getting
"Email: " in the output file.