### PR TITLE
Remove deprecated --tag option

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -223,10 +223,10 @@ def run_encrypt(values, config, verbose=False):
     else:
         guest_image = _validate_ami(aws_svc, values.ami)
     encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
-    default_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
-    tags = merge_aws_tags(values.tags, values.aws_tags)
-    default_tags.update(brkt_cli.parse_tags(tags))
-    aws_svc.default_tags = default_tags
+    aws_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
+    command_line_tags = brkt_cli.parse_tags(values.aws_tags)
+    aws_tags.update(command_line_tags)
+    aws_svc.default_tags = aws_tags
 
     if values.validate:
         _validate(aws_svc, values, encryptor_ami)
@@ -312,10 +312,10 @@ def run_update(values, config, verbose=False):
     aws_svc.connect(values.region, key_name=values.key_name)
     encrypted_image = _validate_ami(aws_svc, values.ami)
     encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region)
-    default_tags = encrypt_ami.get_default_tags(nonce, encryptor_ami)
-    tags = merge_aws_tags(values.tags, values.aws_tags)
-    default_tags.update(brkt_cli.parse_tags(tags))
-    aws_svc.default_tags = default_tags
+    aws_tags = encrypt_ami.get_default_tags(nonce, encryptor_ami)
+    command_line_tags = brkt_cli.parse_tags(values.aws_tags)
+    aws_tags.update(command_line_tags)
+    aws_svc.default_tags = aws_tags
 
     if values.validate:
         _validate_guest_encrypted_ami(
@@ -707,24 +707,3 @@ def _get_updated_image_name(image_name, session_id):
         encrypted_ami_name = util.append_suffix(
             image_name, suffix, max_length=128)
     return encrypted_ami_name
-
-
-def merge_aws_tags(old_tags, new_tags):
-    """ Merge the attribute values for the old and new tag arguments to a
-    single attribute list.
-
-    : return the merged attribute list or None
-    """
-    if old_tags:
-        log.warn(
-                 'The "--tag" argument has been deprecated. Please use '
-                 '"--aws-tag" instead.'
-        )
-        if new_tags:
-            return set(old_tags + new_tags)
-        else:
-            return old_tags
-    elif new_tags:
-        return new_tags
-    else:
-        return None

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -47,16 +47,6 @@ def setup_encrypt_ami_args(parser, parsed_config):
     aws_args.add_security_group(parser)
     aws_args.add_subnet(parser)
     aws_args.add_aws_tag(parser)
-
-    # Hide deprecated --tag argument
-    parser.add_argument(
-        '--tag',
-        metavar='KEY=VALUE',
-        dest='tags',
-        action='append',
-        help=argparse.SUPPRESS
-    )
-
     aws_args.add_encryptor_ami(parser)
     aws_args.add_key(parser)
     aws_args.add_retry_timeout(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -12,8 +12,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-
 from brkt_cli.aws import aws_args
 
 
@@ -51,16 +49,6 @@ def setup_update_encrypted_ami(parser, parsed_config):
     aws_args.add_subnet(parser)
     aws_args.add_key(parser)
     aws_args.add_aws_tag(parser)
-
-    # Hide deprecated --tag argument
-    parser.add_argument(
-        '--tag',
-        metavar='KEY=VALUE',
-        dest='tags',
-        action='append',
-        help=argparse.SUPPRESS
-    )
-
     aws_args.add_encryptor_ami(parser)
     aws_args.add_retry_timeout(parser)
     aws_args.add_retry_initial_sleep_seconds(parser)


### PR DESCRIPTION
Remove the old --tag option, which was replaced by --aws-tag.