### PR TITLE
Cluster name is required when using vCenter

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -157,7 +157,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params()
+    vc_swc.validate_vcenter_params(use_esx)
     # Validate that template does not already exist
     if values.template_vm_name:
         if vc_swc.find_vm(values.template_vm_name):
@@ -355,7 +355,7 @@ def run_update(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params()
+    vc_swc.validate_vcenter_params(use_esx)
     if values.template_vm_name:
         if vc_swc.find_vm(values.template_vm_name) is None:
             raise ValidationError("Template VM %s not found" %
@@ -491,7 +491,7 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params()
+    vc_swc.validate_vcenter_params(use_esx)
     # Validate that template does not already exist
     if values.vm_name:
         if vc_swc.find_vm(values.vm_name):

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -186,7 +186,7 @@ class BaseVCenterService(object):
         pass
 
     @abc.abstractmethod
-    def validate_vcenter_params(self):
+    def validate_vcenter_params(self, use_esx=False):
         pass
 
     @abc.abstractmethod
@@ -468,7 +468,7 @@ class VCenterService(BaseVCenterService):
                 raise Exception('Task failed to finish with error %s' %
                                 task.info.error)
 
-    def validate_vcenter_params(self):
+    def validate_vcenter_params(self, use_esx=False):
         content = self.si.RetrieveContent()
         if self.datacenter_name:
             datacenter = self.__get_obj(content, [vim.Datacenter],
@@ -488,6 +488,8 @@ class VCenterService(BaseVCenterService):
             if not cluster:
                 raise ValidationError("Cluster %s not found",
                                       self.cluster_name)
+        elif not use_esx:
+            raise ValidationError("Cluster name required when using vCenter")
 
     def find_vm(self, vm_name):
         self.validate_connection()


### PR DESCRIPTION
When using vCenter specific command, ensure that the vCenter
cluster name is specified or raise a validation error for the
same.