### PR TITLE
Refactor the encrypt_ami module

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -35,10 +35,9 @@ from brkt_cli.aws import (
     share_logs_args,
     update_encrypted_ami_args
 )
-from brkt_cli.aws.encrypt_ami import (
-    TAG_ENCRYPTOR,
-    TAG_ENCRYPTOR_AMI,
-    TAG_ENCRYPTOR_SESSION_ID)
+from brkt_cli.aws.aws_constants import (
+    TAG_ENCRYPTOR, TAG_ENCRYPTOR_SESSION_ID, TAG_ENCRYPTOR_AMI
+)
 from brkt_cli.aws.update_ami import update_ami
 from brkt_cli.instance_config import (
     INSTANCE_CREATOR_MODE,

--- a/brkt_cli/aws/aws_constants.py
+++ b/brkt_cli/aws/aws_constants.py
@@ -1,0 +1,68 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+# End user-visible terminology.  These are resource names and descriptions
+# that the user will see in his or her EC2 console.
+
+# Snapshot names.
+NAME_LOG_SNAPSHOT = 'Bracket logs from %(instance_id)s'
+DESCRIPTION_LOG_SNAPSHOT = \
+    'Bracket logs from %(instance_id)s in AWS account %(aws_account)s '\
+    'taken at %(timestamp)s'
+
+# Guest instance names.
+NAME_GUEST_CREATOR = 'Bracket guest'
+DESCRIPTION_GUEST_CREATOR = \
+    'Used to create an encrypted guest root volume from %(image_id)s'
+
+# Updater instance
+NAME_METAVISOR_UPDATER = 'Bracket Updater'
+DESCRIPTION_METAVISOR_UPDATER = \
+    'Used to upgrade existing encrypted AMI with latest metavisor'
+
+# Security group names
+NAME_ENCRYPTOR_SECURITY_GROUP = 'Bracket Encryptor %(nonce)s'
+DESCRIPTION_ENCRYPTOR_SECURITY_GROUP = (
+    "Allows access to the encryption service.")
+
+# Encryptor instance names.
+NAME_ENCRYPTOR = 'Bracket volume encryptor'
+DESCRIPTION_ENCRYPTOR = \
+    'Copies the root snapshot from %(image_id)s to a new encrypted volume'
+
+# Snapshot names.
+NAME_ORIGINAL_SNAPSHOT = 'Bracket encryptor original volume'
+DESCRIPTION_ORIGINAL_SNAPSHOT = \
+    'Original unencrypted root volume from %(image_id)s'
+NAME_ENCRYPTED_ROOT_SNAPSHOT = 'Bracket encrypted root volume'
+NAME_METAVISOR_ROOT_SNAPSHOT = 'Bracket system root'
+DESCRIPTION_SNAPSHOT = 'Based on %(image_id)s'
+
+# Volume names.
+NAME_ORIGINAL_VOLUME = 'Original unencrypted root volume from %(image_id)s'
+NAME_ENCRYPTED_ROOT_VOLUME = 'Bracket encrypted root volume'
+NAME_METAVISOR_ROOT_VOLUME = 'Bracket system root'
+
+# Tag names.
+TAG_ENCRYPTOR = 'BrktEncryptor'
+TAG_ENCRYPTOR_SESSION_ID = 'BrktEncryptorSessionID'
+TAG_ENCRYPTOR_AMI = 'BrktEncryptorAMI'
+TAG_DESCRIPTION = 'Description'
+NAME_ENCRYPTED_IMAGE = '%(original_image_name)s %(encrypted_suffix)s'
+NAME_ENCRYPTED_IMAGE_SUFFIX = ' (encrypted %(nonce)s)'
+SUFFIX_ENCRYPTED_IMAGE = (
+    ' - based on %(image_id)s, encrypted by Bracket Computing'
+)
+DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE = \
+    'Based on %(image_id)s, encrypted by Bracket Computing'

--- a/brkt_cli/aws/diag.py
+++ b/brkt_cli/aws/diag.py
@@ -14,16 +14,13 @@
 
 import logging
 import time
-from brkt_cli.aws.encrypt_ami import (
-    wait_for_instance,
-)
+from brkt_cli.aws.aws_service import wait_for_instance, snapshot_log_volume
 
 from boto.ec2.blockdevicemapping import (
     BlockDeviceMapping,
     EBSBlockDeviceType,
 )
 
-from brkt_cli.aws.share_logs import snapshot_log_volume
 from brkt_cli.util import make_nonce
 
 # Security group names

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -39,9 +39,6 @@ running the AWS command line utility.
 
 import logging
 import os
-import string
-import tempfile
-import time
 
 from boto.ec2.blockdevicemapping import (
     BlockDeviceMapping,
@@ -52,79 +49,33 @@ from boto.exception import EC2ResponseError
 
 from brkt_cli import encryptor_service
 from brkt_cli.aws import aws_service
+from brkt_cli.aws.aws_constants import (
+    NAME_ENCRYPTOR, DESCRIPTION_ENCRYPTOR,
+    NAME_ENCRYPTED_ROOT_SNAPSHOT, NAME_METAVISOR_ROOT_SNAPSHOT,
+    DESCRIPTION_SNAPSHOT, NAME_ENCRYPTED_ROOT_VOLUME,
+    NAME_METAVISOR_ROOT_VOLUME, NAME_ENCRYPTED_IMAGE_SUFFIX,
+    SUFFIX_ENCRYPTED_IMAGE, DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE,
+    TAG_ENCRYPTOR, TAG_ENCRYPTOR_SESSION_ID, TAG_ENCRYPTOR_AMI
+)
+from brkt_cli.aws.aws_service import (
+    wait_for_instance, stop_and_wait,
+    wait_for_image, create_encryptor_security_group, run_guest_instance,
+    clean_up, log_exception_console, snapshot_log_volume,
+    wait_for_volume_attached, wait_for_snapshots,
+    snapshot_root_volume)
 from brkt_cli.instance_config import InstanceConfig
 from brkt_cli.user_data import gzip_user_data
 from brkt_cli.util import (
     BracketError,
     Deadline,
     make_nonce,
-    sleep,
     append_suffix,
     CRYPTO_XTS
 )
-from datetime import datetime
-
-# End user-visible terminology.  These are resource names and descriptions
-# that the user will see in his or her EC2 console.
-
-# Snapshot names.
-NAME_LOG_SNAPSHOT = 'Bracket logs from %(instance_id)s'
-DESCRIPTION_LOG_SNAPSHOT = \
-    'Bracket logs from %(instance_id)s in AWS account %(aws_account)s '\
-    'taken at %(timestamp)s'
-
-
-# Guest instance names.
-NAME_GUEST_CREATOR = 'Bracket guest'
-DESCRIPTION_GUEST_CREATOR = \
-    'Used to create an encrypted guest root volume from %(image_id)s'
-
-# Updater instance
-NAME_METAVISOR_UPDATER = 'Bracket Updater'
-DESCRIPTION_METAVISOR_UPDATER = \
-    'Used to upgrade existing encrypted AMI with latest metavisor'
-
-# Security group names
-NAME_ENCRYPTOR_SECURITY_GROUP = 'Bracket Encryptor %(nonce)s'
-DESCRIPTION_ENCRYPTOR_SECURITY_GROUP = (
-    "Allows access to the encryption service.")
-
-# Encryptor instance names.
-NAME_ENCRYPTOR = 'Bracket volume encryptor'
-DESCRIPTION_ENCRYPTOR = \
-    'Copies the root snapshot from %(image_id)s to a new encrypted volume'
-
-# Snapshot names.
-NAME_ORIGINAL_SNAPSHOT = 'Bracket encryptor original volume'
-DESCRIPTION_ORIGINAL_SNAPSHOT = \
-    'Original unencrypted root volume from %(image_id)s'
-NAME_ENCRYPTED_ROOT_SNAPSHOT = 'Bracket encrypted root volume'
-NAME_METAVISOR_ROOT_SNAPSHOT = 'Bracket system root'
-DESCRIPTION_SNAPSHOT = 'Based on %(image_id)s'
-
-# Volume names.
-NAME_ORIGINAL_VOLUME = 'Original unencrypted root volume from %(image_id)s'
-NAME_ENCRYPTED_ROOT_VOLUME = 'Bracket encrypted root volume'
-NAME_METAVISOR_ROOT_VOLUME = 'Bracket system root'
-
-# Tag names.
-TAG_ENCRYPTOR = 'BrktEncryptor'
-TAG_ENCRYPTOR_SESSION_ID = 'BrktEncryptorSessionID'
-TAG_ENCRYPTOR_AMI = 'BrktEncryptorAMI'
-TAG_DESCRIPTION = 'Description'
-
-NAME_ENCRYPTED_IMAGE = '%(original_image_name)s %(encrypted_suffix)s'
-NAME_ENCRYPTED_IMAGE_SUFFIX = ' (encrypted %(nonce)s)'
-SUFFIX_ENCRYPTED_IMAGE = (
-    ' - based on %(image_id)s, encrypted by Bracket Computing'
-)
-DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE = \
-    'Based on %(image_id)s, encrypted by Bracket Computing'
-
-AMI_NAME_MAX_LENGTH = 128
 
 log = logging.getLogger(__name__)
 
+AMI_NAME_MAX_LENGTH = 128
 
 # boto2 does not support this attribute, and this attribute needs to be
 # queried for as metavisor does not support sriovNet
@@ -141,70 +92,6 @@ def get_default_tags(session_id, encryptor_ami):
     return default_tags
 
 
-class SnapshotError(BracketError):
-    pass
-
-
-class InstanceError(BracketError):
-    pass
-
-
-def _get_snapshot_progress_text(snapshots):
-    elements = [
-        '%s: %s' % (str(s.id), str(s.progress))
-        for s in snapshots
-    ]
-    return ', '.join(elements)
-
-
-def wait_for_instance(
-        aws_svc, instance_id, timeout=600, state='running'):
-    """ Wait for up to timeout seconds for an instance to be in the
-    given state.  Sleep for 2 seconds between checks.
-
-    :return: The Instance object
-    :raises InstanceError if a timeout occurs or the instance unexpectedly
-        goes into an error or terminated state
-    """
-
-    log.debug(
-        'Waiting for %s, timeout=%d, state=%s',
-        instance_id, timeout, state)
-
-    deadline = Deadline(timeout)
-    while not deadline.is_expired():
-        instance = aws_svc.get_instance(instance_id)
-        log.debug('Instance %s state=%s', instance.id, instance.state)
-        if instance.state == state:
-            return instance
-        if instance.state == 'error':
-            raise InstanceError(
-                'Instance %s is in an error state.  Cannot proceed.' %
-                instance_id
-            )
-        if state != 'terminated' and instance.state == 'terminated':
-            raise InstanceError(
-                'Instance %s was unexpectedly terminated.' % instance_id
-            )
-        sleep(2)
-    raise InstanceError(
-        'Timed out waiting for %s to be in the %s state' %
-        (instance_id, state)
-    )
-
-
-def stop_and_wait(aws_svc, instance_id):
-    """ Stop the given instance and wait for it to be in the stopped state.
-    If an exception is thrown, log the error and return.
-    """
-    try:
-        aws_svc.stop_instance(instance_id)
-        wait_for_instance(aws_svc, instance_id, state='stopped')
-    except:
-        log.exception(
-            'Error while waiting for instance %s to stop', instance_id)
-
-
 def get_encrypted_suffix():
     """ Return a suffix that will be appended to the encrypted image name.
     The suffix is in the format "(encrypted 787ace7a)".  The nonce portion of
@@ -213,7 +100,7 @@ def get_encrypted_suffix():
     return NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': make_nonce()}
 
 
-def get_name_from_image(image):
+def _get_name_from_image(image):
     name = append_suffix(
         image.name,
         get_encrypted_suffix(),
@@ -222,7 +109,7 @@ def get_name_from_image(image):
     return name
 
 
-def get_description_from_image(image):
+def _get_description_from_image(image):
     if image.description:
         suffix = SUFFIX_ENCRYPTED_IMAGE % {'image_id': image.id}
         description = append_suffix(
@@ -232,97 +119,6 @@ def get_description_from_image(image):
             'image_id': image.id
         }
     return description
-
-
-def wait_for_image(aws_svc, image_id):
-    log.debug('Waiting for %s to become available.', image_id)
-    for i in range(180):
-        sleep(5)
-        try:
-            image = aws_svc.get_image(image_id)
-        except EC2ResponseError, e:
-            if e.error_code == 'InvalidAMIID.NotFound':
-                log.debug('AWS threw a NotFound, ignoring')
-                continue
-            else:
-                log.warn('Unknown AWS error: %s', e)
-        # These two attributes are optional in the response and only
-        # show up sometimes. So we have to getattr them.
-        reason = repr(getattr(image, 'stateReason', None))
-        code = repr(getattr(image, 'code', None))
-        log.debug("%s: %s reason: %s code: %s",
-                  image.id, image.state, reason, code)
-        if image.state == 'available':
-            break
-        if image.state == 'failed':
-            raise BracketError('Image state became failed')
-    else:
-        raise BracketError(
-            'Image failed to become available (%s)' % (image.state,))
-
-
-def wait_for_snapshots(aws_svc, *snapshot_ids):
-    log.debug('Waiting for status "completed" for %s', str(snapshot_ids))
-    last_progress_log = time.time()
-
-    # Give AWS some time to propagate the snapshot creation.
-    # If we create and get immediately, AWS may return 400.
-    sleep(20)
-
-    while True:
-        snapshots = aws_svc.get_snapshots(*snapshot_ids)
-        log.debug('%s', {s.id: s.status for s in snapshots})
-
-        done = True
-        error_ids = []
-        for snapshot in snapshots:
-            if snapshot.status == 'error':
-                error_ids.append(snapshot.id)
-            if snapshot.status != 'completed':
-                done = False
-
-        if error_ids:
-            # Get rid of unicode markers in error the message.
-            error_ids = [str(id) for id in error_ids]
-            raise SnapshotError(
-                'Snapshots in error state: %s.  Cannot continue.' %
-                str(error_ids)
-            )
-        if done:
-            return
-
-        # Log progress if necessary.
-        now = time.time()
-        if now - last_progress_log > 60:
-            log.info(_get_snapshot_progress_text(snapshots))
-            last_progress_log = now
-
-        sleep(5)
-
-
-def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
-                                    encryptor_service.ENCRYPTOR_STATUS_PORT):
-    sg_name = NAME_ENCRYPTOR_SECURITY_GROUP % {'nonce': make_nonce()}
-    sg_desc = DESCRIPTION_ENCRYPTOR_SECURITY_GROUP
-    sg = aws_svc.create_security_group(sg_name, sg_desc, vpc_id=vpc_id)
-    log.info('Created temporary security group with id %s', sg.id)
-    try:
-        aws_svc.add_security_group_rule(
-            sg.id, ip_protocol='tcp',
-            from_port=status_port,
-            to_port=status_port,
-            cidr_ip='0.0.0.0/0')
-    except Exception as e:
-        log.error('Failed adding security group rule to %s: %s', sg.id, e)
-        try:
-            log.info('Cleaning up temporary security group %s', sg.id)
-            aws_svc.delete_security_group(sg.id)
-        except Exception as e2:
-            log.warn('Failed deleting temporary security group: %s', e2)
-        raise
-
-    aws_svc.create_tags(sg.id)
-    return sg
 
 
 def _run_encryptor_instance(
@@ -426,111 +222,7 @@ def _run_encryptor_instance(
     return instance, temp_sg_id
 
 
-def run_guest_instance(aws_svc, image_id, subnet_id=None,
-                       instance_type='m3.medium'):
-    instance = None
-
-    try:
-        instance = aws_svc.run_instance(
-            image_id, subnet_id=subnet_id,
-            instance_type=instance_type, ebs_optimized=False)
-        log.info(
-            'Launching instance %s to snapshot root disk for %s',
-            instance.id, image_id)
-        aws_svc.create_tags(
-            instance.id,
-            name=NAME_GUEST_CREATOR,
-            description=DESCRIPTION_GUEST_CREATOR % {'image_id': image_id}
-        )
-    except:
-        if instance:
-            clean_up(aws_svc, instance_ids=[instance.id])
-        raise
-
-    return instance
-
-
-def _snapshot_root_volume(aws_svc, instance, image_id):
-    """ Snapshot the root volume of the given AMI.
-
-    :except SnapshotError if the snapshot goes into an error state
-    """
-    log.info(
-        'Stopping instance %s in order to create snapshot', instance.id)
-    aws_svc.stop_instance(instance.id)
-    wait_for_instance(aws_svc, instance.id, state='stopped')
-
-    # Snapshot root volume.
-    instance = aws_svc.get_instance(instance.id)
-    root_dev = instance.root_device_name
-    bdm = instance.block_device_mapping
-
-    if root_dev not in bdm:
-        # try stripping partition id
-        root_dev = string.rstrip(root_dev, string.digits)
-    root_vol = bdm[root_dev]
-    vol = aws_svc.get_volume(root_vol.volume_id)
-    aws_svc.create_tags(
-        root_vol.volume_id,
-        name=NAME_ORIGINAL_VOLUME % {'image_id': image_id}
-    )
-
-    snapshot = aws_svc.create_snapshot(
-        vol.id,
-        name=NAME_ORIGINAL_SNAPSHOT,
-        description=DESCRIPTION_ORIGINAL_SNAPSHOT % {'image_id': image_id}
-    )
-    log.info(
-        'Creating snapshot %s of root volume for instance %s',
-        snapshot.id, instance.id
-    )
-
-    try:
-        wait_for_snapshots(aws_svc, snapshot.id)
-
-        # Now try to detach the root volume.
-        log.info('Detaching root volume %s from %s',
-                 root_vol.volume_id, instance.id)
-        aws_svc.detach_volume(
-            root_vol.volume_id,
-            instance_id=instance.id,
-            force=True
-        )
-        aws_service.wait_for_volume(aws_svc, root_vol.volume_id)
-        # And now delete it
-        log.info('Deleting root volume %s', root_vol.volume_id)
-        aws_svc.delete_volume(root_vol.volume_id)
-    except:
-        clean_up(aws_svc, snapshot_ids=[snapshot.id])
-        raise
-
-    iops = None
-    if vol.type == 'io1':
-        iops = vol.iops
-
-    ret_values = (
-        snapshot.id, root_dev, vol.size, vol.type, iops)
-    log.debug('Returning %s', str(ret_values))
-    return ret_values
-
-
-def write_console_output(aws_svc, instance_id):
-
-    try:
-        console_output = aws_svc.get_console_output(instance_id)
-        if console_output.output:
-            prefix = instance_id + '-'
-            with tempfile.NamedTemporaryFile(
-                    prefix=prefix, suffix='-console.txt', delete=False) as t:
-                t.write(console_output.output)
-            return t
-    except:
-        log.exception('Unable to write console output')
-
-    return None
-
-
-def terminate_instance(aws_svc, id, name, terminated_instance_ids):
+def _terminate_instance(aws_svc, id, name, terminated_instance_ids):
     try:
         log.info('Terminating %s instance %s', name, id)
         aws_svc.terminate_instance(id)
@@ -539,136 +231,11 @@ def terminate_instance(aws_svc, id, name, terminated_instance_ids):
         log.warn('Could not terminate %s instance: %s', name, e)
 
 
-def clean_up(aws_svc, instance_ids=None, volume_ids=None,
-              snapshot_ids=None, security_group_ids=None):
-    """ Clean up any resources that were created by the encryption process.
-    Handle and log exceptions, to ensure that the script doesn't exit during
-    cleanup.
-    """
-    instance_ids = instance_ids or []
-    volume_ids = volume_ids or []
-    snapshot_ids = snapshot_ids or []
-    security_group_ids = security_group_ids or []
-
-    # Delete instances and snapshots.
-    terminated_instance_ids = set()
-    for instance_id in instance_ids:
-        try:
-            log.info('Terminating instance %s', instance_id)
-            aws_svc.terminate_instance(instance_id)
-            terminated_instance_ids.add(instance_id)
-        except EC2ResponseError as e:
-            log.warn('Unable to terminate instance %s: %s', instance_id, e)
-        except:
-            log.exception('Unable to terminate instance %s', instance_id)
-
-    for snapshot_id in snapshot_ids:
-        try:
-            log.info('Deleting snapshot %s', snapshot_id)
-            aws_svc.delete_snapshot(snapshot_id)
-        except EC2ResponseError as e:
-            log.warn('Unable to delete snapshot %s: %s', snapshot_id, e)
-        except:
-            log.exception('Unable to delete snapshot %s', snapshot_id)
-
-    # Wait for instances to terminate before deleting security groups and
-    # volumes, to avoid dependency errors.
-    for id in terminated_instance_ids:
-        log.info('Waiting for instance %s to terminate.', id)
-        try:
-            wait_for_instance(aws_svc, id, state='terminated')
-        except (EC2ResponseError, InstanceError) as e:
-            log.warn(
-                'An error occurred while waiting for instance to '
-                'terminate: %s', e)
-        except:
-            log.exception(
-                'An error occurred while waiting for instance '
-                'to terminate'
-            )
-
-    # Delete volumes and security groups.
-    for volume_id in volume_ids:
-        try:
-            log.info('Deleting volume %s', volume_id)
-            aws_svc.delete_volume(volume_id)
-        except EC2ResponseError as e:
-            log.warn('Unable to delete volume %s: %s', volume_id, e)
-        except:
-            log.exception('Unable to delete volume %s', volume_id)
-
-    for sg_id in security_group_ids:
-        try:
-            log.info('Deleting security group %s', sg_id)
-            aws_svc.delete_security_group(sg_id)
-        except EC2ResponseError as e:
-            log.warn('Unable to delete security group %s: %s', sg_id, e)
-        except:
-            log.exception('Unable to delete security group %s', sg_id)
-
-
-def log_exception_console(aws_svc, e, id):
-    log.error(
-        'Encryption failed.  Check console output of instance %s '
-        'for details.',
-        id
-    )
-
-    e.console_output_file = write_console_output(aws_svc, id)
-    if e.console_output_file:
-        log.error(
-            'Wrote console output for instance %s to %s',
-            id, e.console_output_file.name
-        )
-    else:
-        log.error(
-            'Encryptor console output is not currently available.  '
-            'Wait a minute and check the console output for '
-            'instance %s in the EC2 Management '
-            'Console.',
-            id
-        )
-
-
-def snapshot_log_volume(aws_svc, instance_id):
-    """ Snapshot the log volume of the given instance.
-
-    :except SnapshotError if the snapshot goes into an error state
-    """
-
-    # Snapshot root volume.
-    instance = aws_svc.get_instance(instance_id)
-    bdm = instance.block_device_mapping
-
-    log_vol = bdm["/dev/sda1"]
-    vol = aws_svc.get_volume(log_vol.volume_id)
-    image = aws_svc.get_image(instance.image_id)
-    snapshot = aws_svc.create_snapshot(
-        vol.id,
-        name=NAME_LOG_SNAPSHOT % {'instance_id': instance_id},
-        description=DESCRIPTION_LOG_SNAPSHOT % {
-            'instance_id': instance_id,
-            'aws_account': image.owner_id,
-            'timestamp': datetime.utcnow().strftime('%b %d %Y %I:%M%p UTC')
-        }
-    )
-    log.info(
-        'Creating snapshot %s of log volume for instance %s',
-        snapshot.id, instance_id
-    )
-
-    try:
-        wait_for_snapshots(aws_svc, snapshot.id)
-    except:
-        clean_up(aws_svc, snapshot_ids=[snapshot.id])
-        raise
-    return snapshot
-
-
-def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
-                       encryptor_image, image_id=None, vol_type='', iops=None,
-                       legacy=False, save_encryptor_logs=True,
-                       status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
+def _snapshot_encrypted_instance(
+        aws_svc, enc_svc_cls, encryptor_instance,
+        encryptor_image, image_id=None, vol_type='', iops=None,
+        legacy=False, save_encryptor_logs=True,
+        status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     # First wait for encryption to complete
     host_ips = []
     if encryptor_instance.ip_address:
@@ -775,43 +342,9 @@ def snapshot_encrypted_instance(aws_svc, enc_svc_cls, encryptor_instance,
     return mv_root_id, new_bdm
 
 
-def wait_for_volume_attached(aws_svc, instance_id, device):
-    """ Wait until the device appears in the block device mapping of the
-    given instance.
-    :return: the Instance object
-    """
-    # Wait for attachment to complete.
-    log.debug(
-        'Waiting for %s in block device mapping of %s.',
-        device,
-        instance_id
-    )
-
-    found = False
-    instance = None
-
-    for _ in xrange(20):
-        instance = aws_svc.get_instance(instance_id)
-        bdm = instance.block_device_mapping
-        log.debug('Found devices: %s', bdm.keys())
-        if device in bdm:
-            found = True
-            break
-        else:
-            sleep(5)
-
-    if not found:
-        raise BracketError(
-            'Timed out waiting for %s to attach to %s' %
-            (device, instance_id)
-        )
-
-    return instance
-
-
-def register_ami(aws_svc, encryptor_instance, encryptor_image, name,
-                 description, mv_bdm=None, legacy=False, guest_instance=None,
-                 mv_root_id=None):
+def _register_ami(aws_svc, encryptor_instance, encryptor_image, name,
+                  description, mv_bdm=None, legacy=False, guest_instance=None,
+                  mv_root_id=None):
     if not mv_bdm:
         mv_bdm = BlockDeviceMapping()
     # Register the new AMI.
@@ -943,10 +476,14 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
         legacy = True
 
     try:
-        guest_instance = run_guest_instance(aws_svc,
-            image_id, subnet_id=subnet_id, instance_type=guest_instance_type)
+        guest_instance = run_guest_instance(
+            aws_svc,
+            image_id,
+            subnet_id=subnet_id,
+            instance_type=guest_instance_type
+        )
         wait_for_instance(aws_svc, guest_instance.id)
-        snapshot_id, root_dev, size, vol_type, iops = _snapshot_root_volume(
+        snapshot_id, root_dev, size, vol_type, iops = snapshot_root_volume(
             aws_svc, guest_instance, image_id
         )
 
@@ -972,14 +509,22 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             raise BracketError("Can't find image %s" % image_id)
         if encrypted_ami_name:
             name = encrypted_ami_name
-        elif image_id:
-            name = get_name_from_image(image)
-        description = get_description_from_image(image)
+        else:
+            name = _get_name_from_image(image)
+        description = _get_description_from_image(image)
 
-        mv_root_id, mv_bdm = snapshot_encrypted_instance(aws_svc, enc_svc_cls,
-                encryptor_instance, mv_image, image_id=image_id,
-                vol_type=vol_type, iops=iops, legacy=legacy,
-                save_encryptor_logs=save_encryptor_logs, status_port=status_port)
+        mv_root_id, mv_bdm = _snapshot_encrypted_instance(
+            aws_svc,
+            enc_svc_cls,
+            encryptor_instance,
+            mv_image,
+            image_id=image_id,
+            vol_type=vol_type,
+            iops=iops,
+            legacy=legacy,
+            save_encryptor_logs=save_encryptor_logs,
+            status_port=status_port
+        )
 
         if net_sriov_attr.get("sriovNetSupport") != "simple":
             log.info('Enabling sriovNetSupport for guest instance %s',
@@ -996,10 +541,17 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
                 log.warn('Unable to enable sriovNetSupport for guest '
                          'instance %s with error %s', guest_instance.id, e)
 
-        ami_info = register_ami(aws_svc, encryptor_instance, mv_image, name,
-                description, legacy=legacy, guest_instance=guest_instance,
-                mv_root_id=mv_root_id,
-                mv_bdm=mv_bdm)
+        ami_info = _register_ami(
+            aws_svc,
+            encryptor_instance,
+            mv_image,
+            name,
+            description,
+            legacy=legacy,
+            guest_instance=guest_instance,
+            mv_root_id=mv_root_id,
+            mv_bdm=mv_bdm
+        )
         ami = ami_info['ami']
         log.info('Created encrypted AMI %s based on %s', ami, image_id)
     finally:

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import logging
-from brkt_cli.aws.encrypt_ami import (
-    snapshot_log_volume
-)
+from brkt_cli.aws.aws_service import snapshot_log_volume
 
 log = logging.getLogger(__name__)
 

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -25,12 +25,12 @@ from boto.ec2.volume import Volume
 from boto.exception import EC2ResponseError
 from boto.regioninfo import RegionInfo
 from boto.vpc import VPC
-from brkt_cli.validation import ValidationError
 
 import brkt_cli
 import brkt_cli.aws
 import brkt_cli.util
-from brkt_cli.aws import aws_service, encrypt_ami
+from brkt_cli.aws import aws_service
+from brkt_cli.validation import ValidationError
 
 CONSOLE_OUTPUT_TEXT = 'Starting up.\nAll systems go!\n'
 
@@ -468,7 +468,7 @@ class TestInstance(unittest.TestCase):
         aws_svc, encryptor_image, guest_image = build_aws_service()
         instance = aws_svc.run_instance(guest_image.id)
         aws_svc.terminate_instance(instance.id)
-        result = encrypt_ami.wait_for_instance(
+        result = aws_service.wait_for_instance(
             aws_svc, instance.id, state='terminated', timeout=100)
         self.assertEquals(instance, result)
 
@@ -480,8 +480,8 @@ class TestInstance(unittest.TestCase):
         instance = aws_svc.run_instance(guest_image.id)
         instance._state.name = 'error'
         try:
-            encrypt_ami.wait_for_instance(aws_svc, instance.id, timeout=100)
-        except encrypt_ami.InstanceError as e:
+            aws_service.wait_for_instance(aws_svc, instance.id, timeout=100)
+        except aws_service.InstanceError as e:
             self.assertTrue('error state' in e.message)
 
     def test_wait_for_instance_unexpectedly_terminated(self):
@@ -492,9 +492,9 @@ class TestInstance(unittest.TestCase):
         instance = aws_svc.run_instance(guest_image.id)
         aws_svc.terminate_instance(instance.id)
         try:
-            encrypt_ami.wait_for_instance(
+            aws_service.wait_for_instance(
                 aws_svc, instance.id, state='running', timeout=100)
-        except encrypt_ami.InstanceError as e:
+        except aws_service.InstanceError as e:
             self.assertTrue('unexpectedly terminated' in e.message)
 
 
@@ -545,3 +545,26 @@ class TestVolume(unittest.TestCase):
         aws_svc.get_volume_callback = transition_to_available
         result = aws_service.wait_for_volume(aws_svc, volume.id)
         self.assertEqual(volume, result)
+
+
+class TestSnapshotProgress(unittest.TestCase):
+
+    def test_snapshot_progress_text(self):
+        # One snapshot.
+        s1 = Snapshot()
+        s1.id = '1'
+        s1.progress = u'25%'
+        self.assertEqual(
+            '1: 25%',
+            aws_service._get_snapshot_progress_text([s1])
+        )
+
+        # Two snapshots.
+        s2 = Snapshot()
+        s2.id = '2'
+        s2.progress = u'50%'
+
+        self.assertEqual(
+            '1: 25%, 2: 50%',
+            aws_service._get_snapshot_progress_text([s1, s2])
+        )

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -41,17 +41,10 @@ from boto.ec2.blockdevicemapping import (
 
 from brkt_cli.user_data import gzip_user_data
 from brkt_cli.instance_config import InstanceConfig
-from brkt_cli.aws.aws_service import EBS_OPTIMIZED_INSTANCES
-from brkt_cli.aws.encrypt_ami import (
-    run_guest_instance,
-    wait_for_instance,
-    _snapshot_root_volume,
-    clean_up
-)
-from brkt_cli.util import (
-    make_nonce,
-    append_suffix,
-)
+from brkt_cli.aws.aws_service import (
+    EBS_OPTIMIZED_INSTANCES, wait_for_instance, run_guest_instance, clean_up,
+    snapshot_root_volume)
+from brkt_cli.util import make_nonce, append_suffix
 
 # End user-visible terminology.  These are resource names and descriptions
 # that the user will see in his or her EC2 console.
@@ -132,8 +125,8 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
                 guest_instance = run_guest_instance(aws_svc, image_id,
                     subnet_id=subnet_id, instance_type=instance_type)
                 wait_for_instance(aws_svc, guest_instance.id)
-                guest_snapshot, _, _, _, _ = _snapshot_root_volume(aws_svc,
-                    guest_instance, image_id)
+                guest_snapshot, _, _, _, _ = snapshot_root_volume(
+                    aws_svc, guest_instance, image_id)
             finally:
                 if guest_instance:
                     clean_up(aws_svc, instance_ids=[guest_instance.id])


### PR DESCRIPTION
Move utility functions that are called from multiple places out of
encrypt_ami and into a new aws_util module.  Move constants into a new
aws_constants module.  Remove the old backward compatibility test.  It's
no longer necessary, now that we have a single CLI codebase.