### PR TITLE
Simplify the logic that handles BracketEnvironment

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -155,15 +155,18 @@ def get_prod_brkt_env():
     return brkt_env_from_domain('mgmt.brkt.com')
 
 
-def brkt_env_from_values(values):
+def brkt_env_from_values(values, cli_config=None):
     """ Return a BracketEnvironment object based on options specified
-    on the command line.  If the environment was not specified with
-    --service-domain or --brkt-env, return None.
+    by the --service-domain or --brkt-env options.  If the environment was
+    not specified on the command line, return the default environment from
+    the CLIConfig, or None.
     """
     if values.service_domain:
         return brkt_env_from_domain(values.service_domain)
     elif values.brkt_env:
         return parse_brkt_env(values.brkt_env)
+    elif cli_config:
+        return cli_config.get_current_env()[1]
     else:
         return None
 
@@ -260,24 +263,6 @@ def validate_jwt(jwt):
         )
 
     return jwt
-
-
-def add_brkt_env_to_brkt_config(brkt_env, brkt_config):
-    """ Add BracketEnvironment values to the config dictionary
-    that will be passed to the metavisor via userdata.
-
-    :param brkt_env a BracketEnvironment object
-    :param brkt_config a dictionary that contains configuration data
-    """
-    if brkt_env:
-        api_host_port = '%s:%d' % (brkt_env.api_host, brkt_env.api_port)
-        hsmproxy_host_port = '%s:%d' % (
-            brkt_env.hsmproxy_host, brkt_env.hsmproxy_port)
-        network_host_port = '%s:%d' % (
-            brkt_env.network_host, brkt_env.network_port)
-        brkt_config['api_host'] = api_host_port
-        brkt_config['hsmproxy_host'] = hsmproxy_host_port
-        brkt_config['network_host'] = network_host_port
 
 
 class SortingHelpFormatter(argparse.HelpFormatter):

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -220,11 +220,12 @@ def run_wrap_image(values, config, verbose=False):
         _validate(aws_svc, values, metavisor_ami)
         brkt_cli.validate_ntp_servers(values.ntp_servers)
 
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_METAVISOR_MODE,
-        cli_config=config,
+        brkt_env=brkt_env,
         launch_token=lt)
 
     instance_id = wrap_image.launch_wrapped_image(
@@ -255,10 +256,6 @@ def run_encrypt(values, config, verbose=False):
     log.debug(
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
-
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    if not brkt_env:
-        _, brkt_env = config.get_current_env()
 
     if values.validate:
         # Validate the region before connecting.
@@ -301,12 +298,14 @@ def run_encrypt(values, config, verbose=False):
                 crypto_policy, mv_image.name
             )
 
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_CREATOR_MODE,
-        cli_config=config,
-        launch_token=lt)
+        brkt_env=brkt_env,
+        launch_token=lt
+    )
 
     if verbose:
         with tempfile.NamedTemporaryFile(
@@ -350,10 +349,6 @@ def run_update(values, config, verbose=False):
     log.debug(
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
-
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    if not brkt_env:
-        _, brkt_env = config.get_current_env()
 
     if values.validate:
         # Validate the region before connecting.
@@ -408,11 +403,12 @@ def run_update(values, config, verbose=False):
         encrypted_image.id, encryptor_ami
     )
 
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_UPDATER_MODE,
-        cli_config=config,
+        brkt_env=brkt_env,
         launch_token=lt
     )
     if verbose:

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -461,6 +461,16 @@ class TestRunEncryption(unittest.TestCase):
         self.assertFalse(self.security_group_deleted)
 
 
+_test_brkt_env = brkt_cli.BracketEnvironment(
+    api_host='api.example.com',
+    api_port=777,
+    hsmproxy_host='hsmproxy.example.com',
+    hsmproxy_port=888,
+    network_host='network.example.com',
+    network_port=999
+)
+
+
 class TestBrktEnv(unittest.TestCase):
 
     def setUp(self):
@@ -479,10 +489,6 @@ class TestBrktEnv(unittest.TestCase):
         """ Test that we parse the brkt_env value and pass the correct
         values to user_data when launching the encryptor instance.
         """
-
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        network_host_port = 'network.example.com:999'
         crypto = CRYPTO_GCM
         aws_svc, encryptor_image, guest_image = build_aws_service()
 
@@ -491,15 +497,15 @@ class TestBrktEnv(unittest.TestCase):
                 brkt_config = self._get_brkt_config_from_mime(args.user_data)
                 d = json.loads(brkt_config)
                 self.assertEquals(
-                    api_host_port,
+                    'api.example.com:777',
                     d['brkt']['api_host']
                 )
                 self.assertEquals(
-                    hsmproxy_host_port,
+                    'hsmproxy.example.com:888',
                     d['brkt']['hsmproxy_host']
                 )
                 self.assertEquals(
-                    network_host_port,
+                    'network.example.com:999',
                     d['brkt']['network_host']
                 )
                 self.assertEquals(
@@ -507,11 +513,9 @@ class TestBrktEnv(unittest.TestCase):
                     d['brkt']['crypto_policy_type']
                 )
 
-        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
-                                         network_host_port)
-        values = instance_config_args_to_values(cli_args)
+        values = instance_config_args_to_values('')
         values.crypto = crypto
-        ic = instance_config_from_values(values)
+        ic = instance_config_from_values(values, brkt_env=_test_brkt_env)
         aws_svc.run_instance_callback = run_instance_callback
         encrypt_ami.encrypt(
             aws_svc=aws_svc,
@@ -535,28 +539,24 @@ class TestBrktEnv(unittest.TestCase):
             crypto_policy=CRYPTO_GCM
         )
 
-        api_host_port = 'api.example.com:777'
-        hsmproxy_host_port = 'hsmproxy.example.com:888'
-        network_host_port = 'network.example.com:999'
-        cli_args = '--brkt-env %s,%s,%s' % (api_host_port, hsmproxy_host_port,
-                                         network_host_port)
-        values = instance_config_args_to_values(cli_args)
-        ic = instance_config_from_values(values, mode=INSTANCE_UPDATER_MODE)
+        values = instance_config_args_to_values('')
+        ic = instance_config_from_values(
+            values, mode=INSTANCE_UPDATER_MODE, brkt_env=_test_brkt_env)
 
         def run_instance_callback(args):
             if args.image_id == encryptor_image.id:
                 brkt_config = self._get_brkt_config_from_mime(args.user_data)
                 d = json.loads(brkt_config)
                 self.assertEquals(
-                    api_host_port,
+                    'api.example.com:777',
                     d['brkt']['api_host']
                 )
                 self.assertEquals(
-                    hsmproxy_host_port,
+                    'hsmproxy.example.com:888',
                     d['brkt']['hsmproxy_host']
                 )
                 self.assertEquals(
-                    network_host_port,
+                    'network.example.com:999',
                     d['brkt']['network_host']
                 )
                 self.assertEquals(

--- a/brkt_cli/config/__init__.py
+++ b/brkt_cli/config/__init__.py
@@ -27,7 +27,6 @@ import brkt_cli
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.util import parse_endpoint, render_table_rows
 from brkt_cli.validation import ValidationError
-from brkt_cli.yeti import YetiError, YetiService
 
 log = logging.getLogger(__name__)
 
@@ -340,36 +339,6 @@ class CLIConfig(object):
         except:
             _unlink_noraise(f.name)
             raise
-
-
-def _get_yeti_service(parsed_config):
-    _, env = parsed_config.get_current_env()
-    root_url = 'https://%s:%d' % (
-        env.public_api_host, env.public_api_port)
-    token = os.environ.get('BRKT_API_TOKEN')
-    return YetiService(root_url, token=token)
-
-
-def get_yeti_service(parsed_config):
-    """ Return a YetiService object based on the given CLIConfig.
-
-    :raise ValidationError if the API token is not set in config, or if
-    authentication with Yeti fails.
-    """
-    y = _get_yeti_service(parsed_config)
-    if not y.token:
-        raise ValidationError(
-            '$BRKT_API_TOKEN is not set. Run brkt auth to get an API token.')
-
-    try:
-        y.get_customer()
-    except YetiError as e:
-        if e.http_status == 401:
-            raise ValidationError(
-                '$BRKT_API_TOKEN is not authorized to access %s' %
-                y.root_url)
-        raise ValidationError(e.message)
-    return y
 
 
 class ConfigSubcommand(Subcommand):

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -12,9 +12,8 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-import os
 import StringIO
+import argparse
 import unittest
 
 import brkt_cli
@@ -307,26 +306,3 @@ class ConfigCommandTestCase(unittest.TestCase):
         self.cmd._unset_env(UnsetEnvValues('test1'))
         self.cmd._list_envs()
         self.assertEqual(self.out.getvalue(), "* brkt-hosted\n")
-
-
-class YetiServiceTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.original_token = os.environ.get('BRKT_API_TOKEN')
-
-    def tearDown(self):
-        if self.original_token:
-            os.environ['BRKT_API_TOKEN'] = self.original_token
-        else:
-            del os.environ['BRKT_API_TOKEN']
-
-    def test_get_yeti_service(self):
-        cfg = CLIConfig()
-        y = brkt_cli.config._get_yeti_service(cfg)
-        self.assertEqual('https://api.mgmt.brkt.com:443', y.root_url)
-        self.assertEqual(self.original_token, y.token)
-
-        # Make sure the API token environment variable is picked up.
-        os.environ['BRKT_API_TOKEN'] = 'abc'
-        y = brkt_cli.config._get_yeti_service(cfg)
-        self.assertEqual('abc', y.token)

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -105,9 +105,6 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
         _check_env_vars_set('VCENTER_USER_NAME')
     vcenter_password = _get_vcenter_password(use_esx)
     brkt_cli.validate_ntp_servers(values.ntp_servers)
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    if brkt_env is None:
-        _, brkt_env = parsed_config.get_current_env()
     # Verify we have a valid launch token
     instance_config_args.get_launch_token(values, parsed_config)
 
@@ -185,11 +182,12 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
+        brkt_env = brkt_cli.brkt_env_from_values(values, parsed_config)
         lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_CREATOR_MODE,
-            cli_config=parsed_config,
+            brkt_env=brkt_env,
             launch_token=lt
         )
         crypto_policy = values.crypto
@@ -305,9 +303,6 @@ def run_update(values, parsed_config, log, use_esx=False):
         _check_env_vars_set('VCENTER_USER_NAME')
     vcenter_password = _get_vcenter_password(use_esx)
     brkt_cli.validate_ntp_servers(values.ntp_servers)
-    brkt_env = brkt_cli.brkt_env_from_values(values)
-    if brkt_env is None:
-        _, brkt_env = parsed_config.get_current_env()
     # Verify we have a valid launch token
     instance_config_args.get_launch_token(values, parsed_config)
 
@@ -366,11 +361,12 @@ def run_update(values, parsed_config, log, use_esx=False):
             raise ValidationError("Template VM %s not found" %
                                   values.template_vm_name)
     try:
+        brkt_env = brkt_cli.brkt_env_from_values(values, parsed_config)
         lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_UPDATER_MODE,
-            cli_config=parsed_config,
+            brkt_env=brkt_env,
             launch_token=lt
         )
         user_data_str = vc_swc.create_userdata_str(instance_config,
@@ -518,11 +514,12 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
                               "thick-eager-zeroed" % (values.disk_type,))
 
     try:
+        brkt_env = brkt_cli.brkt_env_from_values(values, parsed_config)
         lt = instance_config_args.get_launch_token(values, parsed_config)
         instance_config = instance_config_from_values(
             values,
             mode=INSTANCE_METAVISOR_MODE,
-            cli_config=parsed_config,
+            brkt_env=brkt_env,
             launch_token=lt)
         instance_config.brkt_config['allow_unencrypted_guest'] = True
         user_data_str = vc_swc.create_userdata_str(instance_config,

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -52,11 +52,12 @@ def run_encrypt(values, config):
 
     log.info('Starting encryptor session %s', gcp_svc.get_session_id())
 
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     ic = instance_config_from_values(
         values,
         mode=INSTANCE_CREATOR_MODE,
-        cli_config=config,
+        brkt_env=brkt_env,
         launch_token=lt
     )
     encrypted_image_id = encrypt_gcp_image.encrypt(
@@ -104,11 +105,12 @@ def run_update(values, config):
 
     log.info('Starting updater session %s', gcp_svc.get_session_id())
 
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     ic = instance_config_from_values(
         values,
         mode=INSTANCE_UPDATER_MODE,
-        cli_config=config,
+        brkt_env=brkt_env,
         launch_token=lt
     )
     updated_image_id = update_gcp_image.update_gcp_image(
@@ -188,11 +190,13 @@ def run_wrap_image(values, config):
 
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
+
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,
         mode=INSTANCE_METAVISOR_MODE,
-        cli_config=config,
+        brkt_env=brkt_env,
         launch_token=lt)
     if values.startup_script:
         extra_items = [{

--- a/brkt_cli/make_token.py
+++ b/brkt_cli/make_token.py
@@ -19,7 +19,9 @@ import uuid
 
 import brkt_cli
 import brkt_cli.crypto
-from brkt_cli import brkt_jwt, ValidationError, config, util, argutil
+from brkt_cli import (
+    brkt_jwt, ValidationError, util, argutil, instance_config_args
+)
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.util import parse_timestamp
 
@@ -82,7 +84,10 @@ class MakeTokenSubcommand(Subcommand):
                 raise ValidationError(msg % '--nbf')
 
             # New workflow: get a launch token from Yeti.
-            yeti = config.get_yeti_service(self.config)
+            # TODO: add support for specifying environment on the command
+            # line.
+            brkt_env = self.config.get_current_env()[1]
+            yeti = instance_config_args.get_yeti_service(brkt_env)
             tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
             jwt_string = yeti.get_launch_token(tags=tags)
 

--- a/test.py
+++ b/test.py
@@ -20,8 +20,9 @@ import unittest
 import yaml
 
 import brkt_cli
+import brkt_cli.instance_config_args
 import brkt_cli.util
-from brkt_cli import proxy, version
+from brkt_cli import proxy, version, CLIConfig, instance_config_args
 from brkt_cli.proxy import Proxy
 from brkt_cli.validation import ValidationError
 
@@ -266,7 +267,7 @@ class TestBrktEnv(unittest.TestCase):
         }
         brkt_env = brkt_cli.parse_brkt_env(
             api_host_port + ',' + hsmproxy_host_port + ',' + network_host_port)
-        brkt_cli.add_brkt_env_to_brkt_config(brkt_env, userdata)
+        instance_config_args.add_brkt_env_to_brkt_config(brkt_env, userdata)
         self.assertEqual(userdata, expected_userdata)
 
     def test_brkt_env_from_values(self):
@@ -294,3 +295,8 @@ class TestBrktEnv(unittest.TestCase):
             str(brkt_cli.parse_brkt_env(values.brkt_env)),
             str(brkt_env)
         )
+
+        # Test CLIConfig
+        brkt_env = brkt_cli.brkt_env_from_values(
+            DummyValues(), CLIConfig())
+        self.assertEquals('api.mgmt.brkt.com', brkt_env.public_api_host)


### PR DESCRIPTION
Move the logic that handles BracketEnvironment from
instance_config_from_values() to the callsites.  We want to default the
environment to prod when encrypting and updating.  We don't want to
default it when launching with an encrypted disk, but we do when
wrapping or launching with an unencrypted disk.  And the environment can
come from either the command line or config.  It was getting hard enough
to keep track of all of these combinations that I decided to move these
decisions up to the command-line parsing code.

instance_config_from_values() now accepts a BracketEnvironment object
instead of CLIConfig.  It's the callsite's responsibility to figure out
where the environment data comes from, and whether it should be
defaulted.

Move get_yeti_service() to instance_config_args, since that's the only
callsite.