### PR TITLE
Documentation Updates

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -54,7 +54,7 @@ Run **brkt aws encrypt** to create a new encrypted AMI based on an existing
 image:
 
 ```
-$ brkt aws encrypt --region us-east-1 --token <token> ami-76e27e1e
+$ brkt aws encrypt --region us-east-1 --brkt-tag env=prod ami-76e27e1e
 15:28:37 Starting encryptor session caabe51a
 15:28:38 Launching instance i-703f4c99 to snapshot root disk for ami-76e27e1e
 ...
@@ -74,7 +74,7 @@ Run **brkt aws update** to update an encrypted AMI based on an existing
 encrypted image:
 
 ```
-$ brkt aws update --region us-east-1 --token <token> ami-72094e18
+$ brkt aws update --region us-east-1 --brkt-tag env=prod ami-72094e18
 13:38:14 Using zone us-east-1a
 13:38:15 Updating ami-72094e18
 13:38:15 Creating guest volume snapshot
@@ -99,7 +99,7 @@ image. This generates an encrypted instance, without the guest root
 volume being encrypted.
 
 ```
-$ brkt aws wrap-guest-image --region us-east-1 --token <token> ami-72094e18
+$ brkt aws wrap-guest-image --region us-east-1 --brkt-tag env=prod ami-72094e18
 18:50:33 Created security group with id sg-d821d2a3
 18:50:34 Launching wrapped guest instance i-039dba15316de37a0
 18:50:53 Done.
@@ -251,9 +251,11 @@ version of the Metavisor code.
 
 ```
 usage: brkt aws wrap-guest-image [-h] [--wrapped-instance-name NAME]
-                                 [--instance-type TYPE] [--no-validate] --region
-                                 NAME [--security-group ID] [--subnet ID]
-                                 [--aws-tag KEY=VALUE] [--ntp-server DNS_NAME]
+                                 [--instance-type TYPE] [--no-validate]
+                                 --region NAME [--security-group ID]
+                                 [--subnet ID] [--aws-tag KEY=VALUE]
+                                 [--key NAME] [--iam ROLE]
+                                 [--ntp-server DNS_NAME]
                                  [--proxy HOST:PORT | --proxy-config-file PATH]
                                  [--status-port PORT]
                                  [--token TOKEN | --brkt-tag NAME=VALUE]
@@ -279,6 +281,8 @@ optional arguments:
   --subnet ID           Launch instances in this subnet
   --aws-tag KEY=VALUE   Set an AWS tag on resources created during update. May
                         be specified multiple times.
+  --key NAME            SSH key pair name
+  --iam ROLE            The IAM role to use for the launched instance
   --ntp-server DNS_NAME
                         NTP server to sync Metavisor clock. May be specified
                         multiple times.

--- a/esx.md
+++ b/esx.md
@@ -330,7 +330,7 @@ Run **brkt vmware encrypt-with-vcenter** to create a new encrypted VMDK based on
 VMDK:
 
 ```
-$ ./brkt vmware encrypt-with-vcenter --token <token> --vcenter-host <vcenter_host> --template-vm-name encrypt-vmdk-test --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name> centos66/centos66.vmdk
+$ brkt vmware encrypt-with-vcenter --brkt-tag env=prod --vcenter-host <vcenter_host> --template-vm-name encrypt-vmdk-test --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name> centos66/centos66.vmdk
 18:35:20 Fetching Metavisor OVF from S3
 18:35:31 Launching VM from OVF ./c4ca122117c9f0bb.ovf
 18:35:37 Starting new HTTPS connection (1): 10.9.1.216
@@ -359,7 +359,7 @@ Run **brkt vmware update-with-vcenter** to update an encrypted VMDK with the
 latest Metavisor using vCenter:
 
 ```
-$ brkt vmware update-with-vcenter --token <token> --vcenter-host <vcenter_host> --template-vm-name encrypt-vmdk-test --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name>
+$ brkt vmware update-with-vcenter --brkt-tag env=prod --vcenter-host <vcenter_host> --template-vm-name encrypt-vmdk-test --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name>
 17:08:40 Fetching Metavisor OVF from S3
 17:21:09 Launching encrypted guest VM
 17:34:12 Launching VM from OVF ./c4ca122117c9f0bb.ovf
@@ -392,7 +392,7 @@ Run **brkt vmware wrap-with-vcenter** to wrap an guest VMDK with the latest
 Metavisor using vCenter:
 
 ```
-$ brkt vmware wrap-with-vcenter --token <token> --vcenter-host <vcenter_host> --vm-name wrap-vmdk-test  --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name> centos66/centos66.vmdk
+$ brkt vmware wrap-with-vcenter --brkt-tag env=prod --vcenter-host <vcenter_host> --vm-name wrap-vmdk-test  --vcenter-datacenter <datacenter_name> --vcenter-datastore <datastore_name> --vcenter-cluster <cluster_name> centos66/centos66.vmdk
 02:58:07 Fetching Metavisor OVF from S3
 03:00:17 Launching VM from OVF metavisor-1-0-100-gcaf72844f.ovf
 /usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
@@ -652,7 +652,7 @@ Run **brkt vmware encrypt-with-esx-host** to create an encrypted VM with the
 latest Metavisor on an ESX host:
 
 ```
-$ brkt vmware encrypt-with-esx-host --token <token> --esx-host <HOST> --esx-datastore <datastore> --encrypted-image-directory=<PATH> --encrypted-image-name=centos66encrypted_ovf  centos66-stock/centos66-stock.vmdk --template-vm-name brkt-esx-encrypted-vm
+$ brkt vmware encrypt-with-esx-host --brkt-tag env=prod --esx-host <HOST> --esx-datastore <datastore> --encrypted-image-directory=<PATH> --encrypted-image-name=centos66encrypted_ovf  centos66-stock/centos66-stock.vmdk --template-vm-name brkt-esx-encrypted-vm
 16:49:25 Fetching Metavisor OVF from S3
 16:49:34 Launching VM from OVF ./c4ca122117c9f0bb.ovf
 16:49:35 Starting new HTTPS connection (1): 10.9.1.216
@@ -679,7 +679,8 @@ Run **brkt vmware encrypt-with-esx-host** to create an encrypted OVF image with
 the latest Metavisor on an ESX host.
 
 ```
-$ brkt vmware encrypt-with-esx-host --token <token> --esx-host <HOST> --esx-datastore <datastore> --encrypted-image-directory=<PATH> --create-ovf --encrypted-image-name centos66encrypted --ovftool-path /usr/bin/ovftool centos66/centos66.vmdk
+$ brkt vmware encrypt-with-esx-host --brkt-tag env=prod --esx-host <HOST> --esx-datastore <datastore> --encrypted-image-directory=<PATH> --create-ovf --encrypted-image-name centos66encrypted --ovftool-path /usr/bin/ovftool centos66/centos66.vmdk
+
 17:06:25 Fetching Metavisor OVF from S3
 17:06:34 Launching VM from OVF ./c4ca122117c9f0bb.ovf
 17:06:41 Starting new HTTPS connection (1): 10.9.1.216
@@ -714,7 +715,7 @@ Run **brkt vmware wrap-with-esx-host** to launch an encrypted instance which wra
 the unencrypted guest image (VMDK)
 
 ```
-$ brkt vmware wrap-with-esx-host --token <token> --esx-host <HOST> --esx-datastore <datastore> --vm-name test-wrap-image centos66/centos66.vmdk
+$ brkt vmware wrap-with-esx-host --brkt-tag env=prod --esx-host <HOST> --esx-datastore <datastore> --vm-name test-wrap-image centos66/centos66.vmdk
 22:56:47 Fetching Metavisor OVF from S3
 22:57:03 Launching VM from OVF metavisor-1-0-80-g14a5ec1a0.ovf
 /usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings

--- a/gce.md
+++ b/gce.md
@@ -292,7 +292,7 @@ you specify with the **--status-port** option in the default network
 Run **gcp encrypt** to encrypt an image:
 
 ```
-$ brkt gcp encrypt --zone us-central1-a --project brkt-dev --token <token> --image-project ubuntu-os-cloud ubuntu-1404-trusty-v20160627
+$ brkt gcp encrypt --zone us-central1-a --project brkt-dev --brkt-tag env=prod --image-project ubuntu-os-cloud ubuntu-1404-trusty-v20160627
 ...
 14:30:23 Starting encryptor session 59e3b3a7
 ...
@@ -319,7 +319,7 @@ Run **gcp update** to update an encrypted image with the latest
 Metavisor code:
 
 ```
-$ brkt gcp update --zone us-central1-a --project brkt-dev --token <token> ubuntu-1404-trusty-v20160627-encrypted-ee521b31
+$ brkt gcp update --zone us-central1-a --project brkt-dev --brkt-tag env=prod ubuntu-1404-trusty-v20160627-encrypted-ee521b31
 ...
 15:50:04 Starting updater session 80985e58
 ...
@@ -340,7 +340,7 @@ ubuntu-1404-trusty-v20160627-encrypted-63e57e6e
 Run **gcp launch** to launch an encrypted GCP image
 
 ```
-$ brkt gcp launch --instance-name brkt-test-instance --project <project> --token <token> --zone us-central1-c centos-6-v20160921-encrypted-30fccdeb
+$ brkt gcp launch --instance-name brkt-test-instance --project <project> --brkt-tag env=prod --zone us-central1-c centos-6-v20160921-encrypted-30fccdeb
 18:13:54 Creating guest root disk from snapshot
 18:13:54 Attempting refresh to obtain initial access_token
 18:13:54 Refreshing access_token
@@ -366,7 +366,7 @@ Run **gcp wrap-guest-image** to launch a guest image wrapped with the Bracket
 Metavisor
 
 ```
-$ brkt gcp wrap-guest-image --project <project> --token <token> --zone us-central1-c centos-6-v20170327
+$ brkt gcp wrap-guest-image --project <project> --brkt-tag env=prod --zone us-central1-c centos-6-v20170327
 19:44:47 Retrieving encryptor image from GCP bucket
 19:44:47 Attempting refresh to obtain initial access_token
 19:44:47 Refreshing access_token


### PR DESCRIPTION
Updated documentation to reflect the new CLI usage by using the
`--brkt-tag` argument with the various commands. The `--brkt-tag`
can be used once the user can run `brkt auth`, generated an API
token and set the `$BRKT_API_TOKEN` environment variable with the
corresponding output.