### PR TITLE
Temporary change to debug hung threads

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -27,6 +27,7 @@ Before running brkt encrypt-vmdk, do "pip install pyvmomi".
 """
 
 import logging
+import threading
 from brkt_cli.encryptor_service import (
     wait_for_encryptor_up,
     wait_for_encryption,
@@ -158,6 +159,12 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
                 if vm is not None:
                     vc_swc.destroy_vm(vm)
         log.info("Done")
+        # Temporary hack to debug hung threads
+        t_list = threading.enumerate()
+        for thread_e in t_list:
+            log.info("Thread name: %s Daemon: %d IsAlive %d",
+                     thread_e.name, thread_e.daemon,
+                     thread_e.is_alive())
 
 
 def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -936,7 +936,7 @@ class VCenterService(BaseVCenterService):
                 file_name = url.url[url.url.rfind('/') + 1:]
                 target_file = os.path.join(target_path, file_name)
                 keepalive_thread = Thread(target=self.keep_lease_alive,
-                                          args=(lease,))
+                                          args=(lease,), name="keepalive-export")
                 keepalive_thread.start()
                 # Disable verification as VMDK download happens directly
                 # from the ESX host.
@@ -1095,7 +1095,8 @@ class VCenterService(BaseVCenterService):
                 if vm:
                     self.destroy_vm(vm)
                 raise Exception("Failed to get lease to upload OVF")
-        keepalive_thread = Thread(target=self.keep_lease_alive, args=(lease,))
+        keepalive_thread = Thread(target=self.keep_lease_alive, args=(lease,),
+                                  name="keepalive-upload")
         keepalive_thread.start()
         try:
             count = 0

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import threading
 from brkt_cli.encryptor_service import (
     wait_for_encryptor_up,
     wait_for_encryption,
@@ -115,6 +116,12 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
         vc_swc.destroy_vm(guest_vm)
         vc_swc.destroy_vm(mv_vm)
     log.info("Done")
+    # Temporary hack to debug hung threads
+    t_list = threading.enumerate()
+    for thread_e in t_list:
+        log.info("Thread name: %s Daemon: %d IsAlive %d",
+                 thread_e.name, thread_e.daemon,
+                 thread_e.is_alive())
 
 
 def launch_guest_vm(vc_swc, template_vm_name, target_path, ovf_name,


### PR DESCRIPTION
At the end of updation/encryption, the cli sometimes hangs and does not return.
This does not happen locally.
Dumping thread state to see if a rogue thread is preventing the cli
from finishing. 