### PR TITLE
Remove --verbose at the subcommand level

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -296,15 +296,6 @@ class SortingHelpFormatter(argparse.HelpFormatter):
         return help
 
 
-def is_verbose(values, subcommand):
-    if subcommand.verbose(values):
-        print(
-            '%s --verbose is deprecated. Please use brkt --verbose '
-            'instead.' % subcommand.name(), file=sys.stderr)
-
-    return values.verbose or subcommand.verbose(values)
-
-
 def main():
     parser = argparse.ArgumentParser(
         description='Command-line interface to the Bracket Computing service.',
@@ -404,13 +395,10 @@ def main():
     if not subcommand:
         raise Exception('Could not find subcommand ' + values.subparser_name)
 
-    # Initialize logging.  Verbose logging can be specified for either
-    # the top-level "brkt" command or one of the subcommands.  We support
-    # both because users got confused when "brkt encrypt-ami -v" didn't work.
+    # Initialize logging.
     log_level = logging.INFO
-    verbose = is_verbose(values, subcommand)
-    subcommand.init_logging(verbose)
-    if verbose:
+    subcommand.init_logging(values.verbose)
+    if values.verbose:
         log_level = logging.DEBUG
 
     # Prefix log messages with a compact timestamp, so that the user

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -47,13 +47,7 @@ def setup_encrypt_ami_args(parser, parsed_config):
     aws_args.add_security_group(parser)
     aws_args.add_subnet(parser)
     aws_args.add_aws_tag(parser)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='aws_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
+
     # Hide deprecated --tag argument
     parser.add_argument(
         '--tag',

--- a/brkt_cli/aws/share_logs_args.py
+++ b/brkt_cli/aws/share_logs_args.py
@@ -11,7 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 
 from brkt_cli.aws import aws_args
 
@@ -51,12 +50,5 @@ def setup_share_logs_args(parser, parsed_config):
         default='logs.tar.gz'
     )
     aws_args.add_no_validate(parser)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='aws_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
     aws_args.add_retry_timeout(parser)
     aws_args.add_retry_initial_sleep_seconds(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -51,13 +51,6 @@ def setup_update_encrypted_ami(parser, parsed_config):
     aws_args.add_subnet(parser)
     aws_args.add_key(parser)
     aws_args.add_aws_tag(parser)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='aws_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
 
     # Hide deprecated --tag argument
     parser.add_argument(

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 from brkt_cli.aws import aws_args
 
 
@@ -42,15 +41,6 @@ def setup_wrap_image_args(parser, parsed_config):
     aws_args.add_subnet(parser)
     aws_args.add_aws_tag(parser)
     aws_args.add_key(parser, help='SSH key pair name')
-    # Hide optional sub-command level verbose argument. This should be
-    # removed once this option is removed at the sub-command level
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='aws_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )
 
     # Optional AMI ID that's used to launch the encryptor instance.  This
     # argument is hidden because it's only used for development.

--- a/brkt_cli/get_public_key/__init__.py
+++ b/brkt_cli/get_public_key/__init__.py
@@ -11,7 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 import logging
 
 import brkt_cli.crypto
@@ -50,16 +49,6 @@ class GetPublicKeySubcommand(Subcommand):
                 'OpenSSL PEM format'
             )
         )
-        parser.add_argument(
-            '-v',
-            '--verbose',
-            dest='make_private_key_verbose',
-            action='store_true',
-            help=argparse.SUPPRESS
-        )
-
-    def verbose(self, values):
-        return values.make_private_key_verbose
 
     def run(self, values):
         crypto = brkt_cli.crypto.read_private_key(values.private_key_path)

--- a/brkt_cli/make_key/__init__.py
+++ b/brkt_cli/make_key/__init__.py
@@ -11,7 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import argparse
 import getpass
 import logging
 
@@ -67,16 +66,6 @@ class MakeKeySubcommand(Subcommand):
             metavar='PATH',
             help='Write the associated public key to a file'
         )
-        parser.add_argument(
-            '-v',
-            '--verbose',
-            dest='make_private_key_verbose',
-            action='store_true',
-            help=argparse.SUPPRESS
-        )
-
-    def verbose(self, values):
-        return values.make_private_key_verbose
 
     def run(self, values):
         passphrase = None

--- a/brkt_cli/make_token.py
+++ b/brkt_cli/make_token.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import json
 import logging
 import uuid
@@ -41,9 +40,6 @@ class MakeTokenSubcommand(Subcommand):
     def register(self, subparsers, parsed_config):
         self.config = parsed_config
         _setup_args(subparsers, parsed_config)
-
-    def verbose(self, values):
-        return values.make_jwt_verbose
 
     def run(self, values):
         # The signing_key field doesn't exist if cryptography isn't
@@ -183,10 +179,3 @@ def _setup_args(subparsers, parsed_config):
         help='Token is not valid before this time'
     )
     argutil.add_out(parser)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        dest='make_jwt_verbose',
-        action='store_true',
-        help=argparse.SUPPRESS
-    )

--- a/brkt_cli/make_user_data/__init__.py
+++ b/brkt_cli/make_user_data/__init__.py
@@ -153,13 +153,6 @@ class MakeUserDataSubcommand(Subcommand):
         )
 
         parser.add_argument(
-            '-v',
-            '--verbose',
-            dest='make_user_data_verbose',
-            action='store_true',
-            help=argparse.SUPPRESS
-        )
-        parser.add_argument(
             '--base64',
             dest='base64',
             action='store_true',
@@ -207,9 +200,6 @@ class MakeUserDataSubcommand(Subcommand):
             help=argparse.SUPPRESS
         )
         argutil.add_out(parser)
-
-    def verbose(self, values):
-        return values.make_user_data_verbose
 
     def run(self, values):
         mime = make(values, self.config)

--- a/brkt_cli/subcommand.py
+++ b/brkt_cli/subcommand.py
@@ -39,14 +39,6 @@ class Subcommand(object):
         """
         pass
 
-    def verbose(self, values):
-        """ Subcommands can optionally implement this callback to specify
-        whether the verbose flag was specified.
-
-        @param values the parsed arguments object
-        """
-        return False
-
     def setup_config(self, config):
         """ Subcommands may add options to the supplied ConfigParser.
         Option values will be pulled from ~/.brkt/config.


### PR DESCRIPTION
Remove the -v/--verbose option from subcommands that used it.  This
option was deprecated in the 1.0.8 release.  Users who need verbose
logging must specify --verbose at the brkt command level.