### PR TITLE
Add --brkt-tags to encrypt and update commands

### DIFF
--- a/brkt_cli/argutil.py
+++ b/brkt_cli/argutil.py
@@ -25,3 +25,16 @@ def add_out(parser):
             'character encoding issues when redirecting output on Windows.'
         )
     )
+
+
+def add_brkt_tag(parser):
+    parser.add_argument(
+        '--brkt-tag',
+        metavar='NAME=VALUE',
+        dest='brkt_tags',
+        help=(
+            'Bracket tag which will be embedded in the JWT as a claim.  All '
+            'characters must be alphanumeric or [-_.].  The tag name cannot '
+            'be a JWT registered claim name (see RFC 7519).'),
+        action='append'
+    )

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -57,7 +57,7 @@ def _name_value_list_to_dict(l):
     return d
 
 
-def _brkt_tags_from_name_value_list(l):
+def brkt_tags_from_name_value_list(l):
     """ Convert a list of NAME=VALUE strings to a dictionary.
 
     :raise ValidationError if a key is specified more than once or a key
@@ -86,7 +86,7 @@ def _make_jwt_from_signing_key(values, signing_key):
 
     # Merge claims and tags.
     claims = _name_value_list_to_dict(values.claims)
-    claims.update(_brkt_tags_from_name_value_list(values.brkt_tags))
+    claims.update(brkt_tags_from_name_value_list(values.brkt_tags))
 
     return make_jwt(
         crypto,
@@ -141,7 +141,7 @@ class MakeTokenSubcommand(Subcommand):
 
             # New workflow: get a launch token from Yeti.
             yeti = config.get_yeti_service(self.config)
-            tags = _brkt_tags_from_name_value_list(values.brkt_tags)
+            tags = brkt_tags_from_name_value_list(values.brkt_tags)
             jwt_string = yeti.get_launch_token(tags=tags)
 
         log.debug('Header: %s', json.dumps(get_header(jwt_string)))
@@ -299,18 +299,7 @@ def setup_make_jwt_args(subparsers):
             'The private key that is used to sign the JWT. The key must be a '
             '384-bit ECDSA private key (NIST P-384) in PEM format.')
     )
-
-    parser.add_argument(
-        '--brkt-tag',
-        metavar='NAME=VALUE',
-        dest='brkt_tags',
-        help=(
-            'Bracket tag which will be embedded in the JWT as a claim.  All '
-            'characters must be alphanumeric or [-_.].  The tag name cannot '
-            'be a JWT registered claim name (see RFC 7519).'),
-        action='append'
-    )
-
+    argutil.add_brkt_tag(parser)
     parser.add_argument(
         '--claim',
         metavar='NAME=VALUE',

--- a/brkt_cli/brkt_jwt/test_jwt.py
+++ b/brkt_cli/brkt_jwt/test_jwt.py
@@ -140,8 +140,8 @@ class TestNameValueToDict(unittest.TestCase):
     def test_brkt_tags_from_name_value_list(self):
         self.assertEqual(
             {'a': 'b', 'c': 'd'},
-            brkt_jwt._brkt_tags_from_name_value_list(['a=b', 'c=d'])
+            brkt_jwt.brkt_tags_from_name_value_list(['a=b', 'c=d'])
         )
 
         with self.assertRaises(ValidationError):
-            brkt_jwt._brkt_tags_from_name_value_list(['exp=1'])
+            brkt_jwt.brkt_tags_from_name_value_list(['exp=1'])

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -135,8 +135,15 @@ def run_launch(values, config):
     gcp_svc = gcp_service.GCPService(values.project, None, log)
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
+
+    # Use the token in the image unless a token or tags were specified on
+    # the command line.
+    lt = None
+    if values.token or values.brkt_tags:
+        lt = instance_config_args.get_launch_token(values, config)
+
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_METAVISOR_MODE)
+        values, mode=INSTANCE_METAVISOR_MODE, launch_token=lt)
     if values.startup_script:
         extra_items = [{
             'key': 'startup-script',

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -124,8 +124,15 @@ class MakeUserDataSubcommand(Subcommand):
             formatter_class=brkt_cli.SortingHelpFormatter
         )
 
+        # Don't add --brkt-tag, since we don't want make-user-data to talk
+        # to Yeti to generate a launch token.  Users can generate a token
+        # and specify tags with the make-token command.
         setup_instance_config_args(
-            parser, parsed_config, mode=INSTANCE_METAVISOR_MODE)
+            parser,
+            parsed_config,
+            mode=INSTANCE_METAVISOR_MODE,
+            brkt_tag=False
+        )
 
         parser.add_argument(
             '-v',


### PR DESCRIPTION
Add a --brkt-tags option to the following commands:

* aws encrypt
* aws update
* gcp encrypt
* gcp update
* gcp launch
* vmware encrypt-with-vcenter
* vmware encrypt-with-esx-host
* vmware update-with-vcenter
* vmware update-with-esx-host

When one or more tags is specified with the --brkt-tag option, we pass
the tags to the Bracket service at the time we generate the launch
token.  Yeti embeds the tags into the generated JWT as claims.