### PR TITLE
Check for user provided and auth tokens

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -108,8 +108,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
         _, brkt_env = parsed_config.get_current_env()
-    if not values.token:
-        raise ValidationError('Must provide a token')
+    # Verify we have a valid launch token
+    instance_config_args.get_launch_token(values, parsed_config)
 
     proxy = None
     if values.http_proxy:
@@ -295,8 +295,8 @@ def run_update(values, parsed_config, log, use_esx=False):
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
         _, brkt_env = parsed_config.get_current_env()
-    if not values.token:
-        raise ValidationError('Must provide a token')
+    # Verify we have a valid launch token
+    instance_config_args.get_launch_token(values, parsed_config)
 
     proxy = None
     if values.http_proxy:
@@ -415,8 +415,8 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
     brkt_env = brkt_cli.brkt_env_from_values(values)
     if brkt_env is None:
         _, brkt_env = parsed_config.get_current_env()
-    if not values.token:
-        raise ValidationError('Must provide a token')
+    # Verify we have a valid launch token
+    instance_config_args.get_launch_token(values, parsed_config)
 
     proxy = None
     if values.http_proxy:

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -454,8 +454,8 @@ def check_args(values, gcp_svc, cli_config):
         if values.bucket != 'prod':
             raise ValidationError(
                 "Please provide either an encryptor image or an image bucket")
-    if not values.token:
-        raise ValidationError('Must provide a token')
+    # Verify we have a valid launch token
+    instance_config_args.get_launch_token(values, cli_config)
 
     if values.validate:
         if not gcp_svc.project_exists(values.project):


### PR DESCRIPTION
ESX and GCP operations require a valid token. However the token
could either be user provided as a `--token` argument or a Bracket
generated one by setting the `BRKT_API_TOKEN` argument. Hence we
should validate atleast one of them is set for these operations.