### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 **brkt-cli** is a command-line interface to the
 [Bracket Computing](http://www.brkt.com) service. It produces an
 encrypted version of an operating system image that runs on
-[Amazon Web Services](aws.md) (AWS), [Google Compute Engine](gce.md)
-(GCE), or [VMware ESX](esx.md). The resulting encrypted image can then
+[Amazon Web Services](aws.md) (AWS), [Google Compute Platform](gce.md)
+(GCP), or [VMware ESX](esx.md). The resulting encrypted image can then
 be launched in the same manner as the original.  Please see the
 links above for cloud-provider specific details and an overview of
 the encryption process.
@@ -71,7 +71,7 @@ $ export BRKT_API_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2V...
 
 ## Encrypting an image
 
-See the [AWS](aws.md), [GCE](gce.md) or [VMware](esx.md) pages for
+See the [AWS](aws.md), [GCP](gce.md) or [VMware](esx.md) pages for
 platform-specific documentation on encrypting and updating an image.
 
 ## <a name="docker"/>Running in a Docker container

--- a/esx.md
+++ b/esx.md
@@ -5,13 +5,13 @@ The `vmware` subcommand provides all VMware related operations for encrypting an
 ```
 $ brkt vmware --help
 usage: brkt vmware [-h]
-                   {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,rescue-metavisor}
-                   ...
+                   {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,wrap-with-vcenter,
+                   wrap-with-esx-host} ...
 
 VMware operations
 
 positional arguments:
-  {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,rescue-metavisor}
+  {encrypt-with-vcenter,encrypt-with-esx-host,update-with-vcenter,update-with-esx-host,wrap-with-vcenter, wrap-with-esx-host}
     encrypt-with-vcenter
                         Encrypt a VMDK using vCenter
     encrypt-with-esx-host
@@ -20,7 +20,10 @@ positional arguments:
                         Update an encrypted VMDK using vCenter
     update-with-esx-host
                         Update an encrypted VMDK on an ESX host
-    rescue-metavisor    Upload Metavisor VM cores to URL
+    wrap-with-vcenter   Launch guest image wrapped with Bracket Metavsor using
+                        vCenter
+    wrap-with-esx-host  Launch guest image wrapped with Bracket Metavsor on
+                        ESX host
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -86,7 +89,8 @@ usage: brkt vmware encrypt-with-vcenter [-h] --vcenter-host DNS_NAME
                                         [--disk-type TYPE]
                                         [--ntp-server DNS_NAME]
                                         [--proxy HOST:PORT | --proxy-config-file PATH]
-                                        [--status-port PORT] [--token TOKEN]
+                                        [--status-port PORT]
+                                        [--token TOKEN | --brkt-tag NAME=VALUE]
                                         VMDK-NAME
 
 Create an encrypted VMDK from an existing VMDK using vCenter
@@ -95,6 +99,11 @@ positional arguments:
   VMDK-NAME             The Guest VMDK that will be encrypted
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --console-file-name NAME
                         File name to dump console messages to (default: None)
   --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
@@ -169,11 +178,17 @@ usage: brkt vmware update-with-vcenter [-h] --vcenter-host DNS_NAME
                                        [--use-esx-host]
                                        [--ntp-server DNS_NAME]
                                        [--proxy HOST:PORT | --proxy-config-file PATH]
-                                       [--status-port PORT] [--token TOKEN]
+                                       [--status-port PORT]
+                                       [--token TOKEN --brkt-tag NAME=VALUE]
 
 Update an encrypted VMDK with the latest Metavisor using vCenter
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
   --encrypted-image-directory NAME
                         Directory to fetch the encrypted OVF/OVA image
@@ -224,6 +239,78 @@ optional arguments:
   --vcenter-port N      Port Number of the vCenter Server (default: 443)
   -h, --help            show this help message and exit
 ```
+
+The `vmware wrap-with-vcenter` subcommand creates an encrypted VM with the latest
+version of the Metavisor wrapping the unencrypted guest root disk using vCenter.
+
+```
+usage: brkt vmware wrap-with-vcenter [-h] --vcenter-host DNS_NAME
+                                     [--vcenter-port N]
+                                     [--vcenter-datacenter NAME]
+                                     [--vcenter-datastore NAME]
+                                     [--vcenter-cluster NAME]
+                                     [--vcenter-network-name NAME]
+                                     [--cpu-count N] [--memory GB]
+                                     [--vm-name NAME] [--no-verify-cert]
+                                     [--ovf-source-directory PATH]
+                                     [--metavisor-ovf-image-name NAME]
+                                     [--disk-type TYPE]
+                                     [--ntp-server DNS_NAME]
+                                     [--proxy HOST:PORT | --proxy-config-file PATH]
+                                     [--status-port PORT]
+                                     [--token TOKEN | --brkt-tag NAME=VALUE]
+                                     VMDK-NAME
+
+Launch guest image wrapped with Bracket Metavsor using vCenter
+
+positional arguments:
+  VMDK-NAME             The Guest VMDK path (in the datastore) that will be
+                        encrypted
+
+optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
+  --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
+  --disk-type TYPE      thin/thick-lazy-zeroed/thick-eager-zeroed (default:
+                        thin) (default: thin)
+  --memory GB           Memory to assign to Encryptor VM (default: 32)
+  --metavisor-ovf-image-name NAME
+                        Metavisor OVF name (default: None)
+  --no-verify-cert      Don't validate vCenter certificate
+  --ntp-server DNS_NAME
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --ovf-source-directory PATH
+                        Local path to the Metavisor OVF directory (default:
+                        None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --vcenter-cluster NAME
+                        vCenter cluster to use (default: None)
+  --vcenter-datacenter NAME
+                        vCenter Datacenter to use (default: None)
+  --vcenter-datastore NAME
+                        vCenter datastore to use (default: None)
+  --vcenter-host DNS_NAME
+                        IP address/DNS Name of the vCenter host (default:
+                        None)
+  --vcenter-network-name NAME
+                        vCenter network name to use (default: VM Network)
+  --vcenter-port N      Port Number of the vCenter Server (default: 443)
+  --vm-name NAME        Specify the name of the launched VM
+  -h, --help            show this help message and exit
 
 ## Configuration
 
@@ -299,6 +386,22 @@ encrypt-vmdk-test
 When the process completes, the VMDK specified in the `--template-vm-name` argument
 is updated with the latest Metavisor.
 
+## Wrap a guest VMDK with the Bracket Metavisor
+
+Run **brkt vmware wrap-with-vcenter** to wrap an guest VMDK with the latest
+Metavisor using vCenter:
+
+```
+$ brkt vmware wrap-with-vcenter --token <token> --vcenter-host <vcenter_host> --vm-name wrap-vmdk-test  --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name> centos66/centos66.vmdk
+02:58:07 Fetching Metavisor OVF from S3
+03:00:17 Launching VM from OVF metavisor-1-0-100-gcaf72844f.ovf
+/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+InsecureRequestWarning)
+03:09:21 [ssd-218-datastore] centos66.vmdk disk added to VM wrap-vmdk-test
+03:10:03 VM ip address is 10.9.1.90
+03:10:03 vmware returned 0
+```
+
 # Encrypting images using an ESX host
 
 The `vmware encrypt-with-esx-host` subcommand performs the following steps to create
@@ -336,7 +439,8 @@ usage: brkt vmware encrypt-with-esx-host [-h] --esx-host DNS_NAME
                                          [--disk-type TYPE]
                                          [--ntp-server DNS_NAME]
                                          [--proxy HOST:PORT | --proxy-config-file PATH]
-                                         [--status-port PORT] [--token TOKEN]
+                                         [--status-port PORT]
+                                         [--token TOKEN | --brkt-tag NAME=VALUE]
                                          VMDK-NAME
 
 Create an encrypted VMDK from an existing VMDK on an ESX host
@@ -345,6 +449,11 @@ positional arguments:
   VMDK-NAME             The Guest VMDK that will be encrypted
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --console-file-name NAME
                         File name to dump console messages to (default: None)
   --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
@@ -407,7 +516,8 @@ usage: brkt vmware update-with-esx-host [-h] --esx-host DNS_NAME
                                         [--disk-type TYPE]
                                         [--ntp-server DNS_NAME]
                                         [--proxy HOST:PORT | --proxy-config-file PATH]
-                                        [--status-port PORT] [--token TOKEN]
+                                        [--status-port PORT]
+                                        [--token TOKEN | --brkt-tag NAME=VALUE]
                                         VMDK-NAME
 
 Update an encrypted VMDK with the latest Metavisor on an ESX host
@@ -416,6 +526,11 @@ positional arguments:
   VMDK-NAME             The Guest VMDK that will be encrypted
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --console-file-name NAME
                         File name to dump console messages to (default: None)
   --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
@@ -456,6 +571,67 @@ optional arguments:
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)
+  -h, --help            show this help message and exit
+```
+
+The `vmware wrap-with-esx-host` subcommand creates an encrypted VM with the latest
+version of the Metavisor wrapping the unencrypted guest root disk on an ESX host.
+
+```
+usage: brkt vmware wrap-with-esx-host [-h] --esx-host DNS_NAME [--esx-port N]
+                                      [--esx-datastore NAME]
+                                      [--esx-network-name NAME]
+                                      [--cpu-count N] [--memory GB]
+                                      [--vm-name NAME]
+                                      [--ovf-source-directory PATH]
+                                      [--metavisor-ovf-image-name NAME]
+                                      [--disk-type TYPE]
+                                      [--ntp-server DNS_NAME]
+                                      [--proxy HOST:PORT | --proxy-config-file PATH]
+                                      [--status-port PORT]
+                                      [--token TOKEN | --brkt-tag NAME=VALUE]
+                                      VMDK-NAME
+
+Launch guest image wrapped with Bracket Metavsor on ESX host
+
+positional arguments:
+  VMDK-NAME             The Guest VMDK path (in the datastore) that will be
+                        encrypted
+
+optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
+  --cpu-count N         Number of CPUs to assign to Encryptor VM (default: 8)
+  --disk-type TYPE      thin/thick-lazy-zeroed/thick-eager-zeroed (default:
+                        thin) (default: thin)
+  --esx-datastore NAME  ESX datastore to use (default: None)
+  --esx-host DNS_NAME   IP address/DNS Name of the ESX host (default: None)
+  --esx-network-name NAME
+                        ESX network name to use (default: VM Network)
+  --esx-port N          Port Number of the ESX Server (default: 443)
+  --memory GB           Memory to assign to Encryptor VM (default: 32)
+  --metavisor-ovf-image-name NAME
+                        Metavisor OVF name (default: None)
+  --ntp-server DNS_NAME
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --ovf-source-directory PATH
+                        Local path to the OVF directory (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --status-port PORT    Specify the port to receive http status of encryptor.
+                        Any port in range 1-65535 can be used except for port
+                        81. (default: 80)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --vm-name NAME        Specify the name of the launched VM
   -h, --help            show this help message and exit
 ```
 
@@ -531,3 +707,21 @@ $ brkt vmware encrypt-with-esx-host --token <token> --esx-host <HOST> --esx-data
 ```
 
 When the command completes, it creates an OVF file identified by the `--encrypted-image-name` argument under the path specified by the `--encrypted-image-directory` argument. The same command can be used to create an OVA by using the `--create-ova` argument instead of `--create-ovf`.
+
+## Creating an encrypted instance on an OVF host
+
+Run **brkt vmware wrap-with-esx-host** to launch an encrypted instance which wraps
+the unencrypted guest image (VMDK)
+
+```
+$ brkt vmware wrap-with-esx-host --token <token> --esx-host <HOST> --esx-datastore <datastore> --vm-name test-wrap-image centos66/centos66.vmdk
+22:56:47 Fetching Metavisor OVF from S3
+22:57:03 Launching VM from OVF metavisor-1-0-80-g14a5ec1a0.ovf
+/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+InsecureRequestWarning)
+22:57:21 [ssd-218-datastore] centos66.vmdk disk added to VM test-wrap-image
+22:57:52 VM ip address is 10.9.1.141
+22:57:52 vmware returned 0
+```
+
+When the command completes, it creates a running encrypted VM with the (optional) specified name and also prints its IP address.

--- a/gce.md
+++ b/gce.md
@@ -1,26 +1,28 @@
-# GCE operations
+# GCP operations
 
-The `gce` subcommand provides all GCE related operations for encrypting, updating and launching images.
+The `gcp` subcommand provides all GCP related operations for encrypting, updating and launching images.
 
 ```
-$ brkt gce --help
-usage: brkt gce [-h] {encrypt,update,launch} ...
+$ brkt gcp --help
+usage: brkt gcp [-h] {encrypt,update,launch,wrap-guest-image,share-logs} ...
 
-GCE operations
+GCP operations
 
 positional arguments:
-  {encrypt,update,launch}
-    encrypt             Encrypt a GCE image
-    update              Update an encrypted GCE image
-    launch              Launch a GCE image
+  {encrypt,update,launch,wrap-guest-image,share-logs}
+    encrypt             Encrypt a GCP image
+    update              Update an encrypted GCP image
+    launch              Launch a GCP image
+    wrap-guest-image    Launch guest image wrapped with Bracket Metavisor
+    share-logs          Upload logs file to google bucket
 
 optional arguments:
   -h, --help            show this help message and exit
 ```
 
-# Encrypting images in GCE
+# Encrypting images in GCP
 
-The `gce encrypt` subcommand performs the following steps to create an
+The `gcp encrypt` subcommand performs the following steps to create an
 encrypted image:
 
 1. Get the latest Metavisor image named `latest.image.tar.gz` from 
@@ -52,43 +54,47 @@ order to do this, port 443 must be accessible on the following hosts:
   * 52.88.55.6
 * brkt-cli talks to `api.mgmt.brkt.com` on port 443.
 
-# Encrypting a GCE image
+# Encrypting a GCP image
 
-Run **gce encrypt** to create an encrypted image based on an existing
+Run **gcp encrypt** to create an encrypted image based on an existing
 image.
 
 ```
-$ brkt gce encrypt --help
-usage: brkt gce encrypt [-h] [--encrypted-image-name NAME] --zone ZONE
+$ brkt gcp encrypt --help
+usage: brkt gcp encrypt [-h] [--encrypted-image-name NAME] --zone ZONE
                         [--no-validate] --project PROJECT
-                        [--image-project NAME]
-                        [--encryptor-image ENCRYPTOR_IMAGE]
-                        [--network NETWORK] [--subnetwork SUBNETWORK]
-                        [--gce-tag VALUE] [--ntp-server DNS_NAME]
+                        [--image-project NAME] [--network NETWORK]
+                        [--subnetwork SUBNETWORK] [--gcp-tag VALUE]
+                        [--ntp-server DNS_NAME]
                         [--proxy HOST:PORT | --proxy-config-file PATH]
-                        [--status-port PORT] [--token TOKEN]
+                        [--status-port PORT]
+                        [--token TOKEN | --brkt-tag NAME=VALUE]
                         ID
 
-Create an encrypted GCE image from an existing image
+Create an encrypted GCP image from an existing image
 
 positional arguments:
   ID                    The image that will be encrypted
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --encrypted-image-name NAME
                         Specify the name of the generated encrypted image
                         (default: None)
-  --encryptor-image ENCRYPTOR_IMAGE
-  --gce-tag             Set a GCE tag on the encryptor instance. May be
+  --gcp-tag             Set a GCP tag on the encryptor instance. May be
                         specified multiple times.
-  --image-project NAME  GCE project name which owns the image (e.g. centos-
+  --image-project NAME  GCP project name which owns the image (e.g. centos-
                         cloud) (default: None)
   --network NETWORK
   --no-validate         Don't validate images or token (default: True)
   --ntp-server DNS_NAME
                         Optional NTP server to sync Metavisor clock. May be
                         specified multiple times. (default: None)
-  --project PROJECT     GCE project name (default: None)
+  --project PROJECT     GCP project name (default: None)
   --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
                         specified multiple times. (default: None)
   --proxy-config-file PATH
@@ -101,42 +107,46 @@ optional arguments:
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)
-  --zone ZONE           GCE zone to operate in (default: None)
+  --zone ZONE           GCP zone to operate in (default: None)
   -h, --help            show this help message and exit
 ```
 
-  The `gce update` subcommand updates an encrypted
+  The `gcp update` subcommand updates an encrypted
 image with the latest version of the Metavisor code.
 
 ```
-$ brkt gce update --help
-usage: brkt gce update [-h] [--encrypted-image-name NAME] --zone ZONE
-                       --project PROJECT [--no-validate]
-                       [--encryptor-image ENCRYPTOR_IMAGE] [--network NETWORK]
-                       [--subnetwork SUBNETWORK] [--gce-tag VALUE]
+$ brkt gcp update --help
+usage: brkt gcp update [-h] [--encrypted-image-name NAME] --zone ZONE
+                       --project PROJECT [--no-validate] [--network NETWORK]
+                       [--subnetwork SUBNETWORK] [--gcp-tag VALUE]
                        [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
-                       [--status-port PORT] [--token TOKEN]
+                       [--status-port PORT]
+                       [--token TOKEN | --brkt-tag NAME=VALUE]
                        ID
 
-Update an encrypted GCE image with the latest Metavisor release
+Update an encrypted GCP image with the latest Metavisor release
 
 positional arguments:
   ID                    The image that will be updated
 
 optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.].
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
   --encrypted-image-name NAME
                         Specify the name of the generated encrypted Image
                         (default: None)
-  --encryptor-image ENCRYPTOR_IMAGE
-  --gce-tag             Set a GCE tag on the updater instance. May be
+  --gcp-tag             Set a GCP tag on the updater instance. May be
                         specified multiple times.
   --network NETWORK
   --no-validate         Don't validate images or token (default: True)
   --ntp-server DNS Name
                         Optional NTP server to sync Metavisor clock. May be
                         specified multiple times. (default: None)
-  --project PROJECT     GCE project name (default: None)
+  --project PROJECT     GCP project name (default: None)
   --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
                         specified multiple times. (default: None)
   --proxy-config-file PATH
@@ -149,31 +159,31 @@ optional arguments:
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)
-  --zone ZONE           GCE zone to operate in (default: us-central1-a)
+  --zone ZONE           GCP zone to operate in (default: us-central1-a)
   -h, --help            show this help message and exit
 ```
 
-The `gce launch` subcommand launches an encrypted GCE image.
+The `gcp launch` subcommand launches an encrypted GCP image.
 
 ```
-$ brkt gce launch --help
-usage: brkt gce launch [-h] [--instance-name NAME]
+$ brkt gcp launch --help
+usage: brkt gcp launch [-h] [--instance-name NAME]
                        [--instance-type INSTANCE_TYPE] [--zone ZONE]
                        [--no-delete-boot] --project PROJECT
-                       [--network NETWORK] [--gce-tag VALUE]
+                       [--network NETWORK] [--gcp-tag VALUE]
                        [--subnetwork NAME] [--ssd-scracth-disks N]
                        [--ntp-server DNS_NAME]
                        [--proxy HOST:PORT | --proxy-config-file PATH]
                        [--token TOKEN]
                        ID
 
-Launch a GCE image
+Launch a GCP image
 
 positional arguments:
   ID                    The image that will be launched
 
 optional arguments:
-  --gce-tag             Set a GCE tag on the encrypted instance being
+  --gcp-tag             Set a GCP tag on the encrypted instance being
                         launched. May be specified multiple times.
   --instance-name NAME  Name of the instance
   --instance-type INSTANCE_TYPE
@@ -184,7 +194,7 @@ optional arguments:
   --ntp-server DNS_NAME
                         Optional NTP server to sync Metavisor clock. May be
                         specified multiple times. (default: None)
-  --project PROJECT     GCE project name (default: None)
+  --project PROJECT     GCP project name (default: None)
   --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
                         specified multiple times. (default: None)
   --proxy-config-file PATH
@@ -197,22 +207,80 @@ optional arguments:
   --token TOKEN         Token that the encrypted instance will use to
                         authenticate with the Bracket service. Use the make-
                         token subcommand to generate a token. (default: None)
-  --zone ZONE           GCE zone to operate in (default: us-central1-a)
+  --zone ZONE           GCP zone to operate in (default: us-central1-a)
+  -h, --help            show this help message and exit
+```
+
+The `gcp wrap-guest-image` subcommand launches an encrypted GCP instance
+without the guest root volume being encrypted.
+
+```
+$ brkt gcp launch --help
+usage: brkt gcp launch [-h] [--instance-name NAME]
+                       [--instance-type INSTANCE_TYPE] --zone ZONE
+                       [--no-delete-boot] --project PROJECT
+                       [--image-project NAME] [--network NETWORK]
+                       [--gcp-tag VALUE] [--subnetwork NAME]
+                       [--ssd-scracth-disks N]
+                       [--ntp-server DNS_NAME]
+                       [--proxy HOST:PORT | --proxy-config-file PATH]
+                       [--token TOKEN | --brkt-tag NAME=VALUE]
+                       ID
+
+Launch guest image wrapped with Bracket Metavisor
+
+positional arguments:
+  ID                    The image that will be wrapped with the Bracket
+                        Metavisor
+
+optional arguments:
+  --brkt-tag NAME=VALUE
+                        Bracket tag which will be embedded in the JWT as a
+                        claim. All characters must be alphanumeric or [-_.]
+                        The tag name cannot be a JWT registered claim name
+                        (see RFC 7519).
+  --gcp-tag             Set a GCP tag on the encrypted instance being
+                        launched. May be specified multiple times.
+  --image-project NAME  GCP project name which owns the image (e.g. centos-
+                        cloud)
+  --instance-name NAME  Name of the instance
+  --instance-type INSTANCE_TYPE
+                        Instance type (default: n1-standard-1)
+  --network NETWORK
+  --no-delete-boot      Delete boot disk when instance is deleted (default:
+                        False)
+  --ntp-server DNS_NAME
+                        Optional NTP server to sync Metavisor clock. May be
+                        specified multiple times. (default: None)
+  --project PROJECT     GCP project name (default: None)
+  --proxy HOST:PORT     Use this HTTPS proxy during encryption. May be
+                        specified multiple times. (default: None)
+  --proxy-config-file PATH
+                        Path to proxy.yaml file that will be used during
+                        encryption (default: None)
+  --ssd-scratch-disks N
+                        Number of SSD scratch disks to be attached (max. 8)
+                        (default: 0)
+  --subnetwork NAME     Launch instance in this subnetwork (default: None)
+  --token TOKEN         Token that the encrypted instance will use to
+                        authenticate with the Bracket service. Use the make-
+                        token subcommand to generate a token. (default: None)
+  --zone ZONE           GCP zone to operate in (default: us-central1-a)
   -h, --help            show this help message and exit
 ```
 
 ## Configuration
 
-Before running the GCE commands in **brkt-cli**, you will  need to install
+Before running the GCP commands in **brkt-cli**, you will  need to install
 [gcloud](https://cloud.google.com/sdk/gcloud/) and configure it to work 
 with your Google account and GCP project. Make sure that your Google 
 account has `Editor` permissions within the selected Google project.
 
 You can use the `--network` option to launch the encryptor instance in
-a specific GCE network. Additionally if you created this network using
+a specific GCP network. Additionally if you created this network using
 custom subnetworks, then you **must** specify the corresponding subnetwork
 using the `--subnetwork` option. In the absence of the `--network` option,
-the encryptor is launched in the `default` GCE network.
+the encryptor is launched in the `default` GCP network.
 
 You will also need to add a firewall rule that allows inbound access
 to the Encryptor or Updater instance on port **80**, or the port that
@@ -221,10 +289,10 @@ you specify with the **--status-port** option in the default network
 
 ## Encrypting an image
 
-Run **gce encrypt** to encrypt an image:
+Run **gcp encrypt** to encrypt an image:
 
 ```
-$ brkt gce encrypt --zone us-central1-a --project brkt-dev --token <token> --image-project ubuntu-os-cloud ubuntu-1404-trusty-v20160627
+$ brkt gcp encrypt --zone us-central1-a --project brkt-dev --token <token> --image-project ubuntu-os-cloud ubuntu-1404-trusty-v20160627
 ...
 14:30:23 Starting encryptor session 59e3b3a7
 ...
@@ -247,11 +315,11 @@ ubuntu-1404-trusty-v20160627-encrypted-a1fe1069
 
 ## Updating an image
 
-Run **gce update** to update an encrypted image with the latest
+Run **gcp update** to update an encrypted image with the latest
 Metavisor code:
 
 ```
-$ brkt gce update --zone us-central1-a --project brkt-dev --token <token> ubuntu-1404-trusty-v20160627-encrypted-ee521b31
+$ brkt gcp update --zone us-central1-a --project brkt-dev --token <token> ubuntu-1404-trusty-v20160627-encrypted-ee521b31
 ...
 15:50:04 Starting updater session 80985e58
 ...
@@ -269,10 +337,10 @@ ubuntu-1404-trusty-v20160627-encrypted-63e57e6e
 
 ## Launching an image
 
-Run **gce launch** to launch an encrypted GCE image
+Run **gcp launch** to launch an encrypted GCP image
 
 ```
-$ brkt gce launch --instance-name brkt-test-instance --project <project> --token <token> --zone us-central1-c centos-6-v20160921-encrypted-30fccdeb
+$ brkt gcp launch --instance-name brkt-test-instance --project <project> --token <token> --zone us-central1-c centos-6-v20160921-encrypted-30fccdeb
 18:13:54 Creating guest root disk from snapshot
 18:13:54 Attempting refresh to obtain initial access_token
 18:13:54 Refreshing access_token
@@ -290,4 +358,34 @@ $ brkt gce launch --instance-name brkt-test-instance --project <project> --token
 18:15:59 Waiting for brkt-test-instance to become ready
 18:16:10 Instance brkt-test-instance (104.198.44.8) launched successfully
 brkt-test-instance
+```
+
+## Launching a wrapped instance
+
+Run **gcp wrap-guest-image** to launch a guest image wrapped with the Bracket
+Metavisor
+
+```
+$ brkt gcp wrap-guest-image --project <project> --token <token> --zone us-central1-c centos-6-v20170327
+19:44:47 Retrieving encryptor image from GCP bucket
+19:44:47 Attempting refresh to obtain initial access_token
+19:44:47 Refreshing access_token
+19:46:40 Waiting for guest root disk to become ready
+19:46:40 Disk detach successful
+19:46:40 Launching wrapped guest image
+19:46:46 Waiting for brkt-guest-e37b3894 to become ready
+19:46:51 Waiting for brkt-guest-e37b3894 to become ready
+19:46:57 Waiting for brkt-guest-e37b3894 to become ready
+19:47:02 Waiting for brkt-guest-e37b3894 to become ready
+19:47:07 Waiting for brkt-guest-e37b3894 to become ready
+19:47:15 Waiting for brkt-guest-e37b3894 to become ready
+19:47:20 Waiting for brkt-guest-e37b3894 to become ready
+19:47:25 Waiting for brkt-guest-e37b3894 to become ready
+19:47:31 Waiting for brkt-guest-e37b3894 to become ready
+19:47:36 Waiting for brkt-guest-e37b3894 to become ready
+19:47:42 Waiting for brkt-guest-e37b3894 to become ready
+19:47:48 Waiting for brkt-guest-e37b3894 to become ready
+19:48:00 Instance brkt-guest-e37b3894 (35.184.91.87) launched successfully
+19:48:00 Deleting encryptor image encryptor-e37b3894
+brkt-guest-e37b3894
 ```


### PR DESCRIPTION
Updated AWS, GCP and ESX documentation to reflect the current usage
and arguments. Main changes include:
  * Changed GCE to GCP
  * Added brkt-tag argument to all commands
  * Added documentation for the `wrap` command for each of the CSPs
