### PR TITLE
Pass the user specified instance type

### DIFF
--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -223,6 +223,7 @@ def run_wrap_image(values, config):
         image_project=values.image_project,
         image_file=values.image_file,
         image_bucket=values.bucket,
+        instance_type=values.instance_type,
         network=values.network,
         subnet=values.subnetwork,
         cleanup=values.cleanup,

--- a/brkt_cli/gcp/wrap_gcp_image.py
+++ b/brkt_cli/gcp/wrap_gcp_image.py
@@ -8,11 +8,11 @@ from googleapiclient import errors
 log = logging.getLogger(__name__)
 
 
-def wrap_guest_image(gcp_svc, image_id, encryptor_image,
-                     zone, metadata, instance_name=None,
-                     image_project=None, image_file=None,
-                     image_bucket=None, network=None, subnet=None,
-                     cleanup=True, ssd_disks=0, gcp_tags=None):
+def wrap_guest_image(gcp_svc, image_id, encryptor_image, zone,
+                     metadata, instance_name=None, image_project=None,
+                     image_file=None, image_bucket=None,
+                     instance_type='n1-standard-4', network=None,
+                     subnet=None, cleanup=True, ssd_disks=0, gcp_tags=None):
     try:
         keep_encryptor = True
         if not encryptor_image:
@@ -47,6 +47,7 @@ def wrap_guest_image(gcp_svc, image_id, encryptor_image,
         gcp_svc.run_instance(zone=zone,
                              name=instance_name,
                              image=encryptor_image,
+                             instance_type=instance_type,
                              network=network,
                              subnet=subnet,
                              disks=disks,


### PR DESCRIPTION
Pass the user specified instance type to the launch command instead
of always defaulting the GCP instance type for the `wrap-guest-image`
command to n1-standard-4.