### PR TITLE
Consolidate AWS args

### DIFF
--- a/brkt_cli/aws/aws_args.py
+++ b/brkt_cli/aws/aws_args.py
@@ -11,6 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 
 
 def add_region(parser, parsed_config):
@@ -20,4 +21,95 @@ def add_region(parser, parsed_config):
         help='The AWS region metavisors will be launched into',
         dest='region',
         default=parsed_config.get_option('aws.region')
+    )
+
+
+def add_no_validate(parser):
+    parser.add_argument(
+        '--no-validate',
+        dest='validate',
+        action='store_false',
+        default=True,
+        help="Don't validate AMIs, snapshots, subnet, or security groups"
+    )
+
+
+def add_security_group(parser):
+    parser.add_argument(
+        '--security-group',
+        metavar='ID',
+        dest='security_group_ids',
+        action='append',
+        help=(
+            'Use this security group when running the encryptor instance. '
+            'May be specified multiple times.'
+        )
+    )
+
+
+def add_subnet(parser):
+    parser.add_argument(
+        '--subnet',
+        metavar='ID',
+        dest='subnet_id',
+        help='Launch instances in this subnet'
+    )
+
+
+def add_aws_tag(parser):
+    parser.add_argument(
+        '--aws-tag',
+        metavar='KEY=VALUE',
+        dest='aws_tags',
+        action='append',
+        help=(
+            'Set an AWS tag on resources created during encryption. '
+            'May be specified multiple times.'
+        )
+    )
+
+
+def add_key(parser, help=argparse.SUPPRESS):
+    # Optional EC2 SSH key pair name to use for launching the guest
+    # and encryptor instances.  This argument is hidden by default because
+    # it's only used for development.
+    parser.add_argument(
+        '--key',
+        metavar='NAME',
+        help=help,
+        dest='key_name'
+    )
+
+
+def add_encryptor_ami(parser):
+    # Optional AMI ID that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
+    parser.add_argument(
+        '--encryptor-ami',
+        metavar='ID',
+        dest='encryptor_ami',
+        help=argparse.SUPPRESS
+    )
+
+
+def add_retry_timeout(parser):
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    parser.add_argument(
+        '--retry-timeout',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=10.0
+    )
+
+
+def add_retry_initial_sleep_seconds(parser):
+    parser.add_argument(
+        '--retry-initial-sleep-seconds',
+        metavar='SECONDS',
+        type=float,
+        help=argparse.SUPPRESS,
+        default=0.25
     )

--- a/brkt_cli/aws/diag_args.py
+++ b/brkt_cli/aws/diag_args.py
@@ -38,40 +38,12 @@ def setup_diag_args(parser, parsed_config):
             'The instance type to use when running the diag instance'),
         default='m3.medium'
     )
-    parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate instances and snapshots"
-    )
+    aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    parser.add_argument(
-        '--security-group',
-        metavar='ID',
-        dest='security_group_ids',
-        action='append',
-        help=(
-            'Use this security group when running the encryptor instance. '
-            'May be specified multiple times.'
-        )
-    )
-    parser.add_argument(
-        '--subnet',
-        metavar='ID',
-        dest='subnet_id',
-        help='Launch instances in this subnet'
-    )
-    parser.add_argument(
-        '--aws-tag',
-        metavar='KEY=VALUE',
-        dest='aws_tags',
-        action='append',
-        help=(
-            'Custom tag for resources created during encryption. '
-            'May be specified multiple times.'
-        )
-    )
+    aws_args.add_security_group(parser)
+    aws_args.add_subnet(parser)
+    aws_args.add_aws_tag(parser)
+
     parser.add_argument(
         '-v',
         '--verbose',
@@ -79,13 +51,12 @@ def setup_diag_args(parser, parsed_config):
         action='store_true',
         help=argparse.SUPPRESS
     )
-    parser.add_argument(
-        '--key',
-        metavar='NAME',
-        help='ssh keypair name to be used to connect to diag instance.',
-        required=True,
-        dest='key_name'
+
+    aws_args.add_key(
+        parser,
+        help='ssh keypair name to be used to connect to diag instance.'
     )
+
     # Hide deprecated --tags argument
     parser.add_argument(
         '--tag',
@@ -94,20 +65,6 @@ def setup_diag_args(parser, parsed_config):
         action='append',
         help=argparse.SUPPRESS
     )
-    # Optional arguments for changing the behavior of our retry logic.  We
-    # use these options internally, to avoid intermittent AWS service failures
-    # when running concurrent encryption processes in integration tests.
-    parser.add_argument(
-        '--retry-timeout',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=10.0
-    )
-    parser.add_argument(
-        '--retry-initial-sleep-seconds',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=0.25
-    )
+
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -42,40 +42,11 @@ def setup_encrypt_ami_args(parser, parsed_config):
             'instance'),
         default='m3.medium'
     )
-    parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate AMIs, subnet, and security groups"
-    )
+    aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    parser.add_argument(
-        '--security-group',
-        metavar='ID',
-        dest='security_group_ids',
-        action='append',
-        help=(
-            'Use this security group when running the encryptor instance. '
-            'May be specified multiple times.'
-        )
-    )
-    parser.add_argument(
-        '--subnet',
-        metavar='ID',
-        dest='subnet_id',
-        help='Launch instances in this subnet'
-    )
-    parser.add_argument(
-        '--aws-tag',
-        metavar='KEY=VALUE',
-        dest='aws_tags',
-        action='append',
-        help=(
-            'Set an AWS tag on resources created during encryption. '
-            'May be specified multiple times.'
-        )
-    )
+    aws_args.add_security_group(parser)
+    aws_args.add_subnet(parser)
+    aws_args.add_aws_tag(parser)
     parser.add_argument(
         '-v',
         '--verbose',
@@ -91,40 +62,11 @@ def setup_encrypt_ami_args(parser, parsed_config):
         action='append',
         help=argparse.SUPPRESS
     )
-    # Optional AMI ID that's used to launch the encryptor instance.  This
-    # argument is hidden because it's only used for development.
-    parser.add_argument(
-        '--encryptor-ami',
-        metavar='ID',
-        dest='encryptor_ami',
-        help=argparse.SUPPRESS
-    )
-    # Optional EC2 SSH key pair name to use for launching the guest
-    # and encryptor instances.  This argument is hidden because it's only
-    # used for development.
-    parser.add_argument(
-        '--key',
-        metavar='NAME',
-        help=argparse.SUPPRESS,
-        dest='key_name'
-    )
-    # Optional arguments for changing the behavior of our retry logic.  We
-    # use these options internally, to avoid intermittent AWS service failures
-    # when running concurrent encryption processes in integration tests.
-    parser.add_argument(
-        '--retry-timeout',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=10.0
-    )
-    parser.add_argument(
-        '--retry-initial-sleep-seconds',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=0.25
-    )
+
+    aws_args.add_encryptor_ami(parser)
+    aws_args.add_key(parser)
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)
 
     parser.add_argument(
         '--save-encryptor-logs',

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -29,13 +29,7 @@ def setup_share_logs_args(parser, parsed_config):
         dest='instance_id',
         help='The instance with Bracket system logs to be shared'
     )
-    parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate instance has AMI with Bracket tags"
-    )
+    aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
     parser.add_argument(
         '-v',
@@ -53,20 +47,5 @@ def setup_share_logs_args(parser, parsed_config):
         default=164337164081,
         help=argparse.SUPPRESS
     )
-    # Optional arguments for changing the behavior of our retry logic.  We
-    # use these options internally, to avoid intermittent AWS service failures
-    # when running concurrent encryption processes in integration tests.
-    parser.add_argument(
-        '--retry-timeout',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=10.0
-    )
-    parser.add_argument(
-        '--retry-initial-sleep-seconds',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=0.25
-    )
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -48,49 +48,12 @@ def setup_update_encrypted_ami(parser, parsed_config):
             'instance. Default: m3.medium'),
         default='m3.medium'
     )
-    parser.add_argument(
-        '--no-validate',
-        dest='validate',
-        action='store_false',
-        default=True,
-        help="Don't validate AMIs, subnet, and security groups"
-    )
+    aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    parser.add_argument(
-        '--security-group',
-        metavar='ID',
-        dest='security_group_ids',
-        action='append',
-        help=(
-            'Use this security group when running the encryptor instance. '
-            'May be specified multiple times.'
-        )
-    )
-    parser.add_argument(
-        '--subnet',
-        metavar='ID',
-        dest='subnet_id',
-        help='Launch instances in this subnet'
-    )
-    # Optional EC2 SSH key pair name to use for launching the guest
-    # and encryptor instances.  This argument is hidden because it's only
-    # used for development.
-    parser.add_argument(
-        '--key',
-        metavar='KEY',
-        help=argparse.SUPPRESS,
-        dest='key_name'
-    )
-    parser.add_argument(
-        '--aws-tag',
-        metavar='KEY=VALUE',
-        dest='aws_tags',
-        action='append',
-        help=(
-            'Set an AWS tag on resources created during update. '
-            'May be specified multiple times.'
-        )
-    )
+    aws_args.add_security_group(parser)
+    aws_args.add_subnet(parser)
+    aws_args.add_key(parser)
+    aws_args.add_aws_tag(parser)
     parser.add_argument(
         '-v',
         '--verbose',
@@ -98,6 +61,7 @@ def setup_update_encrypted_ami(parser, parsed_config):
         action='store_true',
         help=argparse.SUPPRESS
     )
+
     # Hide deprecated --tag argument
     parser.add_argument(
         '--tag',
@@ -106,30 +70,7 @@ def setup_update_encrypted_ami(parser, parsed_config):
         action='append',
         help=argparse.SUPPRESS
     )
-    # Optional hidden argument for specifying the metavisor AMI.  This
-    # argument is hidden because it's only used for development.  It can
-    # also be used to override the default AMI if it's determined to be
-    # unstable.
-    parser.add_argument(
-        '--encryptor-ami',
-        metavar='ID',
-        help=argparse.SUPPRESS,
-        dest='encryptor_ami'
-    )
-    # Optional arguments for changing the behavior of our retry logic.  We
-    # use these options internally, to avoid intermittent AWS service failures
-    # when running concurrent encryption processes in integration tests.
-    parser.add_argument(
-        '--retry-timeout',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=10.0
-    )
-    parser.add_argument(
-        '--retry-initial-sleep-seconds',
-        metavar='SECONDS',
-        type=float,
-        help=argparse.SUPPRESS,
-        default=0.25
-    )
+
+    aws_args.add_encryptor_ami(parser)
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)


### PR DESCRIPTION
Consolidate the AWS command line options that appear in multiple
commands.  This ensures that naming and terminology is consistent across
commands.  Move the calls to add_argument() into functions in the
aws_args module and update callsites to call the new functions.