### PR TITLE
Remove sshpubkeys dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python: "2.7"
 install: >-
   pip install boto boto3 google-api-python-client iso8601 oauthlib
-  pyjwt pyvmomi PyYAML pyflakes requests sshpubkeys
+  pyjwt pyvmomi PyYAML pyflakes requests
 script: ./test-travis
 cache: pip

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -24,8 +24,6 @@ import sys
 import tempfile
 from operator import attrgetter
 
-import sshpubkeys
-
 from brkt_cli import brkt_jwt, util, version
 from brkt_cli.config import CLIConfig, CONFIG_PATH
 from brkt_cli.proxy import Proxy, generate_proxy_config, validate_proxy_config
@@ -262,21 +260,6 @@ def validate_jwt(jwt):
         )
 
     return jwt
-
-
-def validate_ssh_pub_key(key):
-    ssh = sshpubkeys.SSHKey(key)
-    try:
-        if ssh.bits > 0:
-            return True
-        else:
-            raise ValidationError(
-                'Invalid public key: %s' % key
-                )
-    except Exception as e:
-        raise ValidationError(
-            'Unable to validate public key: %s' % e.message
-            )
 
 
 def add_brkt_env_to_brkt_config(brkt_env, brkt_config):

--- a/brkt_cli/crypto/__init__.py
+++ b/brkt_cli/crypto/__init__.py
@@ -110,6 +110,16 @@ def is_private_key(pem):
     return 'PRIVATE KEY' in pem
 
 
+def is_public_key(key):
+    """ Return True if the given key contents resemble an ssh public
+    key.  This a sanity check for validation of command line arguments, as
+    opposed to a rigorous test that parses the key.
+
+    :param key the public key contents as a string
+    """
+    return 'ssh-' in key or 'ecdsa-' in key
+
+
 def read_private_key(pem_path):
     """ Read a private key from a PEM file.
 

--- a/brkt_cli/crypto/test_crypto.py
+++ b/brkt_cli/crypto/test_crypto.py
@@ -17,6 +17,7 @@ import unittest
 from brkt_cli.validation import ValidationError
 
 import brkt_cli.crypto
+from brkt_cli.crypto import is_public_key
 
 if brkt_cli.crypto.cryptography_library_available:
     import cryptography.hazmat.backends.openssl.ec
@@ -211,3 +212,21 @@ class TestReadPrivateKey(unittest.TestCase):
         brkt_cli.crypto.validate_cert(TEST_CERT)
         with self.assertRaises(ValidationError):
             brkt_cli.crypto.validate_cert('foobar')
+
+
+class TestPublicKey(unittest.TestCase):
+
+    def test_is_public_key(self):
+        test_key = (
+            'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdH'
+            'AyNTYAAABBBLqHM4+wprVrOlHvygZSuFcXTfOnWqwVyFGbydUw4oPJ4jOvGcTi'
+            'TF3WPcPJRKUq6E4s6E4yhS3/eOU+YerKY2A= test@example.com'
+        )
+        test_cert = (
+            'cert-authority ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQC6Shl5kUu'
+            'TGqkSc8D2vP2kls2GoB/eGlgIb0BnM/zsIsbw5cWsPournZN2IwnwMhCFLT/56'
+            'CzT9ZzVfn26hxn86KMpg76NcfP5Gnd66dsXHhiMXnBeS9r6KPQeqzVInwE='
+        )
+        self.assertTrue(is_public_key(test_key))
+        self.assertTrue(is_public_key(test_cert))
+        self.assertFalse(is_public_key('Not a public key'))

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -42,10 +42,9 @@ from brkt_cli.util import (
     validate_ip_address,
     validate_dns_name_ip_address
 )
-from brkt_cli import validate_ssh_pub_key
+from brkt_cli import crypto
 from brkt_cli.instance_config import INSTANCE_UPDATER_MODE
 from brkt_cli.validation import ValidationError
-
 
 log = logging.getLogger(__name__)
 logging.getLogger('boto3').setLevel(logging.FATAL)
@@ -853,7 +852,10 @@ class VCenterService(BaseVCenterService):
             if ssh_key_file:
                 with open(ssh_key_file, 'r') as f:
                     key_value = (f.read()).strip()
-                validate_ssh_pub_key(key_value)
+                    if not crypto.is_public_key(key_value):
+                        raise ValidationError(
+                            '%s is not a public key file' % ssh_key_file
+                        )
                 brkt_config['ssh-public-key'] = key_value
             if rescue_proto:
                 brkt_config = dict()

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -18,7 +18,7 @@ import os
 import re
 
 import brkt_cli
-from brkt_cli import argutil
+from brkt_cli import argutil, crypto
 from brkt_cli import util
 from brkt_cli.instance_config import GuestFile
 from brkt_cli.instance_config import INSTANCE_METAVISOR_MODE
@@ -98,13 +98,17 @@ def make(values, config):
     if values.ssh_public_key_file:
         with open(values.ssh_public_key_file, 'r') as f:
             key_value = (f.read()).strip()
-            brkt_cli.validate_ssh_pub_key(key_value)
+            if not crypto.is_public_key(key_value):
+                raise ValidationError(
+                    '%s is not a public key file' % values.ssh_public_key_file
+                )
             instance_cfg.brkt_config['ssh-public-key'] = key_value
 
     ud = instance_cfg.make_userdata()
     if values.base64:
         ud = base64.b64encode(ud)
     return ud
+
 
 class MakeUserDataSubcommand(Subcommand):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ pyjwt >= 1.4.0
 pyvmomi == 5.5.0; python_version <= '2.7.8'
 pyvmomi == 6.0.0; python_version >= '2.7.9'
 PyYAML >= 3.11
-sshpubkeys >= 2.0
 requests >= 2.7.0

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'pyjwt>=1.4.0',
         'pyvmomi==' + pyvmomi_version,
         'PyYaml>=3.11',
-        'sshpubkeys>=2.0',
         'requests>=2.7.0',
     ],
     zip_safe=False,


### PR DESCRIPTION
Remove the dependency on sshpubkeys, to simplify setup and avoid issues
with compiling binaries.  We were only using this library to
sanity-check the public key that is passed via the internal
--ssh-public-key option.

Replace the call to sshpubkeys with a simple string comparison that
checks the key content.