### PR TITLE
Split the make-token command out of brkt_jwt

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -37,7 +37,7 @@ from brkt_cli.validation import ValidationError
 SUBCOMMAND_MODULE_PATHS = [
     'brkt_cli.auth',
     'brkt_cli.aws',
-    'brkt_cli.brkt_jwt',
+    'brkt_cli.make_token',
     'brkt_cli.config',
     'brkt_cli.esx',
     'brkt_cli.gcp',
@@ -249,20 +249,16 @@ def validate_jwt(jwt):
     missing_fields = [f for f in expected_fields if f not in header]
     if missing_fields:
         raise ValidationError(
-            'Missing fields in token header: %s.  Use the %s command '
-            'to generate a valid token.' % (
-                ','.join(missing_fields),
-                brkt_jwt.SUBCOMMAND_NAME
-            )
+            'Missing fields in token header: %s.  Use the make-token command '
+            'to generate a valid token.' % ','.join(missing_fields)
         )
 
     # Validate payload.
     payload = brkt_jwt.get_payload(jwt)
     if not payload.get('jti'):
         raise ValidationError(
-            'Token payload does not contain the jti field.  Use the %s '
-            'command to generate a valid token.' %
-            brkt_jwt.SUBCOMMAND_NAME
+            'Token payload does not contain the jti field.  Use the '
+            'make-token command to generate a valid token.'
         )
 
     return jwt

--- a/brkt_cli/brkt_jwt/__init__.py
+++ b/brkt_cli/brkt_jwt/__init__.py
@@ -13,28 +13,17 @@
 # limitations under the License.
 from __future__ import print_function
 
-import argparse
-import json
 import logging
 import re
 import time
-import uuid
-from datetime import datetime
 
-import iso8601
 import jwt
 
-import brkt_cli
-from brkt_cli import argutil, config, util, version
+from brkt_cli import util, version
 from brkt_cli.brkt_jwt import jwk
-from brkt_cli.subcommand import Subcommand
 from brkt_cli.validation import ValidationError
-import brkt_cli.crypto
 
 log = logging.getLogger(__name__)
-
-
-SUBCOMMAND_NAME = 'make-token'
 
 # Registered claim names, per RFC 7519.
 JWT_REGISTERED_CLAIMS = (
@@ -42,7 +31,7 @@ JWT_REGISTERED_CLAIMS = (
 )
 
 
-def _name_value_list_to_dict(l):
+def name_value_list_to_dict(l):
     """ Convert a list of NAME=VALUE strings to a dictionary.
     :raise ValidationError if a key is specified more than once.
     """
@@ -64,153 +53,13 @@ def brkt_tags_from_name_value_list(l):
     :raise ValidationError if a key is specified more than once or a key
     matches a JWT registered claim
     """
-    d = _name_value_list_to_dict(l)
+    d = name_value_list_to_dict(l)
     for k, _ in d.iteritems():
         if k.lower() in JWT_REGISTERED_CLAIMS:
             raise ValidationError(
                 k + ' is a JWT registered claim'
             )
     return d
-
-
-def _make_jwt_from_signing_key(values, signing_key):
-    crypto = brkt_cli.crypto.read_private_key(signing_key)
-    exp = None
-    if values.exp:
-        exp = parse_timestamp(values.exp)
-    nbf = None
-    if values.nbf:
-        nbf = parse_timestamp(values.nbf)
-    customer = None
-    if values.customer:
-        customer = str(values.customer)
-
-    # Merge claims and tags.
-    claims = _name_value_list_to_dict(values.claims)
-    claims.update(brkt_tags_from_name_value_list(values.brkt_tags))
-
-    return make_jwt(
-        crypto,
-        exp=exp,
-        nbf=nbf,
-        customer=customer,
-        claims=claims
-    )
-
-
-class MakeTokenSubcommand(Subcommand):
-
-    def __init__(self):
-        self.config = None
-
-    def name(self):
-        return SUBCOMMAND_NAME
-
-    def register(self, subparsers, parsed_config):
-        self.config = parsed_config
-        setup_make_jwt_args(subparsers)
-
-    def verbose(self, values):
-        return values.make_jwt_verbose
-
-    def run(self, values):
-        if values.signing_key_option:
-            log.warn(
-                'The --signing-key option is deprecated and will be removed '
-                'in a future release.'
-            )
-
-        signing_key = (
-            # The signing_key field doesn't exist if cryptography isn't
-            # installed.
-            getattr(values, 'signing_key', None) or
-            values.signing_key_option
-        )
-        if signing_key:
-            # Original workflow: create a launch token from a private key.
-            if not brkt_cli.crypto.cryptography_library_available:
-                raise ValidationError(
-                    'Token generation from a private key requires the '
-                    'cryptography library.\nPlease run pip install '
-                    'cryptography.'
-                )
-            jwt_string = _make_jwt_from_signing_key(values, signing_key)
-        else:
-            # We're scaling back the list of supported claims.  Don't allow
-            # these until there's a need, and the service API supports it.
-            msg = (
-                '%s is not supported when getting a launch '
-                'token from the Bracket service'
-            )
-            if values.claims:
-                raise ValidationError(msg % '--claim')
-            if values.customer:
-                raise ValidationError(msg % '--customer')
-            if values.exp:
-                raise ValidationError(msg % '--exp')
-            if values.nbf:
-                raise ValidationError(msg % '--nbf')
-
-            # New workflow: get a launch token from Yeti.
-            yeti = config.get_yeti_service(self.config)
-            tags = brkt_tags_from_name_value_list(values.brkt_tags)
-            jwt_string = yeti.get_launch_token(tags=tags)
-
-        log.debug('Header: %s', json.dumps(get_header(jwt_string)))
-        log.debug('Payload: %s', json.dumps(get_payload(jwt_string)))
-        util.write_to_file_or_stdout(jwt_string, path=values.out)
-
-        return 0
-
-
-def _timestamp_to_datetime(ts):
-    """ Convert a Unix timestamp to a datetime with timezone set to UTC. """
-    return datetime.fromtimestamp(ts, tz=iso8601.UTC)
-
-
-def _datetime_to_timestamp(dt):
-    """ Convert a datetime to a Unix timestamp in seconds. """
-    time_zero = _timestamp_to_datetime(0)
-    return (dt - time_zero).total_seconds()
-
-
-def get_subcommands():
-    return [MakeTokenSubcommand()]
-
-
-def parse_timestamp(ts_string):
-    """ Return a datetime that represents the given timestamp
-    string.  The string can be a Unix timestamp in seconds or an ISO 8601
-    timestamp.
-
-    :raise ValidationError if ts_string is malformed
-    """
-    now = int(time.time())
-
-    # Parse integer timestamp.
-    m = re.match('\d+(\.\d+)?$', ts_string)
-    if m:
-        t = float(ts_string)
-        if t < now:
-            raise ValidationError(
-                '%s is earlier than the current timestamp (%s).' % (
-                    ts_string, now))
-        return _timestamp_to_datetime(t)
-
-    # Parse ISO 8601 timestamp.
-    dt_now = _timestamp_to_datetime(now)
-    try:
-        dt = iso8601.parse_date(ts_string)
-    except iso8601.ParseError:
-        raise ValidationError(
-            'Timestamp "%s" must either be a Unix timestamp or in iso8601 '
-            'format (2016-05-10T19:15:36Z).' % ts_string
-        )
-    if dt < dt_now:
-        raise ValidationError(
-            '%s is earlier than the current timestamp (%s).' % (
-                ts_string, dt_now))
-    return dt
 
 
 def make_jwt(crypto, exp=None, nbf=None, claims=None, customer=None):
@@ -235,9 +84,9 @@ def make_jwt(crypto, exp=None, nbf=None, claims=None, customer=None):
         payload.update(claims)
 
     if exp:
-        payload['exp'] = _datetime_to_timestamp(exp)
+        payload['exp'] = util.datetime_to_timestamp(exp)
     if nbf:
-        payload['nbf'] = _datetime_to_timestamp(nbf)
+        payload['nbf'] = util.datetime_to_timestamp(nbf)
     if customer:
         payload['customer'] = customer
 
@@ -287,76 +136,3 @@ def validate_name_value(name, value):
         )
 
 
-def setup_make_jwt_args(subparsers):
-    parser = subparsers.add_parser(
-        SUBCOMMAND_NAME,
-        description=(
-            'Generate a launch token (JSON Web Token) for encrypting an '
-            'instance or launching an encrypted instance. If a signing key is '
-            'not specified, get a token from the Bracket service. '
-            'A timestamp can be either a '
-            'Unix timestamp in seconds or ISO 8601 (2016-05-10T19:15:36Z). '
-            'Timezone offset defaults to UTC if not specified.'),
-        help=(
-            'Generate a JSON Web Token for encrypting or launching an '
-            'instance'),
-        formatter_class=brkt_cli.SortingHelpFormatter
-    )
-
-    if brkt_cli.crypto.cryptography_library_available:
-        parser.add_argument(
-            'signing_key',
-            metavar='SIGNING-KEY-PATH',
-            nargs='?',
-            help=(
-                'The private key that is used to sign the JWT. The key must '
-                'be a 384-bit ECDSA private key (NIST P-384) in PEM format.'
-            )
-        )
-
-    argutil.add_brkt_tag(parser)
-    parser.add_argument(
-        '--claim',
-        metavar='NAME=VALUE',
-        dest='claims',
-        help=(
-            'JWT claim specified by name and value.  May be specified '
-            'multiple times.'),
-        action='append'
-    )
-
-    parser.add_argument(
-        '--customer',
-        metavar='UUID',
-        type=uuid.UUID,
-        help=(
-            'Required for API access when using a third party JWK server'
-        )
-    )
-    parser.add_argument(
-        '--exp',
-        metavar='TIMESTAMP',
-        help='Token expiration time'
-    )
-    parser.add_argument(
-        '--nbf',
-        metavar='TIMESTAMP',
-        help='Token is not valid before this time'
-    )
-    argutil.add_out(parser)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='make_jwt_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
-
-    # The signing key is now passed as a positional argument.  This option
-    # is deprecated and will be removed in a future release.
-    parser.add_argument(
-        '--signing-key',
-        dest='signing_key_option',
-        metavar='PATH',
-        help=argparse.SUPPRESS
-    )

--- a/brkt_cli/brkt_jwt/test_jwt.py
+++ b/brkt_cli/brkt_jwt/test_jwt.py
@@ -11,42 +11,23 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import time
 import unittest
 import uuid
 from datetime import datetime, timedelta
 
 import iso8601
+import jwt as pyjwt
 
 import brkt_cli.crypto
-import brkt_cli.util
+from brkt_cli import util
 from brkt_cli import brkt_jwt
 from brkt_cli.crypto import test_crypto
 from brkt_cli.validation import ValidationError
-import jwt as pyjwt
 
 if brkt_cli.crypto.cryptography_library_available:
     _crypto = brkt_cli.crypto.from_private_key_pem(
         test_crypto.TEST_PRIVATE_KEY_PEM
     )
-
-
-class TestTimestamp(unittest.TestCase):
-
-    def test_datetime_to_timestamp(self):
-        now = time.time()
-        dt = datetime.fromtimestamp(now, tz=iso8601.UTC)
-        self.assertEqual(now, brkt_jwt._datetime_to_timestamp(dt))
-
-    def test_parse_timestamp(self):
-        ts = int(time.time()) + 10     # JWT timestamps must be in the future
-        dt = datetime.fromtimestamp(ts, tz=iso8601.UTC)
-
-        self.assertEqual(dt, brkt_jwt.parse_timestamp(str(ts)))
-        self.assertEqual(dt, brkt_jwt.parse_timestamp(dt.isoformat()))
-
-        with self.assertRaises(ValidationError):
-            brkt_jwt.parse_timestamp('abc')
 
 
 class TestGenerateJWT(unittest.TestCase):
@@ -88,13 +69,13 @@ class TestGenerateJWT(unittest.TestCase):
         self.assertEqual(1, payload['one'])
         self.assertEqual(2, payload['two'])
 
-        iat = brkt_jwt._timestamp_to_datetime(payload['iat'])
+        iat = util.timestamp_to_datetime(payload['iat'])
         self.assertTrue(now <= iat <= after)
 
-        nbf_result = brkt_jwt._timestamp_to_datetime(payload['nbf'])
+        nbf_result = util.timestamp_to_datetime(payload['nbf'])
         self.assertEqual(nbf, nbf_result)
 
-        exp_result = brkt_jwt._timestamp_to_datetime(payload['exp'])
+        exp_result = util.timestamp_to_datetime(payload['exp'])
         self.assertEqual(exp, exp_result)
 
     def test_malformed(self):
@@ -139,10 +120,10 @@ class TestNameValueToDict(unittest.TestCase):
     def test_name_value_to_dict(self):
         self.assertEqual(
             {'a': 'b', 'c': 'd'},
-            brkt_jwt._name_value_list_to_dict(['a=b', 'c=d'])
+            brkt_jwt.name_value_list_to_dict(['a=b', 'c=d'])
         )
         with self.assertRaises(ValidationError):
-            brkt_jwt._name_value_list_to_dict(['a=b', 'a=c'])
+            brkt_jwt.name_value_list_to_dict(['a=b', 'a=c'])
 
     def test_brkt_tags_from_name_value_list(self):
         self.assertEqual(

--- a/brkt_cli/make_token.py
+++ b/brkt_cli/make_token.py
@@ -1,0 +1,197 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import logging
+import uuid
+
+import brkt_cli
+import brkt_cli.crypto
+from brkt_cli import brkt_jwt, ValidationError, config, util, argutil
+from brkt_cli.subcommand import Subcommand
+from brkt_cli.util import parse_timestamp
+
+log = logging.getLogger(__name__)
+
+SUBCOMMAND_NAME = 'make-token'
+
+
+class MakeTokenSubcommand(Subcommand):
+
+    def __init__(self):
+        self.config = None
+
+    def name(self):
+        return SUBCOMMAND_NAME
+
+    def register(self, subparsers, parsed_config):
+        self.config = parsed_config
+        _setup_args(subparsers)
+
+    def verbose(self, values):
+        return values.make_jwt_verbose
+
+    def run(self, values):
+        if values.signing_key_option:
+            log.warn(
+                'The --signing-key option is deprecated and will be removed '
+                'in a future release.'
+            )
+
+        signing_key = (
+            # The signing_key field doesn't exist if cryptography isn't
+            # installed.
+            getattr(values, 'signing_key', None) or
+            values.signing_key_option
+        )
+        if signing_key:
+            # Original workflow: create a launch token from a private key.
+            if not brkt_cli.crypto.cryptography_library_available:
+                raise ValidationError(
+                    'Token generation from a private key requires the '
+                    'cryptography library.\nPlease run pip install '
+                    'cryptography.'
+                )
+            jwt_string = _make_jwt_from_signing_key(values, signing_key)
+        else:
+            # We're scaling back the list of supported claims.  Don't allow
+            # these until there's a need, and the service API supports it.
+            msg = (
+                '%s is not supported when getting a launch '
+                'token from the Bracket service'
+            )
+            if values.claims:
+                raise ValidationError(msg % '--claim')
+            if values.customer:
+                raise ValidationError(msg % '--customer')
+            if values.exp:
+                raise ValidationError(msg % '--exp')
+            if values.nbf:
+                raise ValidationError(msg % '--nbf')
+
+            # New workflow: get a launch token from Yeti.
+            yeti = config.get_yeti_service(self.config)
+            tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
+            jwt_string = yeti.get_launch_token(tags=tags)
+
+        log.debug('Header: %s', json.dumps(brkt_jwt.get_header(jwt_string)))
+        log.debug('Payload: %s', json.dumps(brkt_jwt.get_payload(jwt_string)))
+        util.write_to_file_or_stdout(jwt_string, path=values.out)
+
+        return 0
+
+
+def get_subcommands():
+    return [MakeTokenSubcommand()]
+
+
+def _make_jwt_from_signing_key(values, signing_key):
+    crypto = brkt_cli.crypto.read_private_key(signing_key)
+    exp = None
+    if values.exp:
+        exp = parse_timestamp(values.exp)
+    nbf = None
+    if values.nbf:
+        nbf = parse_timestamp(values.nbf)
+    customer = None
+    if values.customer:
+        customer = str(values.customer)
+
+    # Merge claims and tags.
+    claims = brkt_jwt.name_value_list_to_dict(values.claims)
+    claims.update(brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags))
+
+    return brkt_jwt.make_jwt(
+        crypto,
+        exp=exp,
+        nbf=nbf,
+        customer=customer,
+        claims=claims
+    )
+
+
+def _setup_args(subparsers):
+    parser = subparsers.add_parser(
+        SUBCOMMAND_NAME,
+        description=(
+            'Generate a launch token (JSON Web Token) for encrypting an '
+            'instance or launching an encrypted instance. If a signing key is '
+            'not specified, get a token from the Bracket service. '
+            'A timestamp can be either a '
+            'Unix timestamp in seconds or ISO 8601 (2016-05-10T19:15:36Z). '
+            'Timezone offset defaults to UTC if not specified.'),
+        help=(
+            'Generate a JSON Web Token for encrypting or launching an '
+            'instance'),
+        formatter_class=brkt_cli.SortingHelpFormatter
+    )
+
+    if brkt_cli.crypto.cryptography_library_available:
+        parser.add_argument(
+            'signing_key',
+            metavar='SIGNING-KEY-PATH',
+            nargs='?',
+            help=(
+                'The private key that is used to sign the JWT. The key must '
+                'be a 384-bit ECDSA private key (NIST P-384) in PEM format.'
+            )
+        )
+
+    argutil.add_brkt_tag(parser)
+    parser.add_argument(
+        '--claim',
+        metavar='NAME=VALUE',
+        dest='claims',
+        help=(
+            'JWT claim specified by name and value.  May be specified '
+            'multiple times.'),
+        action='append'
+    )
+
+    parser.add_argument(
+        '--customer',
+        metavar='UUID',
+        type=uuid.UUID,
+        help=(
+            'Required for API access when using a third party JWK server'
+        )
+    )
+    parser.add_argument(
+        '--exp',
+        metavar='TIMESTAMP',
+        help='Token expiration time'
+    )
+    parser.add_argument(
+        '--nbf',
+        metavar='TIMESTAMP',
+        help='Token is not valid before this time'
+    )
+    argutil.add_out(parser)
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        dest='make_jwt_verbose',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
+
+    # The signing key is now passed as a positional argument.  This option
+    # is deprecated and will be removed in a future release.
+    parser.add_argument(
+        '--signing-key',
+        dest='signing_key_option',
+        metavar='PATH',
+        help=argparse.SUPPRESS
+    )

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -11,8 +11,11 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+from datetime import datetime
 import time
 import unittest
+
+import iso8601
 
 from brkt_cli import util
 from brkt_cli.validation import ValidationError
@@ -144,3 +147,21 @@ class TestRetry(unittest.TestCase):
         """ Test retry based on the exception type. """
         self._get_wrapped(on=[TestException])(5)
         self.assertEqual(6, self.num_calls)
+
+
+class TestTimestamp(unittest.TestCase):
+
+    def test_datetime_to_timestamp(self):
+        now = time.time()
+        dt = datetime.fromtimestamp(now, tz=iso8601.UTC)
+        self.assertEqual(now, util.datetime_to_timestamp(dt))
+
+    def test_parse_timestamp(self):
+        ts = int(time.time()) + 10     # JWT timestamps must be in the future
+        dt = datetime.fromtimestamp(ts, tz=iso8601.UTC)
+
+        self.assertEqual(dt, util.parse_timestamp(str(ts)))
+        self.assertEqual(dt, util.parse_timestamp(dt.isoformat()))
+
+        with self.assertRaises(ValidationError):
+            util.parse_timestamp('abc')


### PR DESCRIPTION
Split the code that handles the make-token subcommand out of the
brkt_jwt module.  This divides responsibility more clearly, and avoids
circular dependencies in JWT library callsites (e.g.
callsite->brkt_jwt->brkt_cli->brkt_jwt).

Also move the timestamp parsing functions into the util module, since
they're called from multiple places.