### PR TITLE
Fix configuration of static IP for encryption

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -53,9 +53,6 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         mv_vm_name = vc_swc.get_vm_name(vm)
         # Reconfigure VM with more CPUs and memory
         vc_swc.reconfigure_vm_cpu_ram(vm)
-        # Reconfigure VM with serial port
-        if serial_port_file_name:
-            vc_swc.add_serial_port_to_file(vm, serial_port_file_name)
         # Add datastore path to the guest vmdk
         guest_vmdk_path = vc_swc.get_datastore_path(guest_vmdk)
         # Attach guest vmdk
@@ -71,7 +68,12 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         vc_swc.add_disk(vm, disk_size=encrypted_guest_size, unit_number=1)
         # Configure Static IP for the encryptor VM
         if static_ip:
+            vc_swc.power_on(vm)
+            vc_swc.power_off(vm)
             vc_swc.configure_static_ip(vm, static_ip)
+        # Reconfigure VM with serial port
+        if serial_port_file_name:
+            vc_swc.add_serial_port_to_file(vm, serial_port_file_name)
         # Power on the VM and wait for encryption
         vc_swc.power_on(vm)
         # Send user data

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -581,7 +581,7 @@ class VCenterService(BaseVCenterService):
                                    memoryMB=(memoryGB*1024),
                                    numCPUs=numCPUs,
                                    files=vmx_file,
-                                   guestId='otherGuest64',
+                                   guestId='otherLinuxGuest64',
                                    version='vmx-11',
                                    deviceChange=dev_changes)
         task = vmfolder.CreateVM_Task(config=config, pool=pool)
@@ -602,6 +602,7 @@ class VCenterService(BaseVCenterService):
 
     def configure_static_ip(self, vm, static_ip):
         self.validate_connection()
+        log.info("Configuring static IP address")
         adaptermap = vim.vm.customization.AdapterMapping()
         globalip = vim.vm.customization.GlobalIPSettings()
         adaptermap.adapter = vim.vm.customization.IPSettings()
@@ -611,9 +612,10 @@ class VCenterService(BaseVCenterService):
         adaptermap.adapter.gateway = static_ip.gw
         globalip.dnsServerList = static_ip.dns
         adaptermap.adapter.dnsDomain = static_ip.dns_domain
+        fixedname = 'brkt-' + self.session_id
         ident = vim.vm.customization.LinuxPrep(
             domain=static_ip.dns_domain,
-            hostName=vim.vm.customization.FixedName(name=vm.config.name))
+            hostName=vim.vm.customization.FixedName(name=fixedname))
         customspec = vim.vm.customization.Specification()
         customspec.identity = ident
         customspec.nicSettingMap = [adaptermap]


### PR DESCRIPTION
1. Configuration of static ip requires first power on
and then power off before it can be done.
2. Add console file after static ip configuration.
3. Set a static host name.

Updater does not work yet with static IP.