### PR TITLE
Prefer user-passed brkt-env, if available

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -208,6 +208,10 @@ def run_wrap_image(values, config, verbose=False):
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = config.get_current_env()
+
     aws_svc.connect(values.region, key_name=values.key_name)
 
     if values.validate:
@@ -229,7 +233,7 @@ def run_wrap_image(values, config, verbose=False):
             mv_image.name
         )
 
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_METAVISOR_MODE,
@@ -311,7 +315,7 @@ def run_encrypt(values, config, verbose=False):
                 crypto_policy, mv_image.name
             )
 
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_CREATOR_MODE,
@@ -418,7 +422,7 @@ def run_update(values, config, verbose=False):
         encrypted_image.id, encryptor_ami
     )
 
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_UPDATER_MODE,

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -344,8 +344,9 @@ class CLIConfig(object):
             raise
 
 
-def _get_yeti_service(parsed_config):
-    _, env = parsed_config.get_current_env()
+def _get_yeti_service(parsed_config, env=None):
+    if not env:
+        _, env = parsed_config.get_current_env()
     root_url = 'https://%s:%d' % (
         env.public_api_host, env.public_api_port)
     token = (
@@ -355,13 +356,13 @@ def _get_yeti_service(parsed_config):
     return YetiService(root_url, token=token)
 
 
-def get_yeti_service(parsed_config):
-    """ Return a YetiService object based on the given CLIConfig.
+def get_yeti_service(parsed_config, brkt_env):
+    """ Return a YetiService object based on the given brkt_env.
 
     :raise ValidationError if the API token is not set in config, or if
     authentication with Yeti fails.
     """
-    y = _get_yeti_service(parsed_config)
+    y = _get_yeti_service(parsed_config, brkt_env)
     if not y.token:
         raise ValidationError(
             '$BRKT_API_TOKEN is not set. Run brkt auth to get an API token.')

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -175,7 +175,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
-        lt = instance_config_args.get_launch_token(values, parsed_config)
+        lt = instance_config_args.get_launch_token(
+            values, parsed_config, brkt_env)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_CREATOR_MODE,
@@ -342,7 +343,8 @@ def run_update(values, parsed_config, log, use_esx=False):
             raise ValidationError("Template VM %s not found" %
                                   values.template_vm_name)
     try:
-        lt = instance_config_args.get_launch_token(values, parsed_config)
+        lt = instance_config_args.get_launch_token(
+            values, parsed_config, brkt_env)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_UPDATER_MODE,
@@ -481,7 +483,8 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
-        lt = instance_config_args.get_launch_token(values, parsed_config)
+        lt = instance_config_args.get_launch_token(
+            values, parsed_config, brkt_env)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_METAVISOR_MODE,

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -35,6 +35,10 @@ def run_encrypt(values, config):
     gcp_svc = gcp_service.GCPService(values.project, session_id, log)
     check_args(values, gcp_svc, config)
 
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = config.get_current_env()
+
     encrypted_image_name = gcp_service.get_image_name(
         values.encrypted_image_name, values.image)
     gcp_service.validate_image_name(encrypted_image_name)
@@ -52,7 +56,7 @@ def run_encrypt(values, config):
 
     log.info('Starting encryptor session %s', gcp_svc.get_session_id())
 
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     ic = instance_config_from_values(
         values,
         mode=INSTANCE_CREATOR_MODE,
@@ -89,6 +93,10 @@ def run_update(values, config):
     gcp_svc = gcp_service.GCPService(values.project, session_id, log)
     check_args(values, gcp_svc, config)
 
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = config.get_current_env()
+
     encrypted_image_name = gcp_service.get_image_name(
         values.encrypted_image_name, values.image)
     gcp_service.validate_image_name(encrypted_image_name)
@@ -104,7 +112,7 @@ def run_update(values, config):
 
     log.info('Starting updater session %s', gcp_svc.get_session_id())
 
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     ic = instance_config_from_values(
         values,
         mode=INSTANCE_UPDATER_MODE,
@@ -186,9 +194,13 @@ def run_wrap_image(values, config):
     session_id = util.make_nonce()
     gcp_svc = gcp_service.GCPService(values.project, session_id, log)
 
+    brkt_env = brkt_cli.brkt_env_from_values(values)
+    if brkt_env is None:
+        _, brkt_env = config.get_current_env()
+
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
-    lt = instance_config_args.get_launch_token(values, config)
+    lt = instance_config_args.get_launch_token(values, config, brkt_env)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_METAVISOR_MODE,
@@ -463,9 +475,6 @@ def check_args(values, gcp_svc, cli_config):
                 "Project provider either does not exist or you do not have access to it")
         if not gcp_svc.network_exists(values.network):
             raise ValidationError("Network provided does not exist")
-        brkt_env = brkt_cli.brkt_env_from_values(values)
-        if brkt_env is None:
-            _, brkt_env = cli_config.get_current_env()
 
 
 def validate_tags(tags):

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -226,7 +226,7 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
     return ic
 
 
-def get_launch_token(values, cli_config):
+def get_launch_token(values, cli_config, brkt_env=None):
     """ Return the launch token either from values.token or from Yeti, in that
     order.  Assume that the values.token and values.brkt_tags fields exist.
 
@@ -235,7 +235,7 @@ def get_launch_token(values, cli_config):
     token = values.token
     if not token:
         log.debug('Getting launch token from Yeti')
-        y = config.get_yeti_service(cli_config)
+        y = config.get_yeti_service(cli_config, brkt_env)
         tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
         token = y.get_launch_token(tags=tags)
 


### PR DESCRIPTION
With the recent changes to support brkt-tags, we always defauled
to the environment specified in the `brkt config` settings, ignoring
the user passed environment. This change picks the user specified
environment (if available) before defaulting the the `brkt config`
environment settings.