### PR TITLE
Expose SSH Key pair for wrap command

### DIFF
--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -41,7 +41,7 @@ def setup_wrap_image_args(parser, parsed_config):
     aws_args.add_security_group(parser)
     aws_args.add_subnet(parser)
     aws_args.add_aws_tag(parser)
-    aws_args.add_key(parser)
+    aws_args.add_key(parser, help='SSH key pair name')
     # Hide optional sub-command level verbose argument. This should be
     # removed once this option is removed at the sub-command level
     parser.add_argument(


### PR DESCRIPTION
For the `wrap-guest-image` command, exposed the SSH Key argument.
In the absence of this argument, users may be unable to connect
to the launched instance.