### PR TITLE
Update default AWS instance types

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -75,7 +75,7 @@ class BaseAWSService(object):
     def run_instance(self,
                      image_id,
                      security_group_ids=None,
-                     instance_type='c3.xlarge',
+                     instance_type='c4.xlarge',
                      placement=None,
                      block_device_map=None,
                      subnet_id=None,
@@ -310,7 +310,7 @@ class AWSService(BaseAWSService):
     def run_instance(self,
                      image_id,
                      security_group_ids=None,
-                     instance_type='c3.xlarge',
+                     instance_type='c4.xlarge',
                      placement=None,
                      block_device_map=None,
                      subnet_id=None,
@@ -737,7 +737,7 @@ def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
 
 
 def run_guest_instance(aws_svc, image_id, subnet_id=None,
-                       instance_type='m3.medium'):
+                       instance_type='m4.large'):
     instance = None
 
     try:

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -439,7 +439,7 @@ def _register_ami(aws_svc, encryptor_instance, encryptor_image, name,
 
 def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            guest_instance_type='m3.medium', instance_config=None,
+            guest_instance_type='m4.large', instance_config=None,
             save_encryptor_logs=True,
             status_port=encryptor_service.ENCRYPTOR_STATUS_PORT,
             terminate_encryptor_on_failure=True):

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -40,7 +40,7 @@ def setup_encrypt_ami_args(parser, parsed_config):
         help=(
             'The instance type to use when running the unencrypted guest '
             'instance'),
-        default='m3.medium'
+        default='m4.large'
     )
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)

--- a/brkt_cli/aws/share_logs.py
+++ b/brkt_cli/aws/share_logs.py
@@ -108,7 +108,7 @@ def share(aws_svc=None, logs_svc=None, instance_id=None, region=None,
 
         # Launch new instance, with volume and startup script
         new_instance = aws_svc.run_instance(
-            image_id, instance_type='m3.medium', block_device_map=bdm,
+            image_id, instance_type='m4.large', block_device_map=bdm,
             user_data=amzn, ebs_optimized=False)
 
         # wait for instance to launch

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -103,7 +103,7 @@ class DummyAWSService(aws_service.BaseAWSService):
     def run_instance(self,
                      image_id,
                      security_group_ids=None,
-                     instance_type='c3.xlarge',
+                     instance_type='c4.xlarge',
                      placement=None,
                      block_device_map=None,
                      subnet_id=None,

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -257,17 +257,17 @@ class TestRunEncryption(unittest.TestCase):
         self.assertTrue(self.security_group_was_created)
 
     def test_instance_type(self):
-        """ Test that we launch the guest as m3.medium and the encryptor
-        as c3.xlarge.
+        """ Test that we launch the guest as m4.large and the encryptor
+        as c4.xlarge.
         """
         aws_svc, encryptor_image, guest_image = build_aws_service()
 
         def run_instance_callback(args):
             if args.image_id == guest_image.id:
-                self.assertEqual('m3.medium', args.instance_type)
+                self.assertEqual('m4.large', args.instance_type)
                 self.assertFalse(args.ebs_optimized)
             elif args.image_id == encryptor_image.id:
-                self.assertEqual('c3.xlarge', args.instance_type)
+                self.assertEqual('c4.xlarge', args.instance_type)
                 self.assertTrue(args.ebs_optimized)
             else:
                 self.fail('Unexpected image id: ' + args.image_id)

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -85,7 +85,7 @@ class TestRunUpdate(unittest.TestCase):
             if args.image_id == encrypted_ami_id:
                 self.assertEqual('t2.micro', args.instance_type)
             elif args.image_id == encryptor_image.id:
-                self.assertEqual('m3.medium', args.instance_type)
+                self.assertEqual('m4.large', args.instance_type)
             else:
                 self.fail('Unexpected image: ' + args.image_id)
 

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -125,15 +125,15 @@ class TestRunEncryption(unittest.TestCase):
         self.assertTrue(self.security_group_was_created)
 
     def test_default_instance_type(self):
-        """ Test that we launch the wrapped guest as m3.medium by default
+        """ Test that we launch the wrapped guest as m4.large by default
         """
         aws_svc, encryptor_image, guest_image = build_aws_service()
 
         def run_instance_callback(args):
             if args.image_id == guest_image.id:
-                self.assertEqual('m3.medium', args.instance_type)
+                self.assertEqual('m4.large', args.instance_type)
             elif args.image_id == encryptor_image.id:
-                self.assertEqual('m3.medium', args.instance_type)
+                self.assertEqual('m4.large', args.instance_type)
             else:
                 self.fail('Unexpected image id: ' + args.image_id)
 

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -53,8 +53,8 @@ log = logging.getLogger(__name__)
 def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
                subnet_id=None, security_group_ids=None,
                enc_svc_class=encryptor_service.EncryptorService,
-               guest_instance_type='m3.medium',
-               updater_instance_type='m3.medium',
+               guest_instance_type='m4.large',
+               updater_instance_type='m4.large',
                instance_config=None,
                status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
     encrypted_guest = None

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -34,19 +34,16 @@ def setup_update_encrypted_ami(parser, parsed_config):
         '--guest-instance-type',
         metavar='TYPE',
         dest='guest_instance_type',
-        help=(
-            'The instance type to use when running the encrypted guest '
-            'instance. Default: m3.medium'),
-        default='m3.medium'
+        help='The instance type to use when running the encrypted guest '
+             'instance',
+        default='m4.large'
     )
     parser.add_argument(
         '--updater-instance-type',
         metavar='TYPE',
         dest='updater_instance_type',
-        help=(
-            'The instance type to use when running the updater '
-            'instance. Default: m3.medium'),
-        default='m3.medium'
+        help='The instance type to use when running the updater instance',
+        default='m4.large'
     )
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -102,7 +102,7 @@ def create_instance_security_group(aws_svc, vpc_id=None):
 
 def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
                          wrapped_instance_name=None, subnet_id=None,
-                         security_group_ids=None, instance_type='m3.medium',
+                         security_group_ids=None, instance_type='m4.large',
                          instance_config=None):
     temp_sg_id = None
     guest_image = aws_svc.get_image(image_id)

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -34,7 +34,7 @@ def setup_wrap_image_args(parser, parsed_config):
         metavar='TYPE',
         dest='instance_type',
         help='The instance type to use when launching the wrapped image',
-        default='m3.medium'
+        default='m4.large'
     )
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)


### PR DESCRIPTION
Use modern AWS instance types that are supported in all regions.
Default the guest instance to m4.large and use c4.xlarge for the
encryptor/updater.