### PR TITLE
Expose the --ca-cert option

### DIFF
--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -114,9 +114,12 @@ def setup_instance_config_args(parser, parsed_config,
     # or provided via userdata to a MV with an unencrypted guest root.
     parser.add_argument(
         '--ca-cert',
-        metavar='CERT_FILE',
+        metavar='PATH',
         dest='ca_cert',
-        help=argparse.SUPPRESS
+        help=(
+            'Certificate that Metavisor uses to communicate with a '
+            'Customer Managed MCP.'
+        )
     )
 
     token_group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Expose --ca-cert for users who run the Bracket MCP on site.