### PR TITLE
Assume FreeBSD as the default encryptor image

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -221,14 +221,6 @@ def run_wrap_image(values, config, verbose=False):
         _validate(aws_svc, values, metavisor_ami)
         brkt_cli.validate_ntp_servers(values.ntp_servers)
 
-    mv_image = aws_svc.get_image(metavisor_ami)
-    # Raise error if it is not a FreeBSD Metavisor
-    if 'metavisor-' not in mv_image.name:
-        raise ValidationError(
-            'Unsupported Bracket image for wrapped guest: %s' %
-            mv_image.name
-        )
-
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -952,14 +952,6 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
 
         net_sriov_attr = aws_svc.get_instance_attribute(guest_instance.id,
                                                         "sriovNetSupport")
-        if (guest_image.virtualization_type == 'hvm' and
-            'metavisor' not in mv_image.name):
-            if net_sriov_attr.get("sriovNetSupport") == "simple":
-                log.warn("Guest Operating System license information will not "
-                         "be preserved because guest has sriovNetSupport "
-                         "enabled and metavisor does not support sriovNet")
-                legacy = True
-
         encryptor_instance, temp_sg_id = _run_encryptor_instance(
             aws_svc=aws_svc,
             encryptor_image_id=encryptor_ami,
@@ -989,8 +981,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
                 vol_type=vol_type, iops=iops, legacy=legacy,
                 save_encryptor_logs=save_encryptor_logs, status_port=status_port)
 
-        if 'metavisor' in mv_image.name and \
-            net_sriov_attr.get("sriovNetSupport") != "simple":
+        if net_sriov_attr.get("sriovNetSupport") != "simple":
             log.info('Enabling sriovNetSupport for guest instance %s',
                       guest_instance.id)
             try:

--- a/brkt_cli/gcp/wrap_gcp_image.py
+++ b/brkt_cli/gcp/wrap_gcp_image.py
@@ -16,14 +16,14 @@ def wrap_guest_image(gcp_svc, image_id, encryptor_image,
     try:
         keep_encryptor = True
         if not encryptor_image:
-            log.info('Retrieving encryptor image from GCE bucket')
+            log.info('Retrieving encryptor image from GCP bucket')
             try:
                 encryptor_image = gcp_svc.get_latest_encryptor_image(zone,
                     image_bucket, image_file=image_file)
                 keep_encryptor = False
             except errors.HttpError as e:
                 encryptor_image = None
-                log.exception('GCE API call to retrieve image failed')
+                log.exception('GCP API call to retrieve image failed')
                 return
 
         if not instance_name:
@@ -57,7 +57,7 @@ def wrap_guest_image(gcp_svc, image_id, encryptor_image,
         log.info("Instance %s (%s) launched successfully" % (instance_name,
             gcp_svc.get_instance_ip(instance_name, zone)))
     except errors.HttpError as e:
-        log.exception('GCE API request failed: {}'.format(e.message))
+        log.exception('GCP API request failed: {}'.format(e.message))
     finally:
         if not cleanup:
             log.info("Not cleaning up")


### PR DESCRIPTION
Removed all checks for verifying the Metavisor version/type as
going forward FreeBSD would be the default encryptor image used.
Also fixed log messages to refer to GCP, instead of GCE.