### PR TITLE
Allow make-token times specified in days, months, years

### DIFF
--- a/brkt_cli/make_token.py
+++ b/brkt_cli/make_token.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import uuid
+from dateutil.parser import parse
 
 import brkt_cli
 import brkt_cli.crypto
@@ -100,6 +101,12 @@ def _make_jwt_from_signing_key(values, signing_key):
     nbf = None
     if values.nbf:
         nbf = parse_timestamp(values.nbf)
+    if exp and nbf:
+        exp_time = parse(str(exp))
+        nbf_time = parse(str(nbf))
+        if exp_time < nbf_time:
+            raise ValidationError(
+                "exp value cannot be earlier than nbf")
     customer = None
     if values.customer:
         customer = str(values.customer)

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -163,5 +163,13 @@ class TestTimestamp(unittest.TestCase):
         self.assertEqual(dt, util.parse_timestamp(str(ts)))
         self.assertEqual(dt, util.parse_timestamp(dt.isoformat()))
 
+        ts = int(time.time()) + 18000 # 5 hours from now
+        dt1 = datetime.fromtimestamp(ts, tz=iso8601.UTC)
+        dur = util.parse_timestamp('5h')
+        ts = int(time.time()) + 18000 # 5 hours from now
+        dt2 = datetime.fromtimestamp(ts, tz=iso8601.UTC)
+        self.assertLessEqual(dt1, dur)
+        self.assertGreaterEqual(dt2, dur)
+
         with self.assertRaises(ValidationError):
             util.parse_timestamp('abc')


### PR DESCRIPTION
Allow the expiry timestamp and not valid before timestamp to be
specified in user friendly manner of relative hour, day, week,
month or year.