### PR TITLE
Remove OVF property if using ESX host for encrytion

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -22,6 +22,7 @@ import os
 import signal
 import hashlib
 import requests
+import xml.etree.ElementTree
 from functools import wraps
 from operator import attrgetter
 from threading import Thread
@@ -917,6 +918,15 @@ class VCenterService(BaseVCenterService):
         # Load the OVF file
         spec_params = vim.OvfManager.CreateImportSpecParams()
         ovfd = self.get_ovf_descriptor(ovf_path)
+        if self.is_esx_host():
+            # Remove property section
+            e = xml.etree.ElementTree.fromstring(ovfd)
+            for child in e:
+                if "VirtualSystem" in child.tag:
+                    for child_2 in child:
+                        if "ProductSection" in child_2.tag:
+                            child.remove(child_2)
+            ovfd = xml.etree.ElementTree.tostring(e)
         datacenter = self.__get_obj(content, [vim.Datacenter],
                                     self.datacenter_name)
         datastore = self.__get_obj(content, [vim.Datastore],


### PR DESCRIPTION
OVF containing OVF properties cannot be launched on ESX hosts.
So remove the property section from the OVF descriptor when
launching on ESX hosts.