### PR TITLE
Minor README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ the encryption process.
 and generating a JSON Web Token (JWT) that is used to authenticate with
 The Bracket Computing service.
 
-The latest release of **brkt-cli** is [1.0.8]
-(https://github.com/brkt/brkt-cli/releases/tag/brkt-cli-1.0.8).
+The latest release of **brkt-cli** is [1.0.8](https://github.com/brkt/brkt-cli/releases/tag/brkt-cli-1.0.8).
 
 ## Requirements
 
@@ -97,10 +96,5 @@ files into the container.  Some examples:
 ```
 $ docker run --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-brkt encrypt-ami --region us-west-2 ami-9025e1f0
-```
-
-```
-$ docker run --rm -v ~/keys:/keys brkt make-token --signing-key /keys/secret.pem
-eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImU2MTNhYzI0YzRkN2ExY...
+brkt aws encrypt --region us-west-2 ami-9025e1f0
 ```


### PR DESCRIPTION
Fix the formatting of the link to the latest release.  Update Docker
example to use the new command line syntax.