### PR TITLE
Optional IAM role for wrapped instance

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -164,6 +164,10 @@ def run_wrap_image(values, config):
     else:
         guest_image = aws_svc.get_image(values.ami)
 
+    if values.iam:
+        if not aws_svc.iam_role_exists(values.iam):
+            raise ValidationError('IAM role %s does not exist' % values.iam)
+
     metavisor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
     if values.validate:
         values.encrypted_ami_name = None
@@ -186,7 +190,8 @@ def run_wrap_image(values, config):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         instance_type=values.instance_type,
-        instance_config=instance_config
+        instance_config=instance_config,
+        iam=values.iam
     )
     # Print the Instance ID to stdout, in case the caller wants to process
     # the output. Log messages go to stderr

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -52,6 +52,7 @@ class RunInstanceArgs(object):
         self.subnet_id = None
         self.user_data = None
         self.instance = None
+        self.instance_profile_name = None
 
 
 class DummyAWSService(aws_service.BaseAWSService):
@@ -142,6 +143,7 @@ class DummyAWSService(aws_service.BaseAWSService):
             args.subnet_id = subnet_id
             args.user_data = user_data
             args.instance = instance
+            args.instance_profile_name = instance_profile_name
             self.run_instance_callback(args)
 
         return instance
@@ -355,6 +357,12 @@ class DummyAWSService(aws_service.BaseAWSService):
         if attribute == 'sriovNetSupport':
             return dict()
         return None
+
+    def iam_role_exists(self, role):
+        if role == 'brkt-objectstore':
+            return True
+        else:
+            return False
 
     def modify_instance_attribute(self, instance_id, attribute, value, dry_run=False):
         if attribute == 'sriovNetSupport':

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -162,6 +162,23 @@ class TestRunEncryption(unittest.TestCase):
             instance_type='t2.micro'
         )
 
+    def test_iam_role(self):
+        """ Test that the IAM role is passed to the calls to
+        AWSService.run_instance().
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        def run_instance_callback(args):
+            self.assertEqual('valid', args.instance_profile_name)
+
+        aws_svc.run_instance_callback = run_instance_callback
+        wrap_image.launch_wrapped_image(
+            aws_svc=aws_svc,
+            image_id=guest_image.id,
+            metavisor_ami=encryptor_image.id,
+            iam='valid'
+        )
+
 
 class TestBrktEnv(unittest.TestCase):
 

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -103,7 +103,7 @@ def create_instance_security_group(aws_svc, vpc_id=None):
 def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
                          wrapped_instance_name=None, subnet_id=None,
                          security_group_ids=None, instance_type='m4.large',
-                         instance_config=None):
+                         instance_config=None, iam=None):
     temp_sg_id = None
     guest_image = aws_svc.get_image(image_id)
     guest_root_device = guest_image.root_device_name
@@ -166,7 +166,8 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
             placement=None,
             block_device_map=bdm,
             ebs_optimized=ebs_optimized,
-            subnet_id=subnet_id
+            subnet_id=subnet_id,
+            instance_profile_name=iam
         )
         aws_svc.create_tags(
             instance.id,

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -46,6 +46,13 @@ def setup_wrap_image_args(parser, parsed_config):
     # argument is hidden because it's only used for development.
     aws_args.add_encryptor_ami(parser)
 
+    # Optional IAM role for the instance
+    parser.add_argument(
+        '--iam',
+        metavar='ROLE',
+        dest='iam',
+        help='The IAM role to use for the launched instance',
+    )
     # Optional arguments for changing the behavior of our retry logic.  We
     # use these options internally, to avoid intermittent AWS service failures
     # when running concurrent encryption processes in integration tests.


### PR DESCRIPTION
Added an optional `--iam` argument which can be specified when
launching a wrapped instance. The specified IAM role is validated
before instance launch. This is useful when launching wrapped
instances to be used with Bracket Object store or other services
that depend on an instance IAM role.