### PR TITLE
Enable sriovNetSupport for AWS wrapped instances

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -94,6 +94,10 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
+    def start_instance(self, instance_id):
+        pass
+
+    @abc.abstractmethod
     def stop_instance(self, instance_id):
         pass
 
@@ -366,6 +370,12 @@ class AWSService(BaseAWSService):
         log.debug('Tagging %s with %s', resource_id, tags)
         create_tags = self.retry(self.conn.create_tags, r'.*\.NotFound')
         create_tags([resource_id], tags)
+
+    def start_instance(self, instance_id):
+        log.debug('Starting instnace %s', instance_id)
+        start_instances = self.retry(self.conn.start_instances)
+        instances = start_instances([instance_id])
+        return instances[0]
 
     def stop_instance(self, instance_id):
         log.debug('Stopping instance %s', instance_id)

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -90,6 +90,7 @@ class DummyAWSService(aws_service.BaseAWSService):
         self.create_snapshot_callback = None
         self.get_snapshot_callback = None
         self.delete_snapshot_callback = None
+        self.start_instance_callback = None
         self.stop_instance_callback = None
         self.create_tags_callback = None
         self.terminate_instance_callback = None
@@ -169,6 +170,15 @@ class DummyAWSService(aws_service.BaseAWSService):
         if self.create_tags_callback:
             self.create_tags_callback(resource_id, name, description)
         pass
+
+    def start_instance(self, instance_id):
+        instance = self.instances[instance_id]
+        if self.start_instance_callback:
+            self.start_instance_callback(instance)
+
+        instance._state.code = 0
+        instance._state.name = 'running'
+        return instance
 
     def stop_instance(self, instance_id):
         instance = self.instances[instance_id]

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -83,11 +83,15 @@ class TestRunEncryption(unittest.TestCase):
         calls to AWSService.run_instance().
         """
 
+        def start_instance_callback(instance):
+            self.instance_stopped = True
+
         def run_instance_callback(args):
             self.assertEqual('subnet-1', args.subnet_id)
             self.assertEqual(['sg-1', 'sg-2'], args.security_group_ids)
 
         aws_svc, encryptor_image, guest_image = build_aws_service()
+        aws_svc.start_instance_callback = start_instance_callback
         aws_svc.run_instance_callback = run_instance_callback
         wrap_image.launch_wrapped_image(
             aws_svc=aws_svc,


### PR DESCRIPTION
If the AWS wrapped instance does not have sriovNetSupport enabled,
then stop the instance (which is required) and try to enable the
same. Report an error if sriovNetSupport cannot be enabled, but
leave the instance running as the only drawback is that the
network performance might not be optimal.