### PR TITLE
Handle guest image lookup failure with --no-validate

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -269,8 +269,7 @@ def run_encrypt(values, config, verbose=False):
     if values.validate:
         guest_image = _validate_guest_ami(aws_svc, values.ami)
     else:
-        guest_image = aws_svc.get_image(values.ami)
-
+        guest_image = _validate_ami(aws_svc, values.ami)
     encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
     default_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
     tags = merge_aws_tags(values.tags, values.aws_tags)


### PR DESCRIPTION
Call _validate_ami() instead of AWSService.get_image() when validation
is disabled.  This raises ValidationError when the image doesn't exist
and the AWS API returns None.  When the user disables validation, we
still can't proceed without a valid guest image.