### PR TITLE
Add support for using launch tokens

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -229,8 +229,12 @@ def run_wrap_image(values, config, verbose=False):
             mv_image.name
         )
 
+    lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_METAVISOR_MODE, cli_config=config)
+        values,
+        mode=INSTANCE_METAVISOR_MODE,
+        cli_config=config,
+        launch_token=lt)
 
     instance_id = wrap_image.launch_wrapped_image(
         aws_svc=aws_svc,

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -95,7 +95,7 @@ def create_instance_security_group(aws_svc, vpc_id=None):
         log.error('Failed adding security group rule to %s: %s', sg.id, e)
         clean_up(aws_svc, security_group_ids=[sg.id])
 
-    aws_svc.create_tags(sg.id)
+    aws_svc.create_tags(sg.id, name=sg_name, description=sg_desc)
     return sg
 
 

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -481,8 +481,12 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
+        lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
-            values, mode=INSTANCE_METAVISOR_MODE, cli_config=parsed_config)
+            values,
+            mode=INSTANCE_METAVISOR_MODE,
+            cli_config=parsed_config,
+            launch_token=lt)
         instance_config.brkt_config['allow_unencrypted_guest'] = True
         user_data_str = vc_swc.create_userdata_str(instance_config,
             update=False, ssh_key_file=values.ssh_public_key_file)

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -188,8 +188,12 @@ def run_wrap_image(values, config):
 
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
+    lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
-        values, mode=INSTANCE_METAVISOR_MODE)
+        values,
+        mode=INSTANCE_METAVISOR_MODE,
+        cli_config=config,
+        launch_token=lt)
     if values.startup_script:
         extra_items = [{
             'key': 'startup-script',

--- a/brkt_cli/gcp/gcp_service.py
+++ b/brkt_cli/gcp/gcp_service.py
@@ -689,7 +689,7 @@ class GCPService(BaseGCPService):
             project=self.project,
             zone=zone,
             body=config)
-        retry(execute_gcp_api_call)(instance_req)
+        retry(execute_gcp_api_call, timeout=30.0)(instance_req)
         if tags:
             self.log.info("Setting instance tags %s", tags)
             self.set_tags(zone, name, tags)


### PR DESCRIPTION
Added support for launch tokens to keep the wrap image command on
par with the encrypt/update commands. Also fixed an issue with
security group creation in AWS as no valid tags were being passed
with the request.