### PR TITLE
Fixes to AWS `wrap-guest-image` command

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -474,7 +474,7 @@ class AWSSubcommand(Subcommand):
         aws_subparsers = aws_parser.add_subparsers(
             dest='aws_subcommand',
             # Hardcode the list, so that we don't expose internal subcommands.
-            metavar='{encrypt,update}'
+            metavar='{encrypt,update,wrap-guest-image}'
         )
 
         diag_parser = aws_subparsers.add_parser(

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -28,6 +28,23 @@ from brkt_cli.validation import ValidationError
 
 log = logging.getLogger(__name__)
 
+EBS_OPTIMIZED_INSTANCES = ['c1.xlarge', 'c3.xlarge', 'c3.2xlarge',
+                           'c3.4xlarge', 'c4.large', 'c4.xlarge',
+                           'c4.2xlarge', 'c4.4xlarge', 'c4.8xlarge',
+                           'd2.xlarge', 'd2.4xlarge', 'd2.8xlarge',
+                           'g2.2xlarge', 'i2.xlarge', 'i2.2xlarge',
+                           'i2.4xlarge', 'i2.8xlarge', 'i3.16xlarge',
+                           'm1.large', 'm1.xlarge', 'm1.2xlarge',
+                           'm1.4xlarge', 'm2.2xlarge', 'm2.4xlarge',
+                           'm3.xlarge', 'm3.2xlarge', 'm4.large',
+                           'm4.xlarge', 'm4.2xlarge', 'm4.4xlarge',
+                           'm4.10xlarge', 'm4.16xlarge', 'p2.xlarge',
+                           'p2.8xlarge', 'p2.16xlarge', 'r3.xlarge',
+                           'r3.2xlarge', 'r3.4large', 'r4.large',
+                           'r4.xlarge', 'r4.2xlarge', 'r4.4xlarge',
+                           'r4.8xlarge', 'r4.16xlarge', 'x1.16xlarge',
+                           'x1.32xlarge']
+
 
 class BaseAWSService(object):
     __metaclass__ = abc.ABCMeta

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -38,6 +38,7 @@ from boto.ec2.blockdevicemapping import (
 
 from brkt_cli.user_data import gzip_user_data
 from brkt_cli.instance_config import InstanceConfig
+from brkt_cli.aws.aws_service import EBS_OPTIMIZED_INSTANCES
 from brkt_cli.aws.encrypt_ami import wait_for_instance, clean_up
 from brkt_cli.util import (
     make_nonce,
@@ -134,6 +135,7 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
                 aws_svc, vpc_id=vpc_id)
             security_group_ids = [temp_sg_id]
 
+        ebs_optimized = instance_type in EBS_OPTIMIZED_INSTANCES
         instance = aws_svc.run_instance(
             mv_image.id,
             instance_type=instance_type,
@@ -141,6 +143,7 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
             user_data=compressed_user_data,
             placement=None,
             block_device_map=bdm,
+            ebs_optimized=ebs_optimized,
             subnet_id=subnet_id
         )
         aws_svc.create_tags(

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 from brkt_cli.aws import aws_args
 
 
@@ -41,6 +42,15 @@ def setup_wrap_image_args(parser, parsed_config):
     aws_args.add_subnet(parser)
     aws_args.add_aws_tag(parser)
     aws_args.add_key(parser)
+    # Hide optional sub-command level verbose argument. This should be
+    # removed once this option is removed at the sub-command level
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='aws_verbose',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
 
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.


### PR DESCRIPTION
 - Added the missing verbose parameter, which was causing the
   command to fail
 - Print the `wrap-guest-image` in the top-level help of supported
   commands
 - Added a means to identify EBS optimized instances and pass the
   flag accordingly