### PR TITLE
Provide ability to launch Bracket "wrapped" instance

### DIFF
--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -282,6 +282,7 @@ class DummyAWSService(aws_service.BaseAWSService):
         image.name = name
         image.description = description
         image.virtualization_type = 'hvm'
+        image.root_device_name = '/dev/sda1'
         image.root_device_type = 'ebs'
         image.hypervisor = 'xen'
         self.images[image.id] = image
@@ -374,12 +375,12 @@ def build_aws_service():
     bdm = BlockDeviceMapping()
     bdm['/dev/sda1'] = BlockDeviceType()
     bdm['/dev/sdg'] = BlockDeviceType()
-    id = aws_svc.register_image(name='brkt-avatar', block_device_map=bdm)
+    id = aws_svc.register_image(name='metavisor-0-0-1234', block_device_map=bdm)
     encryptor_image = aws_svc.get_image(id)
 
     # Guest image
     bdm = BlockDeviceMapping()
-    bdm['/dev/sda1'] = BlockDeviceType()
+    bdm['/dev/sda1'] = BlockDeviceType(snapshot_id='snap-12345678')
     id = aws_svc.register_image(name='Guest image', block_device_map=bdm)
     guest_image = aws_svc.get_image(id)
 

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -1,0 +1,271 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import email
+import json
+import unittest
+import zlib
+
+from boto.vpc import Subnet
+
+import brkt_cli
+import brkt_cli.aws
+import brkt_cli.util
+from brkt_cli.aws import wrap_image
+from brkt_cli.aws.test_aws_service import build_aws_service
+from brkt_cli.instance_config import (
+    BRKT_CONFIG_CONTENT_TYPE,
+    INSTANCE_METAVISOR_MODE,
+)
+from brkt_cli.instance_config_args import (
+    instance_config_args_to_values,
+    instance_config_from_values
+)
+
+
+class TestWrappedInstanceName(unittest.TestCase):
+
+    def test_encrypted_image_suffix(self):
+        """ Test that generated suffixes are unique.
+        """
+        s1 = wrap_image.get_wrapped_suffix()
+        s2 = wrap_image.get_wrapped_suffix()
+        self.assertNotEqual(s1, s2)
+
+
+class TestException(Exception):
+    pass
+
+
+class TestRunEncryption(unittest.TestCase):
+
+    def setUp(self):
+        brkt_cli.util.SLEEP_ENABLED = False
+
+    def test_smoke(self):
+        """ Run the entire process and test that nothing obvious is broken.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+        instance = wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+        )
+        self.assertIsNotNone(instance)
+
+    def test_wrapped_instance_name(self):
+        """ Test that the wrapped instance is launched with the Metavisor AMI.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        name = 'Am I an unencrypted guest instance?'
+        instance = wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            wrapped_instance_name=name,
+        )
+        instance = aws_svc.get_instance(instance.id)
+        self.assertEqual(encryptor_image.id, instance.image_id)
+
+    def test_subnet_with_security_groups(self):
+        """ Test that the subnet and security groups are passed to the
+        calls to AWSService.run_instance().
+        """
+
+        def run_instance_callback(args):
+            self.assertEqual('subnet-1', args.subnet_id)
+            self.assertEqual(['sg-1', 'sg-2'], args.security_group_ids)
+
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            subnet_id='subnet-1',
+            security_group_ids=['sg-1', 'sg-2']
+        )
+
+    def test_subnet_without_security_groups(self):
+        """ Test that we create the temporary security group in the subnet
+        that the user specified.
+        """
+        self.security_group_was_created = False
+
+        def create_security_group_callback(vpc_id):
+            self.security_group_was_created = True
+            self.assertEqual('vpc-1', vpc_id)
+
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+        aws_svc.create_security_group_callback = \
+            create_security_group_callback
+
+        subnet = Subnet()
+        subnet.id = 'subnet-1'
+        subnet.vpc_id = 'vpc-1'
+        aws_svc.subnets = {subnet.id: subnet}
+
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            subnet_id='subnet-1'
+        )
+        self.assertTrue(self.security_group_was_created)
+
+    def test_default_instance_type(self):
+        """ Test that we launch the wrapped guest as m3.medium by default
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        def run_instance_callback(args):
+            if args.image_id == guest_image.id:
+                self.assertEqual('m3.medium', args.instance_type)
+            elif args.image_id == encryptor_image.id:
+                self.assertEqual('m3.medium', args.instance_type)
+            else:
+                self.fail('Unexpected image id: ' + args.image_id)
+
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+        )
+
+    def test_guest_instance_type(self):
+        """ Test that we use the specified instance type to launch the wrapped
+        instance.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        def run_instance_callback(args):
+            if args.image_id == guest_image.id:
+                self.assertEqual('t2.micro', args.instance_type)
+
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            instance_type='t2.micro'
+        )
+
+
+class TestBrktEnv(unittest.TestCase):
+
+    def setUp(self):
+        brkt_cli.util.SLEEP_ENABLED = False
+
+    def _get_brkt_config_from_mime(self, compressed_mime_data):
+        """Look for a 'brkt-config' part in the multi-part MIME input"""
+        data = zlib.decompress(compressed_mime_data, 16 + zlib.MAX_WBITS)
+        msg = email.message_from_string(data)
+        for part in msg.walk():
+            if part.get_content_type() == BRKT_CONFIG_CONTENT_TYPE:
+                return part.get_payload(decode=True)
+        self.assertTrue(False, 'Did not find brkt-config part in userdata')
+
+    def test_brkt_env_wrapped_instance(self):
+        """ Test that we parse the brkt_env value and pass the correct
+        values to user_data when launching the encryptor instance.
+        """
+
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        network_host_port = 'network.example.com:999'
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                brkt_config = self._get_brkt_config_from_mime(args.user_data)
+                d = json.loads(brkt_config)
+                self.assertEquals(
+                    api_host_port,
+                    d['brkt']['api_host']
+                )
+                self.assertEquals(
+                    hsmproxy_host_port,
+                    d['brkt']['hsmproxy_host']
+                )
+                self.assertEquals(
+                    network_host_port,
+                    d['brkt']['network_host']
+                )
+                self.assertEquals(
+                    True,
+                    d['brkt']['allow_unencrypted_guest']
+                )
+
+        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
+                                         network_host_port)
+        values = instance_config_args_to_values(cli_args)
+        values.unencrypted_guest = True
+        ic = instance_config_from_values(values)
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            instance_config=ic
+        )
+
+    def test_brkt_env_update(self):
+        """ Test that the Bracket environment is passed through to metavisor
+        user data.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        api_host_port = 'api.example.com:777'
+        hsmproxy_host_port = 'hsmproxy.example.com:888'
+        network_host_port = 'network.example.com:999'
+        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
+                                         network_host_port)
+        values = instance_config_args_to_values(cli_args)
+        values.unencrypted_guest = True
+        ic = instance_config_from_values(values, mode=INSTANCE_METAVISOR_MODE)
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                brkt_config = self._get_brkt_config_from_mime(args.user_data)
+                d = json.loads(brkt_config)
+                self.assertEquals(
+                    api_host_port,
+                    d['brkt']['api_host']
+                )
+                self.assertEquals(
+                    hsmproxy_host_port,
+                    d['brkt']['hsmproxy_host']
+                )
+                self.assertEquals(
+                    network_host_port,
+                    d['brkt']['network_host']
+                )
+                self.assertEquals(
+                    'metavisor',
+                    d['brkt']['solo_mode']
+                )
+                self.assertEquals(
+                    True,
+                    d['brkt']['allow_unencrypted_guest']
+                )
+
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            wrapped_instance_name='Test wrapped instance',
+            instance_config=ic
+        )

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -1,0 +1,157 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Create an Bracket wrapped based on an existing unencrypted AMI.
+
+Overview of the process:
+    * Obtain the Bracket (metavisor) image to be used
+    * Obtain the root volume snapshot of the guest image
+    * Configure the Bracket image to be launched with the guest
+        root volume attached at /dev/sdf
+    * Pass appropriate user-data to the Bracket image to indicate
+        that the guest volume is unencrypted
+    * Launch the Bracket image
+
+Before running brkt encrypt-ami, set the AWS_ACCESS_KEY_ID and
+AWS_SECRET_ACCESS_KEY environment variables, like you would when
+running the AWS command line utility.
+"""
+
+import logging
+
+from boto.ec2.blockdevicemapping import (
+    BlockDeviceMapping,
+    EBSBlockDeviceType,
+)
+
+from brkt_cli.user_data import gzip_user_data
+from brkt_cli.instance_config import InstanceConfig
+from brkt_cli.aws.encrypt_ami import wait_for_instance, clean_up
+from brkt_cli.util import (
+    make_nonce,
+    append_suffix,
+)
+
+# End user-visible terminology.  These are resource names and descriptions
+# that the user will see in his or her EC2 console.
+
+# Security group names
+NAME_INSTANCE_SECURITY_GROUP = 'Bracket Wrapped %(nonce)s'
+DESCRIPTION_INSTANCE_SECURITY_GROUP = (
+    "Allows SSH access to the Bracket wrapped instance.")
+
+NAME_WRAPPED_IMAGE_SUFFIX = ' (wrapped %(nonce)s)'
+
+INSTANCE_NAME_MAX_LENGTH = 128
+
+log = logging.getLogger(__name__)
+
+
+def get_wrapped_suffix():
+    """ Return a suffix that will be appended to the wrapped instance name.
+    The suffix is in the format "(wrapped 787ace7a)".
+    """
+    return NAME_WRAPPED_IMAGE_SUFFIX % {'nonce': make_nonce()}
+
+
+def get_name_from_image(image):
+    name = append_suffix(
+        image.name,
+        get_wrapped_suffix(),
+        max_length=INSTANCE_NAME_MAX_LENGTH
+    )
+    return name
+
+
+def create_instance_security_group(aws_svc, vpc_id=None):
+    """ Creates a default security group to allow SSH access. This ensures
+    that even if a security group is not specified in the arguments, the
+    user can SSH in to the launched instance.
+    """
+    sg_name = NAME_INSTANCE_SECURITY_GROUP % {'nonce': make_nonce()}
+    sg_desc = DESCRIPTION_INSTANCE_SECURITY_GROUP
+    sg = aws_svc.create_security_group(sg_name, sg_desc, vpc_id=vpc_id)
+    log.info('Created security group with id %s', sg.id)
+    try:
+        aws_svc.add_security_group_rule(
+            sg.id, ip_protocol='tcp',
+            from_port=22,
+            to_port=22,
+            cidr_ip='0.0.0.0/0')
+    except Exception as e:
+        log.error('Failed adding security group rule to %s: %s', sg.id, e)
+        clean_up(aws_svc, security_group_ids=[sg.id])
+
+    aws_svc.create_tags(sg.id)
+    return sg
+
+
+def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
+                         wrapped_instance_name=None, subnet_id=None,
+                         security_group_ids=None, instance_type='m3.medium',
+                         instance_config=None):
+    temp_sg_id = None
+    guest_image = aws_svc.get_image(image_id)
+    guest_root_device = guest_image.root_device_name
+    guest_snapshot = guest_image.block_device_mapping[guest_root_device].snapshot_id
+    mv_image = aws_svc.get_image(metavisor_ami)
+
+    if wrapped_instance_name:
+        instance_name = wrapped_instance_name
+    else:
+        instance_name = get_name_from_image(guest_image)
+
+    bdm = BlockDeviceMapping()
+    guest_unencrypted_root = EBSBlockDeviceType(
+        volume_type='gp2',
+        snapshot_id=guest_snapshot,
+        delete_on_termination=True)
+    bdm['/dev/sdf'] = guest_unencrypted_root
+    if instance_config is None:
+        instance_config = InstanceConfig()
+    instance_config.brkt_config['allow_unencrypted_guest'] = True
+    user_data = instance_config.make_userdata()
+    compressed_user_data = gzip_user_data(user_data)
+    try:
+        if not security_group_ids:
+            vpc_id = None
+            if subnet_id:
+                subnet = aws_svc.get_subnet(subnet_id)
+                vpc_id = subnet.vpc_id
+            temp_sg_id = create_instance_security_group(
+                aws_svc, vpc_id=vpc_id)
+            security_group_ids = [temp_sg_id]
+
+        instance = aws_svc.run_instance(
+            mv_image.id,
+            instance_type=instance_type,
+            security_group_ids=security_group_ids,
+            user_data=compressed_user_data,
+            placement=None,
+            block_device_map=bdm,
+            subnet_id=subnet_id
+        )
+        aws_svc.create_tags(
+            instance.id,
+            name=instance_name
+        )
+
+        log.info('Launching wrapped guest instance %s', instance.id)
+        instance = wait_for_instance(aws_svc, instance.id)
+    finally:
+        pass
+
+    log.info('Done.')
+    return instance

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -1,0 +1,53 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+from brkt_cli.aws import aws_args
+
+
+def setup_wrap_image_args(parser, parsed_config):
+    parser.add_argument(
+        'ami',
+        metavar='ID',
+        help='The guest AMI that will be launched as a wrapped Bracket instance'
+    )
+    parser.add_argument(
+        '--wrapped-instance-name',
+        metavar='NAME',
+        dest='wrapped_instance_name',
+        help='Specify the name of the wrapped Bracket instance',
+        required=False
+    )
+    parser.add_argument(
+        '--instance-type',
+        metavar='TYPE',
+        dest='instance_type',
+        help='The instance type to use when launching the wrapped image',
+        default='m3.medium'
+    )
+    aws_args.add_no_validate(parser)
+    aws_args.add_region(parser, parsed_config)
+    aws_args.add_security_group(parser)
+    aws_args.add_subnet(parser)
+    aws_args.add_aws_tag(parser)
+    aws_args.add_key(parser)
+
+    # Optional AMI ID that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
+    aws_args.add_encryptor_ami(parser)
+
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -28,7 +28,8 @@ from brkt_cli import (
 )
 from brkt_cli.instance_config import (
     INSTANCE_CREATOR_MODE,
-    INSTANCE_UPDATER_MODE
+    INSTANCE_UPDATER_MODE,
+    INSTANCE_METAVISOR_MODE
 )
 from brkt_cli.instance_config_args import (
     instance_config_from_values,
@@ -46,6 +47,9 @@ from brkt_cli.esx import (
     update_encrypted_vmdk_args,
     encrypt_with_esx_host_args,
     update_with_esx_host_args,
+    wrap_image,
+    wrap_with_vcenter_args,
+    wrap_with_esx_host_args,
 )
 from brkt_cli.validation import ValidationError
 
@@ -395,6 +399,121 @@ def run_update(values, parsed_config, log, use_esx=False):
         return 1
 
 
+def run_wrap_image(values, parsed_config, log, use_esx=False):
+    session_id = util.make_nonce()
+
+    if not use_esx and values.vm_name is None:
+        raise ValidationError("Missing vm-name for the VM")
+    if (values.source_image_path is not None and values.image_name is None):
+        raise ValidationError("Specify the Metavisor OVF file.")
+    if use_esx:
+        _check_env_vars_set('ESX_USER_NAME')
+    else:
+        _check_env_vars_set('VCENTER_USER_NAME')
+    vcenter_password = _get_vcenter_password(use_esx)
+    brkt_cli.validate_ntp_servers(values.ntp_servers)
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = parsed_config.get_current_env()
+    if not values.token:
+        raise ValidationError('Must provide a token')
+
+    proxy = None
+    if values.http_proxy:
+        proxy = _parse_proxies(values.http_proxy)[0]
+
+    # Download images from S3
+    try:
+        if (values.encryptor_vmdk is None and
+            values.source_image_path is None):
+            (ovf, file_list) = \
+                esx_service.download_ovf_from_s3(
+                    values.bucket_name,
+                    image_name=values.image_name,
+                    proxy=proxy
+                )
+            if ovf is None:
+                raise ValidationError("Did not find MV OVF images")
+    except Exception as e:
+        raise ValidationError("Failed to download MV image from S3: ", e)
+
+    # Connect to vCenter
+    try:
+        vc_swc = esx_service.initialize_vcenter(
+            host=values.vcenter_host,
+            user=os.getenv('ESX_USER_NAME') if use_esx else os.getenv('VCENTER_USER_NAME'),
+            password=vcenter_password,
+            port=values.vcenter_port,
+            datacenter_name=None if use_esx else values.vcenter_datacenter,
+            datastore_name=values.vcenter_datastore,
+            esx_host=use_esx,
+            cluster_name=None if use_esx else values.vcenter_cluster,
+            no_of_cpus=values.no_of_cpus,
+            memory_gb=values.memory_gb,
+            session_id=session_id,
+            network_name=values.network_name,
+            nic_type=values.nic_type,
+            verify=False if use_esx else values.validate,
+        )
+    except Exception as e:
+        raise ValidationError("Failed to connect to vCenter: ", e)
+    # Validate vCenter parameters
+    vc_swc.validate_vcenter_params()
+    # Validate that template does not already exist
+    if values.vm_name:
+        if vc_swc.find_vm(values.vm_name):
+            raise ValidationError("VM with the same name as requested "
+                                  "template VM name %s already exists" %
+                                  values.vm_name)
+    # Set the disk-type
+    if values.disk_type == "thin":
+        vc_swc.set_thin_disk(True)
+        vc_swc.set_eager_scrub(False)
+    elif values.disk_type == "thick-lazy-zeroed":
+        vc_swc.set_thin_disk(False)
+        vc_swc.set_eager_scrub(False)
+    elif values.disk_type == "thick-eager-zeroed":
+        vc_swc.set_thin_disk(False)
+        vc_swc.set_eager_scrub(True)
+    else:
+        raise ValidationError("Disk Type %s not correct. Can only be "
+                              "thin, thick-lazy-zeroed or "
+                              "thick-eager-zeroed" % (values.disk_type,))
+
+    try:
+        instance_config = instance_config_from_values(
+            values, mode=INSTANCE_METAVISOR_MODE, cli_config=parsed_config)
+        instance_config.brkt_config['allow_unencrypted_guest'] = True
+        user_data_str = vc_swc.create_userdata_str(instance_config,
+            update=False, ssh_key_file=values.ssh_public_key_file)
+        if values.encryptor_vmdk is not None:
+            # Create from MV VMDK
+            wrap_image.wrap_from_vmdk(
+                vc_swc, values.vmdk, vm_name=values.vm_name,
+                metavisor_vmdk=values.encryptor_vmdk,
+                user_data_str=user_data_str
+            )
+        elif values.source_image_path is not None:
+            # Create from MV OVF in local directory
+            wrap_image.wrap_from_local_ovf(
+                vc_swc, values.vmdk, vm_name=values.vm_name,
+                source_image_path=values.source_image_path,
+                ovf_image_name=values.image_name,
+                user_data_str=user_data_str
+            )
+        else:
+            # Create from MV OVF in S3
+            wrap_image.wrap_from_s3(
+                vc_swc, values.vmdk, vm_name=values.vm_name,
+                ovf_name=ovf, download_file_list=file_list,
+                user_data_str=user_data_str, cleanup=values.cleanup
+            )
+        return 0
+    except Exception as e:
+        log.error("Failed to wrap the guest VMDK: %s", e)
+        return 1
+
+
 def run_rescue_metavisor(values, parsed_config, log):
     session_id = util.make_nonce()
     if values.protocol != 'http':
@@ -453,7 +572,8 @@ class VMwareSubcommand(Subcommand):
             # Hardcode the list, so that we don't expose internal subcommands.
             metavar=(
                 '{encrypt-with-vcenter,encrypt-with-esx-host,'
-                'update-with-vcenter,update-with-esx-host}'
+                'update-with-vcenter,update-with-esx-host,'
+                'wrap-with-vcenter, wrap-with-esx-host}'
             )
         )
 
@@ -505,6 +625,30 @@ class VMwareSubcommand(Subcommand):
             update_with_esx_parser)
         setup_instance_config_args(update_with_esx_parser, parsed_config)
 
+        wrap_with_vcenter_parser = vmware_subparsers.add_parser(
+            'wrap-with-vcenter',
+            description=(
+                'Launch guest image wrapped with Bracket Metavsor using vCenter'
+            ),
+            help='Launch guest image wrapped with Bracket Metavsor using vCenter',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        wrap_with_vcenter_args.setup_wrap_with_vcenter_args(
+            wrap_with_vcenter_parser)
+        setup_instance_config_args(wrap_with_vcenter_parser, parsed_config)
+
+        wrap_with_esx_host_parser = vmware_subparsers.add_parser(
+            'wrap-with-esx-host',
+            description=(
+                'Launch guest image wrapped with Bracket Metavsor on ESX host'
+            ),
+            help='Launch guest image wrapped with Bracket Metavsor on ESX host',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        wrap_with_esx_host_args.setup_wrap_with_esx_host_args(
+            wrap_with_esx_host_parser)
+        setup_instance_config_args(wrap_with_esx_host_parser, parsed_config)
+
         rescue_metavisor_parser = vmware_subparsers.add_parser(
             # Don't specify the help field.  This is an internal command
             # which shouldn't show up in usage output.
@@ -529,6 +673,10 @@ class VMwareSubcommand(Subcommand):
             return run_update(values, self.config, log, use_esx=True)
         if values.vmware_subcommand == 'rescue-metavisor':
             return run_rescue_metavisor(values, self.config, log)
+        if values.vmware_subcommand == 'wrap-with-vcenter':
+            return run_wrap_image(values, self.config, log)
+        if values.vmware_subcommand == 'wrap-with-esx-host':
+            return run_wrap_image(values, self.config, log, use_esx=True)
 
 
 def get_subcommands():

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -159,7 +159,7 @@ class BaseVCenterService(object):
         pass
 
     @abc.abstractmethod
-    def create_vm(self, memoryGB=1, numCPUs=1):
+    def create_vm(self, memoryGB=1, numCPUs=1, vm_name=None):
         pass
 
     @abc.abstractmethod
@@ -481,7 +481,7 @@ class VCenterService(BaseVCenterService):
             retry = retry + 1
         return (vm.guest.ipAddress)
 
-    def create_vm(self, memoryGB=1, numCPUs=1):
+    def create_vm(self, memoryGB=1, numCPUs=1, vm_name=None):
         self.validate_connection()
         content = self.si.RetrieveContent()
         datacenter = self.__get_obj(content, [vim.Datacenter],
@@ -491,7 +491,8 @@ class VCenterService(BaseVCenterService):
                                  self.cluster_name)
         pool = cluster.resourcePool
         timestamp = datetime.datetime.utcnow().isoformat() + 'Z'
-        vm_name = "VM-" + timestamp
+        if not vm_name:
+            vm_name = "VM-" + timestamp
         vmx_file = vim.vm.FileInfo(logDirectory=None,
                                    snapshotDirectory=None,
                                    suspendDirectory=None,

--- a/brkt_cli/esx/wrap_image.py
+++ b/brkt_cli/esx/wrap_image.py
@@ -1,0 +1,117 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+"""
+Create a Bracket wrapped instance based on an existing unencrypted VMDK
+
+Overview of the process:
+    * Create a VM based on the metavisor VMDK.
+    * Attach the unencrypted guest VMDK to the above VM
+    * Pass appropriate guestInfo to the VM to indicate that the guest
+        volume is unencrypted
+    * Start the VM and display its IP address
+
+Before running, do "pip install pyvmomi".
+"""
+
+import logging
+from brkt_cli.esx.esx_service import (
+    launch_mv_vm_from_s3,
+    validate_local_mv_ovf
+)
+
+
+log = logging.getLogger(__name__)
+
+
+def wrap_from_s3(vc_swc, guest_vmdk, vm_name=None,
+                 ovf_name=None, download_file_list=None,
+                 user_data_str=None, cleanup=True):
+    vm = None
+    try:
+        if (ovf_name is None or download_file_list is None):
+            log.error("Cannot get metavisor OVF from S3")
+            raise Exception("Invalid MV OVF")
+        vm = launch_mv_vm_from_s3(vc_swc, ovf_name,
+                                  download_file_list, vm_name,
+                                  cleanup)
+        guest_vmdk_path = vc_swc.get_datastore_path(guest_vmdk)
+        vc_swc.add_disk(vm, filename=guest_vmdk_path, unit_number=1)
+        if user_data_str:
+            vc_swc.send_userdata(vm, user_data_str)
+        vc_swc.power_on(vm)
+        ip_addr = vc_swc.get_ip_address(vm)
+        log.info("VM ip address is %s", ip_addr)
+    except Exception as e:
+        log.exception("Failed to launch wrapped guest from S3 (%s)", e)
+        if (vm is not None):
+            vc_swc.destroy_vm(vm)
+        raise
+
+
+def wrap_from_local_ovf(vc_swc, guest_vmdk, vm_name=None,
+                        source_image_path=None, ovf_image_name=None,
+                        user_data_str=None):
+    vm = None
+    try:
+        if ((source_image_path is None) or
+            (ovf_image_name is None)):
+            log.error("Metavisor OVF path needs to be specified")
+            return
+        # Launch OVF
+        log.info("Launching VM from local OVF")
+        ovf_image_name = ovf_image_name + ".ovf"
+        validate_local_mv_ovf(source_image_path, ovf_image_name)
+        vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
+                                          ovf_image_name,
+                                          vm_name=vm_name)
+        guest_vmdk_path = vc_swc.get_datastore_path(guest_vmdk)
+        vc_swc.add_disk(vm, filename=guest_vmdk_path, unit_number=1)
+        if user_data_str:
+            vc_swc.send_userdata(vm, user_data_str)
+        vc_swc.power_on(vm)
+        ip_addr = vc_swc.get_ip_address(vm)
+        log.info("VM ip address is %s", ip_addr)
+    except Exception as e:
+        log.exception("Failed to launch from metavisor OVF (%s)", e)
+        if (vm is not None):
+            vc_swc.destroy_vm(vm)
+        raise
+
+
+def wrap_from_vmdk(vc_swc, guest_vmdk, vm_name=None,
+                   metavisor_vmdk=None, user_data_str=None):
+    try:
+        vm = None
+        if (metavisor_vmdk is None):
+            log.error("Metavisor VMDK is not specified")
+            return
+        # Add datastore path to the vmdk
+        metavisor_vmdk_path = vc_swc.get_datastore_path(metavisor_vmdk)
+        guest_vmdk_path = vc_swc.get_datastore_path(guest_vmdk)
+        # Create a metavisor VM
+        vm = vc_swc.create_vm(vm_name=vm_name)
+        # Attach metavisor vmdk as root disk
+        vc_swc.add_disk(vm, filename=metavisor_vmdk_path, unit_number=0)
+        # Attach guest vmdk as first attached disk
+        vc_swc.add_disk(vm, filename=guest_vmdk_path, unit_number=1)
+        if user_data_str:
+            vc_swc.send_userdata(vm, user_data_str)
+        vc_swc.power_on(vm)
+        ip_addr = vc_swc.get_ip_address(vm)
+        log.info("VM ip address is %s", ip_addr)
+    except Exception as e:
+        log.exception("Failed to launch metavisor VMDK (%s)", e)
+        if (vm is not None):
+            vc_swc.destroy_vm(vm)
+        raise

--- a/brkt_cli/esx/wrap_with_esx_host_args.py
+++ b/brkt_cli/esx/wrap_with_esx_host_args.py
@@ -1,0 +1,157 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+
+def setup_wrap_with_esx_host_args(parser):
+    parser.add_argument(
+        'vmdk',
+        metavar='VMDK-NAME',
+        help='The Guest VMDK path (in the datastore) that will be encrypted'
+    )
+    parser.add_argument(
+        "--esx-host",
+        help="IP address/DNS Name of the ESX host",
+        dest="vcenter_host",
+        metavar='DNS_NAME',
+        required=True)
+    parser.add_argument(
+        "--esx-port",
+        help="Port Number of the ESX Server",
+        metavar='N',
+        dest="vcenter_port",
+        default="443",
+        required=False)
+    parser.add_argument(
+        "--esx-datastore",
+        help="ESX datastore to use",
+        dest="vcenter_datastore",
+        metavar='NAME',
+        default=None,
+        required=False)
+    parser.add_argument(
+        "--esx-network-name",
+        help="ESX network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
+        "--cpu-count",
+        help="Number of CPUs to assign to Encryptor VM",
+        metavar='N',
+        dest="no_of_cpus",
+        default="8",
+        required=False)
+    parser.add_argument(
+        "--memory",
+        help="Memory to assign to Encryptor VM",
+        metavar='GB',
+        dest="memory_gb",
+        default="32",
+        required=False)
+    parser.add_argument(
+        '--vm-name',
+        metavar='NAME',
+        dest='vm_name',
+        help='Specify the name of the launched VM',
+        required=False
+    )
+    parser.add_argument(
+        '--ovf-source-directory',
+        metavar='PATH',
+        dest='source_image_path',
+        help='Local path to the OVF directory',
+        default=None,
+        required=False
+    )
+    parser.add_argument(
+        '--metavisor-ovf-image-name',
+        metavar='NAME',
+        dest='image_name',
+        help='Metavisor OVF name',
+        default=None,
+        required=False
+    )
+
+    parser.add_argument(
+        '--disk-type',
+        metavar='TYPE',
+        dest='disk_type',
+        help='thin/thick-lazy-zeroed/thick-eager-zeroed (default: thin)',
+        default='thin',
+        required=False
+    )
+
+    # Optional VMDK that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
+    parser.add_argument(
+        '--encryptor-vmdk',
+        metavar='VMDK-NAME',
+        dest='encryptor_vmdk',
+        help=argparse.SUPPRESS
+    )
+    # Optional ssh-public key to be put into the Metavisor.
+    # Use only with debug instances.
+    # Hidden because it is used only for development.
+    parser.add_argument(
+        '--ssh-public-key',
+        metavar='PATH',
+        dest='ssh_public_key_file',
+        default=None,
+        help=argparse.SUPPRESS
+    )
+    # Optional bucket-name in case dev/qa need to use
+    # other internal buckets to fetch the MV image from
+    parser.add_argument(
+        '--bucket-name',
+        metavar='NAME',
+        dest='bucket_name',
+        help=argparse.SUPPRESS,
+        default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
+    )
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='HOST:PORT',
+        default=None,
+        help=argparse.SUPPRESS
+    )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        '--guest-fqdn',
+        metavar='FQDN',
+        dest='guest_fqdn',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/esx/wrap_with_vcenter_args.py
+++ b/brkt_cli/esx/wrap_with_vcenter_args.py
@@ -1,0 +1,177 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+
+def setup_wrap_with_vcenter_args(parser):
+    parser.add_argument(
+        'vmdk',
+        metavar='VMDK-NAME',
+        help='The Guest VMDK path (in the datastore) that will be encrypted'
+    )
+    parser.add_argument(
+        "--vcenter-host",
+        help="IP address/DNS Name of the vCenter host",
+        dest="vcenter_host",
+        metavar='DNS_NAME',
+        required=True)
+    parser.add_argument(
+        "--vcenter-port",
+        help="Port Number of the vCenter Server",
+        metavar='N',
+        dest="vcenter_port",
+        default="443",
+        required=False)
+    parser.add_argument(
+        "--vcenter-datacenter",
+        help="vCenter Datacenter to use",
+        dest="vcenter_datacenter",
+        metavar='NAME',
+        default=None,
+        required=False)
+    parser.add_argument(
+        "--vcenter-datastore",
+        help="vCenter datastore to use",
+        dest="vcenter_datastore",
+        metavar='NAME',
+        default=None,
+        required=False)
+    parser.add_argument(
+        "--vcenter-cluster",
+        help="vCenter cluster to use",
+        dest="vcenter_cluster",
+        metavar='NAME',
+        default=None,
+        required=False)
+    parser.add_argument(
+        "--vcenter-network-name",
+        help="vCenter network name to use",
+        dest="network_name",
+        metavar='NAME',
+        default="VM Network",
+        required=False)
+    parser.add_argument(
+        "--cpu-count",
+        help="Number of CPUs to assign to Encryptor VM",
+        metavar='N',
+        dest="no_of_cpus",
+        default="8",
+        required=False)
+    parser.add_argument(
+        "--memory",
+        help="Memory to assign to Encryptor VM",
+        metavar='GB',
+        dest="memory_gb",
+        default="32",
+        required=False)
+    parser.add_argument(
+        '--vm-name',
+        metavar='NAME',
+        dest='vm_name',
+        help='Specify the name of the launched VM',
+        required=False
+    )
+    parser.add_argument(
+        '--no-verify-cert',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate vCenter certificate"
+    )
+    parser.add_argument(
+        '--ovf-source-directory',
+        metavar='PATH',
+        dest='source_image_path',
+        help='Local path to the OVF directory',
+        default=None,
+        required=False
+    )
+    parser.add_argument(
+        '--metavisor-ovf-image-name',
+        metavar='NAME',
+        dest='image_name',
+        help='Metavisor OVF name',
+        default=None,
+        required=False
+    )
+    parser.add_argument(
+        '--disk-type',
+        metavar='TYPE',
+        dest='disk_type',
+        help='thin/thick-lazy-zeroed/thick-eager-zeroed (default: thin)',
+        default='thin',
+        required=False
+    )
+
+    # Optional HTTP Proxy argument which can be used in proxied environments
+    # Specifies the HTTP Proxy to use for S3/AWS connections
+    parser.add_argument(
+        '--http-s3-proxy',
+        dest='http_proxy',
+        metavar='HOST:PORT',
+        default=None,
+        help=argparse.SUPPRESS
+    )
+    # Optional VMDK that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
+    parser.add_argument(
+        '--encryptor-vmdk',
+        metavar='VMDK-NAME',
+        dest='encryptor_vmdk',
+        help=argparse.SUPPRESS
+    )
+    # Optional ssh-public key to be put into the Metavisor.
+    # Use only with debug instances.
+    # Hidden because it is used only for development.
+    parser.add_argument(
+        '--ssh-public-key',
+        metavar='PATH',
+        dest='ssh_public_key_file',
+        default=None,
+        help=argparse.SUPPRESS
+    )
+    # Optional bucket-name in case dev/qa need to use
+    # other internal buckets to fetch the MV image from
+    parser.add_argument(
+        '--bucket-name',
+        metavar='NAME',
+        dest='bucket_name',
+        help=argparse.SUPPRESS,
+        default="solo-brkt-prod-ovf-image"
+    )
+    # Optional nic-type to be used with VDS
+    # Values can be Port, VirtualPort or VirtualPortGroup
+    parser.add_argument(
+        '--nic-type',
+        metavar='NAME',
+        dest='nic_type',
+        help=argparse.SUPPRESS,
+        default="Port"
+    )
+    # Optional argument to keep the downloaded artifacts. Can we used in
+    # cases where the same (downloaded) OVF is used for multiple
+    # encryption/update jobs
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        '--guest-fqdn',
+        metavar='FQDN',
+        dest='guest_fqdn',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -21,6 +21,8 @@ from brkt_cli.gcp import (
     launch_gcp_image_args,
     update_gcp_image,
     update_encrypted_gcp_image_args,
+    wrap_gcp_image,
+    wrap_gcp_image_args,
     share_logs_gcp_args,
 )
 from brkt_cli.validation import ValidationError
@@ -170,6 +172,55 @@ def run_launch(values, config):
                             values.ssd_scratch_disks,
                             values.gcp_tags)
     print(encrypted_instance_id)
+    return 0
+
+
+def run_wrap_image(values, config):
+    session_id = util.make_nonce()
+    gcp_svc = gcp_service.GCPService(values.project, session_id, log)
+
+    if values.ssd_scratch_disks > 8:
+        raise ValidationError("Maximum of 8 SSD scratch disks are supported")
+    instance_config = instance_config_from_values(
+        values, mode=INSTANCE_METAVISOR_MODE)
+    if values.startup_script:
+        extra_items = [{
+            'key': 'startup-script',
+            'value': values.startup_script
+        }]
+    else:
+        extra_items = None
+    instance_config.brkt_config['allow_unencrypted_guest'] = True
+    brkt_userdata = instance_config.make_userdata()
+    metadata = gcp_service.gcp_metadata_from_userdata(
+        brkt_userdata, extra_items=extra_items)
+
+    if values.instance_name:
+        gcp_service.validate_image_name(values.instance_name)
+    if values.gcp_tags:
+        validate_tags(values.gcp_tags)
+    if not values.verbose:
+        logging.getLogger('googleapiclient').setLevel(logging.ERROR)
+    
+    wrapped_instance = wrap_gcp_image.wrap_guest_image(
+        gcp_svc=gcp_svc,
+        image_id=values.image,
+        encryptor_image=values.encryptor_image,
+        zone=values.zone,
+        metadata=metadata,
+        instance_name=values.instance_name,
+        image_project=values.image_project,
+        image_file=values.image_file,
+        image_bucket=values.bucket,
+        network=values.network,
+        subnet=values.subnetwork,
+        cleanup=values.cleanup,
+        ssd_disks=values.ssd_scratch_disks,
+        gcp_tags=values.gcp_tags
+    )
+    # Print the instance name to stdout in case the caller want to process
+    # the output. Log messages go to stderr
+    print(wrapped_instance)
     return 0
 
 
@@ -343,6 +394,19 @@ class GCPSubcommand(Subcommand):
         setup_instance_config_args(launch_gcp_image_parser, parsed_config,
                                    mode=INSTANCE_METAVISOR_MODE)
 
+        wrap_image_parser = gcp_subparsers.add_parser(
+            'wrap-guest-image',
+            description=(
+                'Launch guest image wrapped with Bracket Metavisor'
+            ),
+            help='Launch guest image wrapped with Bracket Metavisor',
+            formatter_class=brkt_cli.SortingHelpFormatter
+        )
+        wrap_gcp_image_args.setup_wrap_gcp_image_args(
+            wrap_image_parser, parsed_config)
+        setup_instance_config_args(wrap_image_parser, parsed_config,
+                                   mode=INSTANCE_METAVISOR_MODE)
+
         share_logs_parser = gcp_subparsers.add_parser(
             'share-logs',
             description='Creates a logs file of an instance and uploads it '
@@ -366,6 +430,8 @@ class GCPSubcommand(Subcommand):
             return run_launch(values, self.config)
         if values.gcp_subcommand == 'share-logs':
             return run_sharelogs(values, self.config)
+        if values.gcp_subcommand == 'wrap-guest-image':
+            return run_wrap_image(values, self.config)
 
 
 def get_subcommands():

--- a/brkt_cli/gcp/wrap_gcp_image.py
+++ b/brkt_cli/gcp/wrap_gcp_image.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import logging
+
+from googleapiclient import errors
+
+
+log = logging.getLogger(__name__)
+
+
+def wrap_guest_image(gcp_svc, image_id, encryptor_image,
+                     zone, metadata, instance_name=None,
+                     image_project=None, image_file=None,
+                     image_bucket=None, network=None, subnet=None,
+                     cleanup=True, ssd_disks=0, gcp_tags=None):
+    try:
+        keep_encryptor = True
+        if not encryptor_image:
+            log.info('Retrieving encryptor image from GCE bucket')
+            try:
+                encryptor_image = gcp_svc.get_latest_encryptor_image(zone,
+                    image_bucket, image_file=image_file)
+                keep_encryptor = False
+            except errors.HttpError as e:
+                encryptor_image = None
+                log.exception('GCE API call to retrieve image failed')
+                return
+
+        if not instance_name:
+            instance_name = 'brkt-guest-' + gcp_svc.get_session_id()
+            guest_disk_name = instance_name + '-unencrypted'
+        else:
+            guest_disk_name = instance_name + gcp_svc.get_session_id()
+        
+        gcp_svc.disk_from_image(zone, image_id, guest_disk_name, image_project)
+        log.info('Waiting for guest root disk to become ready')
+        gcp_svc.wait_for_detach(zone, guest_disk_name)
+
+        guest_disk = gcp_svc.get_disk(zone, guest_disk_name)
+        guest_disk['autoDelete'] = True
+        disks = [guest_disk]
+        for x in range(ssd_disks):
+            ssd_disk = gcp_svc.create_ssd_disk(zone)
+            disks.append(ssd_disk)
+
+        log.info('Launching wrapped guest image')
+        gcp_svc.run_instance(zone=zone,
+                             name=instance_name,
+                             image=encryptor_image,
+                             network=network,
+                             subnet=subnet,
+                             disks=disks,
+                             delete_boot=True,
+                             metadata=metadata,
+                             tags=gcp_tags)
+        gcp_svc.wait_instance(instance_name, zone)
+        log.info("Instance %s (%s) launched successfully" % (instance_name,
+            gcp_svc.get_instance_ip(instance_name, zone)))
+    except errors.HttpError as e:
+        log.exception('GCE API request failed: {}'.format(e.message))
+    finally:
+        if not cleanup:
+            log.info("Not cleaning up")
+        else:
+            if not keep_encryptor and encryptor_image:
+                log.info('Deleting encryptor image %s' % encryptor_image)
+                gcp_svc.delete_image(encryptor_image)
+
+    return instance_name
+
+

--- a/brkt_cli/gcp/wrap_gcp_image_args.py
+++ b/brkt_cli/gcp/wrap_gcp_image_args.py
@@ -1,0 +1,141 @@
+import argparse
+
+
+# VERY EXPERIMENTAL FEATURE
+# It will not work for you
+def setup_wrap_gcp_image_args(parser, parsed_config):
+    parser.add_argument(
+        'image',
+        metavar='ID',
+        help='The image that will be wrapped with the Bracket Metavisor',
+    )
+    parser.add_argument(
+        '--instance-name',
+        metavar='NAME',
+        dest='instance_name',
+        help='Name of the instance'
+    )
+    parser.add_argument(
+        '--instance-type',
+        help='Instance type',
+        dest='instance_type',
+        default='n1-standard-1'
+    )
+    zone_kwargs = {
+        'help': 'GCP zone to operate in',
+        'dest': 'zone',
+        'default': parsed_config.get_option('gcp.zone'),
+        'required': False,
+    }
+    if zone_kwargs['default'] is None:
+        zone_kwargs['required'] = True
+    parser.add_argument(
+        '--zone',
+        **zone_kwargs
+    )
+    parser.add_argument(
+        '--no-delete-boot',
+        help='Do not delete boot disk when instance is deleted',
+        dest='delete_boot',
+        default=True,
+        action='store_false'
+    )
+    proj_kwargs = {
+        'help': 'GCP project name',
+        'dest': 'project',
+        'default': parsed_config.get_option('gcp.project'),
+        'required': False,
+    }
+    if proj_kwargs['default'] is None:
+        proj_kwargs['required'] = True
+    parser.add_argument(
+        '--project',
+        **proj_kwargs
+    )
+    parser.add_argument(
+        '--image-project',
+        metavar='NAME',
+        help='GCP project name which owns the image (e.g. centos-cloud)',
+        dest='image_project',
+        required=False
+    )
+    parser.add_argument(
+        '--network',
+        dest='network',
+        default=parsed_config.get_option('gcp.network', 'default'),
+        required=False
+    )
+    parser.add_argument(
+        '--gcp-tag',
+        dest='gcp_tags',
+        action='append',
+        metavar='VALUE',
+        help=(
+              'Set a GCP tag on the encrypted instance being launched. May be '
+              'specified multiple times.'
+        )
+    )
+    parser.add_argument(
+        '--encryptor-image',
+        dest='encryptor_image',
+        required=False
+    )
+
+    # Optional Image Name that's used to launch the metavisor instance. This
+    # argument is hidden because it's only used for development.
+    parser.add_argument(
+        '--encryptor-image-file',
+        dest='image_file',
+        required=False,
+        help=argparse.SUPPRESS
+    )
+    # Optional bucket name to retrieve the metavisor image from
+    # (prod, stage, shared, <custom>)
+    parser.add_argument(
+        '--encryptor-image-bucket',
+        help=argparse.SUPPRESS,
+        dest='bucket',
+        default='prod',
+        required=False
+    )
+    # Optional startup script. Hidden because it is only used for development
+    # and testing. It should be passed as a string containing a multi-line
+    # script (bash, python etc.)
+    parser.add_argument(
+        '--startup-script',
+        help=argparse.SUPPRESS,
+        dest='startup_script',
+        metavar='SCRIPT'
+    )
+    parser.add_argument(
+        '--subnetwork',
+        metavar='NAME',
+        help='Launch instance in this subnetwork',
+        dest='subnetwork',
+        default=parsed_config.get_option('gcp.subnetwork', None),
+        required=False
+    )
+    parser.add_argument(
+        '--guest-fqdn',
+        metavar='FQDN',
+        dest='guest_fqdn',
+        help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        '--no-cleanup',
+        dest='cleanup',
+        required=False,
+        default=True,
+        action='store_false',
+        help=argparse.SUPPRESS
+    )
+    # Optional (number of) SSD scratch disks because these can only be attached
+    # at instance launch time, compared to the other (persistent) disks
+    parser.add_argument(
+        '--ssd-scratch-disks',
+        metavar='N',
+        type=int,
+        default=0,
+        dest='ssd_scratch_disks',
+        help='Number of SSD scratch disks to be attached (max. 8)'
+    )

--- a/test_gce.py
+++ b/test_gce.py
@@ -9,6 +9,7 @@ from brkt_cli.gcp import encrypt_gcp_image
 from brkt_cli.gcp import gcp_service
 from brkt_cli.gcp import update_gcp_image
 from brkt_cli.gcp import share_logs
+from brkt_cli.gcp import wrap_gcp_image
 from brkt_cli.instance_config import InstanceConfig
 from brkt_cli.util import CRYPTO_GCM
 from brkt_cli.test_encryptor_service import (
@@ -467,3 +468,34 @@ class TestShareLogs(unittest.TestCase):
         gcp_svc = GCPService3()
         with self.assertRaises(util.BracketError):
             share_logs(self.values, gcp_svc)
+
+
+class TestWrappedGuest(unittest.TestCase):
+
+    def setUp(self):
+        util.SLEEP_ENABLED = False
+
+    def test_smoke(self):
+        gcp_svc = DummyGCPService()
+        wrapped_instance = wrap_gcp_image.wrap_guest_image(
+            gcp_svc=gcp_svc,
+            image_id=IGNORE_IMAGE,
+            encryptor_image='encryptor-image',
+            zone='us-central1-a',
+            metadata={}
+        )
+        self.assertIsNotNone(wrapped_instance)
+        self.assertEqual(len(gcp_svc.disks), 0)
+        self.assertEqual(len(gcp_svc.instances), 1)
+
+    def test_cleanup(self):
+        gcp_svc = DummyGCPService()
+        wrap_gcp_image.wrap_guest_image(
+            gcp_svc=gcp_svc,
+            image_id=IGNORE_IMAGE,
+            encryptor_image='encryptor-image',
+            zone='us-central1-a',
+            metadata={}
+        )
+        self.assertEqual(len(gcp_svc.disks), 0)
+        self.assertEqual(len(gcp_svc.instances), 1)


### PR DESCRIPTION
A Bracket wrapped instance consists of a Metavisor which wraps the
guest root volume without encrypting it. This greatly speeds up the
process of deploying Bracket instances, providing all the benefits
of the Bracket Metavisor, without an encrypted guest root volume.

A new `wrap-guest-image` command has been added to all the three supported
CSPs which given a guest "image", would wrap the guest image with
the Bracket metavisor image and launch an instance using the same.
The launched instance should show up on your Bracket Management
Console (UI) within a few minutes. All Bracket supported features
including disk encryption (of attached disks), network policy and
network segmentation would be supported by such an instance.

The recommendation is once the instance is launched, the user create
an image based off the running instance for subsequent use as part
of their Bracket infrastructure.