### PR TITLE
Refactor cert validation

### DIFF
--- a/brkt_cli/crypto/__init__.py
+++ b/brkt_cli/crypto/__init__.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 import logging
 
+from brkt_cli.validation import ValidationError
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography import x509
 
 SECP384R1 = ec.SECP384R1.name
 
@@ -95,3 +97,15 @@ def is_encrypted_key(pem):
 
 def is_private_key(pem):
     return 'PRIVATE KEY' in pem
+
+
+def validate_cert(cert_data):
+    """ Validate that the given string is a valid x509 certificate.
+
+    :return True if the cert is valid
+    :raise ValidationError if the string has an unexpected format
+    """
+    try:
+        x509.load_pem_x509_certificate(cert_data, default_backend())
+    except Exception as e:
+        raise ValidationError('Error validating CA cert: %s' % e)

--- a/brkt_cli/crypto/test_crypto.py
+++ b/brkt_cli/crypto/test_crypto.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import unittest
 
+from brkt_cli.validation import ValidationError
+
 import brkt_cli.crypto
 from cryptography.hazmat.backends.openssl import ec
 
@@ -44,6 +46,20 @@ U7wZaJcaN6RelbwRqnM7Qk9HqD5U9+lvS7g7vhP++AXhQretG7l9LYMZKxk3F/th
 pZPjFPt2fjlVkJnhl6NkhsTder9rJE3qKlP9JM8zwUQ=
 -----END EC PRIVATE KEY-----"""
 TEST_ENCRYPTED_PRIVATE_KEY_PASSWORD = 'test123'
+
+TEST_CERT = """
+-----BEGIN CERTIFICATE-----
+MIIBtTCCATugAwIBAgIQZBk/5Ngmtc0sE7XGFlF11TAKBggqhkjOPQQDAzAcMRow
+GAYDVQQKExFCcmFja2V0IENvbXB1dGluZzAeFw0xNjA1MTIwNDIwNDVaFw0xOTAy
+MDYwNDIwNDVaMBwxGjAYBgNVBAoTEUJyYWNrZXQgQ29tcHV0aW5nMHYwEAYHKoZI
+zj0CAQYFK4EEACIDYgAEAohisKTivkVGrLwSYMo17ttWnw2cBdK5ZPTun48r781/
+Z1DTxrLjnc7cCFMYWq01XOsjEhy+bIZNh/82E9i/GfqAfycitfuNO1OESZ8bdD17
+00SMs0y08DVB3kdTy9aNo0IwQDAOBgNVHQ8BAf8EBAMCAqwwHQYDVR0lBBYwFAYI
+KwYBBQUHAwEGCCsGAQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMD
+aAAwZQIxAO7hEZk6O74+Vz20OCiLit7HKOFhsGgvFtQfqzsz3LiOahpGAZaAphbu
+rjBoDDI8bgIwJWB24fgP6ueUOVbUQ9NaV/m3RHloIhQyY5LypcJALmnQVC7YPqwx
+lu+fKEaeTQLW
+-----END CERTIFICATE-----"""
 
 
 class TestCrypto(unittest.TestCase):
@@ -96,3 +112,8 @@ class TestCrypto(unittest.TestCase):
         self.assertTrue('BEGIN EC PRIVATE KEY' in pem)
         pem = crypto.get_private_key_pem('test123')
         self.assertTrue('Proc-Type: 4,ENCRYPTED' in pem)
+
+    def test_validate_cert(self):
+        brkt_cli.crypto.validate_cert(TEST_CERT)
+        with self.assertRaises(ValidationError):
+            brkt_cli.crypto.validate_cert('foobar')

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -15,9 +15,6 @@
 import argparse
 import logging
 
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-
 import brkt_cli
 from brkt_cli import (
     add_brkt_env_to_brkt_config,
@@ -27,6 +24,7 @@ from brkt_cli import (
 )
 from brkt_cli import argutil
 from brkt_cli import brkt_jwt
+import brkt_cli.crypto
 from brkt_cli.config import CLIConfig
 from brkt_cli.instance_config import (
     InstanceConfig,
@@ -210,10 +208,8 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
                 ca_cert_data = f.read()
         except IOError as e:
             raise ValidationError(e)
-        try:
-            x509.load_pem_x509_certificate(ca_cert_data, default_backend())
-        except Exception as e:
-            raise ValidationError('Error validating CA cert: %s' % e)
+
+        brkt_cli.crypto.validate_cert(ca_cert_data)
 
         domain = get_domain_from_brkt_env(brkt_env)
 


### PR DESCRIPTION
Move the cert validation code in instance_config_args to a new
validate_cert() function the crypto module.  When we make the
cryptography library optional, we'll want to only call it from
brkt_cli.crypto.