### PR TITLE
Back up the old template till the new template is created

### DIFF
--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -90,15 +90,24 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
                 print(ovf)
         else:
             # delete the old vm template
-            log.info("Deleting the old template")
             template_vm = vc_swc.find_vm(template_vm_name)
-            if (template_vm):
-                vc_swc.destroy_vm(template_vm)
+            old_template_vm_name = None
+            if template_vm:
+                old_template_vm_name = template_vm_name + "-" + \
+                                       vc_swc.session_id
+                log.info("Renaming the old template to %s",
+                         old_template_vm_name)
+                vc_swc.rename_vm(template_vm, old_template_vm_name)
             # clone the vm to create template
             log.info("Creating the template VM")
             template_vm = vc_swc.clone_vm(guest_vm, vm_name=template_vm_name,
                                           template=True)
             print(vc_swc.get_vm_name(template_vm))
+            if old_template_vm_name:
+                old_template = vc_swc.find_vm(old_template_vm_name)
+                if old_template:
+                    log.info("Deleting the old template")
+                    vc_swc.destroy_vm(old_template)
     except Exception as e:
         log.exception("Failed to update the image with error %s", e)
         raise

--- a/test_esx.py
+++ b/test_esx.py
@@ -64,7 +64,7 @@ class DummyVCenterService(esx_service.BaseVCenterService):
         self.connection = False
         super(DummyVCenterService, self).__init__(
             'testhost', 'testuser', 'testpass', 'testport', 'testdcname',
-            'testdsname', False, 'testclustername', 1, 1024, 123,
+            'testdsname', False, 'testclustername', 1, 1024, "123",
             'VM Network', 'Port')
 
     def connect(self):
@@ -117,6 +117,22 @@ class DummyVCenterService(esx_service.BaseVCenterService):
     def reconfigure_vm_cpu_ram(self, vm):
         vm.cpu = self.no_of_cpus
         vm.memory = self.memoryGB
+
+    def rename_vm(self, vm, new_name):
+        del self.vms[vm.name]
+        vm.name = new_name
+        self.vms[new_name] = vm
+        disk_list = vm.disks.keys()
+        for c_unit in disk_list:
+            c_disk = vm.disks.get(c_unit)
+            name = c_disk.filename
+            size = c_disk.size
+            new_d_name = new_name + name
+            self.disks.pop(name)
+            vm.disks.pop(c_unit)
+            new_disk = DummyDisk(size, new_d_name)
+            self.disks[new_d_name] = new_disk
+            vm.add_disk(new_disk, c_unit)
 
     def add_disk(self, vm, disk_size=12*1024*1024,
                  filename=None, unit_number=0):


### PR DESCRIPTION
During update, the old template gets replaced with the new one.
During the transition, the old one gets deleted and and the new
one is added. If something goes wrong during the addition of the
new template, the old template is lost while the new one is not
created either. So, backup the old template, then create a new one,
and finally delete the old template.