### PR TITLE
Normalize user specified OVF

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -201,7 +201,9 @@ def encrypt_from_local_ovf(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
             return
         # Launch OVF
         log.info("Launching VM from local OVF")
-        ovf_image_name = ovf_image_name + ".ovf"
+        # Normalize image name if required
+        if not ovf_image_name.endswith('.ovf'):
+            ovf_image_name = ovf_image_name + ".ovf"
         validate_local_mv_ovf(source_image_path, ovf_image_name)
         mv_vm_name = None
         if vc_swc.is_esx_host():

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -186,7 +186,9 @@ def update_from_local_ovf(vc_swc, enc_svc_cls, template_vm_name=None,
         raise
     try:
         log.info("Launching MV VM from local OVF")
-        ovf_image_name = ovf_image_name + ".ovf"
+        # Normalize image name if required
+        if not ovf_image_name.endswith('.ovf'):
+            ovf_image_name = ovf_image_name + ".ovf"
         validate_local_mv_ovf(source_image_path, ovf_image_name)
         mv_vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
                                              ovf_image_name)

--- a/brkt_cli/esx/wrap_image.py
+++ b/brkt_cli/esx/wrap_image.py
@@ -73,7 +73,9 @@ def wrap_from_local_ovf(vc_swc, guest_vmdk, vm_name=None,
             return
         # Launch OVF
         log.info("Launching VM from local OVF")
-        ovf_image_name = ovf_image_name + ".ovf"
+        # Normalize image name if required
+        if not ovf_image_name.endswith('.ovf'):
+            ovf_image_name = ovf_image_name + ".ovf"
         validate_local_mv_ovf(source_image_path, ovf_image_name)
         vm = vc_swc.upload_ovf_to_vcenter(source_image_path,
                                           ovf_image_name,


### PR DESCRIPTION
When a user specifies a Metavisor OVF, do not automatically assume
that it does not have the `.ovf` extension. Add the extension only
when it is not present.