### PR TITLE
Add an aws.subnet config option

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -403,8 +403,12 @@ class AWSSubcommand(Subcommand):
 
     def setup_config(self, config):
         config.register_option(
-            '%s.region' % self.name(),
+            'aws.region',
             'The AWS region metavisors will be launched into')
+        config.register_option(
+            'aws.subnet',
+            'The AWS subnet metavisors will be launched into'
+        )
 
     def register(self, subparsers, parsed_config):
         self.config = parsed_config

--- a/brkt_cli/aws/aws_args.py
+++ b/brkt_cli/aws/aws_args.py
@@ -47,12 +47,13 @@ def add_security_group(parser):
     )
 
 
-def add_subnet(parser):
+def add_subnet(parser, parsed_config):
     parser.add_argument(
         '--subnet',
         metavar='ID',
         dest='subnet_id',
-        help='Launch instances in this subnet'
+        help='Launch instances in this subnet',
+        default=parsed_config.get_option('aws.subnet')
     )
 
 

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -45,7 +45,7 @@ def setup_encrypt_ami_args(parser, parsed_config):
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
     aws_args.add_security_group(parser)
-    aws_args.add_subnet(parser)
+    aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
     aws_args.add_encryptor_ami(parser)
     aws_args.add_key(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -46,7 +46,7 @@ def setup_update_encrypted_ami(parser, parsed_config):
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
     aws_args.add_security_group(parser)
-    aws_args.add_subnet(parser)
+    aws_args.add_subnet(parser, parsed_config)
     aws_args.add_key(parser)
     aws_args.add_aws_tag(parser)
     aws_args.add_encryptor_ami(parser)

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -38,7 +38,7 @@ def setup_wrap_image_args(parser, parsed_config):
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
     aws_args.add_security_group(parser)
-    aws_args.add_subnet(parser)
+    aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
     aws_args.add_key(parser, help='SSH key pair name')
 


### PR DESCRIPTION
Add an aws.subnet config option for defaulting the subnet when
encrypting, updating, or wrapping an image.