### PR TITLE
Use the correct brkt-env

### DIFF
--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -140,7 +140,7 @@ class MakeTokenSubcommand(Subcommand):
                 raise ValidationError(msg % '--nbf')
 
             # New workflow: get a launch token from Yeti.
-            yeti = config.get_yeti_service(self.config)
+            yeti = config.get_yeti_service(self.config, values)
             tags = brkt_tags_from_name_value_list(values.brkt_tags)
             jwt_string = yeti.get_launch_token(tags=tags)
 

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -344,8 +344,11 @@ class CLIConfig(object):
             raise
 
 
-def _get_yeti_service(parsed_config):
-    _, env = parsed_config.get_current_env()
+def _get_yeti_service(parsed_config, values=None):
+    if values:
+        env = brkt_cli.brkt_env_from_values(values)
+    if not values or env is None:
+        _, env = parsed_config.get_current_env()
     root_url = 'https://%s:%d' % (
         env.public_api_host, env.public_api_port)
     token = (
@@ -355,13 +358,13 @@ def _get_yeti_service(parsed_config):
     return YetiService(root_url, token=token)
 
 
-def get_yeti_service(parsed_config):
+def get_yeti_service(parsed_config, values=None):
     """ Return a YetiService object based on the given CLIConfig.
 
     :raise ValidationError if the API token is not set in config, or if
     authentication with Yeti fails.
     """
-    y = _get_yeti_service(parsed_config)
+    y = _get_yeti_service(parsed_config, values)
     if not y.token:
         raise ValidationError(
             '$BRKT_API_TOKEN is not set. Run brkt auth to get an API token.')

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -235,7 +235,7 @@ def get_launch_token(values, cli_config):
     token = values.token
     if not token:
         log.debug('Getting launch token from Yeti')
-        y = config.get_yeti_service(cli_config)
+        y = config.get_yeti_service(cli_config, values)
         tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
         token = y.get_launch_token(tags=tags)
 


### PR DESCRIPTION
Use the user passed brkt-env if available, before defaulting to the
default environment (or the environment set in `brkt config`)