### PR TITLE
Add metavisor-version argument

### DIFF
--- a/brkt_cli/aws/aws_args.py
+++ b/brkt_cli/aws/aws_args.py
@@ -70,6 +70,18 @@ def add_aws_tag(parser):
     )
 
 
+def add_metavisor_version(parser):
+    parser.add_argument(
+        '--metavisor-version',
+        metavar='NAME',
+        dest='metavisor_version',
+        default=None,
+        help=(
+            'Metavisor version [e.g 1.2.12 ] (default: latest)'
+        )
+    )
+
+
 def add_key(parser, help=argparse.SUPPRESS):
     # Optional EC2 SSH key pair name to use for launching the guest
     # and encryptor instances.  This argument is hidden by default because

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -47,6 +47,7 @@ def setup_encrypt_ami_args(parser, parsed_config):
     aws_args.add_security_group(parser)
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
+    aws_args.add_metavisor_version(parser)
     aws_args.add_encryptor_ami(parser)
     aws_args.add_key(parser)
     aws_args.add_retry_timeout(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -49,6 +49,7 @@ def setup_update_encrypted_ami(parser, parsed_config):
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_key(parser)
     aws_args.add_aws_tag(parser)
+    aws_args.add_metavisor_version(parser)
     aws_args.add_encryptor_ami(parser)
     aws_args.add_retry_timeout(parser)
     aws_args.add_retry_initial_sleep_seconds(parser)

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -40,6 +40,7 @@ def setup_wrap_image_args(parser, parsed_config):
     aws_args.add_security_group(parser)
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
+    aws_args.add_metavisor_version(parser)
     aws_args.add_key(parser, help='SSH key pair name')
 
     # Optional AMI ID that's used to launch the encryptor instance.  This

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -129,7 +129,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             (ovf, file_list) = \
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
-                    image_name=values.image_name,
+                    version=values.metavisor_version,
                     proxy=proxy
                 )
             if ovf is None:
@@ -327,7 +327,7 @@ def run_update(values, parsed_config, log, use_esx=False):
             (ovf_name, download_file_list) = \
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
-                    image_name=values.image_name,
+                    version=values.metavisor_version,
                     proxy=proxy
                 )
             if ovf_name is None:
@@ -462,7 +462,7 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
             (ovf, file_list) = \
                 esx_service.download_ovf_from_s3(
                     values.bucket_name,
-                    image_name=values.image_name,
+                    version=values.metavisor_version,
                     proxy=proxy
                 )
             if ovf is None:

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -54,6 +54,7 @@ def setup_encrypt_vmdk_args(parser):
     esx_args.add_ovftool_path(parser)
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_console_file_name(parser)
     esx_args.add_disk_type(parser)
     esx_args.add_use_esx_host(parser)

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -46,6 +46,7 @@ def setup_encrypt_with_esx_host_args(parser):
     esx_args.add_ovftool_path(parser)
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_console_file_name(parser)
     esx_args.add_disk_type(parser)
     esx_args.add_encryptor_vmdk(parser)

--- a/brkt_cli/esx/esx_args.py
+++ b/brkt_cli/esx/esx_args.py
@@ -282,6 +282,17 @@ def add_metavisor_ovf_image_name(parser):
     )
 
 
+def add_metavisor_version(parser):
+    parser.add_argument(
+        '--metavisor-version',
+        metavar='NAME',
+        dest='metavisor_version',
+        help='Metavisor version [e.g 1.2.12 ] (default: latest)',
+        default=None,
+        required=False
+    )
+
+
 def add_console_file_name(parser):
     parser.add_argument(
         '--console-file-name',

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -43,6 +43,7 @@ from brkt_cli.util import (
     validate_dns_name_ip_address
 )
 from brkt_cli import crypto
+from brkt_cli import mv_version
 from brkt_cli.instance_config import INSTANCE_UPDATER_MODE
 from brkt_cli.validation import ValidationError
 
@@ -1195,15 +1196,11 @@ def need_to_download_from_s3(file_list):
     return fetch_s3_objects
 
 
-def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
+def download_ovf_from_s3(bucket_name, version=None, proxy=None):
     log.info("Fetching Metavisor OVF from S3")
     if bucket_name is None:
         log.error("Bucket-name is unknown, cannot get metavisor OVF")
         raise Exception("Invalid bucket-name")
-
-    # Normalize image_name for S3 downloads
-    if image_name and image_name.endswith('.ovf'):
-        image_name = image_name[:image_name.find('.ovf')]
 
     try:
         _environ = dict(os.environ)
@@ -1218,25 +1215,13 @@ def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
         if not (set(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']) <= set(os.environ)):
             s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
 
+        mv = mv_version.get_version(version=version,
+                                    bucket=bucket_name)
+
         bucket = s3.Bucket(bucket_name)
-        blist = list(bucket.objects.filter(Prefix="metavisor/"))
-        if not blist:
-            blist = list(bucket.objects.all())
+        blist = list(bucket.objects.filter(Prefix=mv))
 
-        # Get latest, exact, or partial match of ovfs
-        # No debug for partial match
-        if image_name is None:
-            ovfs = [ o for o in blist if o.key.endswith('.ovf')
-                     and ('latest/' in o.key or 'release-' in o.key)
-                     and not '-debug' in o.key ]
-        else:
-            exact_match = image_name + '.ovf'
-            ovfs = [ o for o in blist if o.key.endswith(exact_match) ]
-            if not ovfs:
-                ovfs = [ o for o in blist if o.key.endswith('.ovf')
-                         and image_name in o.key
-                         and not '-debug' in o.key ]
-
+        ovfs = [ o for o in blist if o.key.endswith('.ovf') ]
         if ovfs:
             ovf_key = sorted(ovfs, key=attrgetter('last_modified'))[-1].key
             ovf_name = ovf_key[ovf_key.rfind('/')+1:]
@@ -1251,8 +1236,7 @@ def download_ovf_from_s3(bucket_name, image_name=None, proxy=None):
             else:
                 log.info("Using previously downloaded OVF image: %s", ovf_name)
         else:
-            log.error("No OVF image found with name %s in bucket "
-                     "%s" % (image_name, bucket_name))
+            log.error("No metavisor ovfs found in bucket %s", bucket_name)
             ovf_name = ovf_filenames = None
 
         os.environ.clear()

--- a/brkt_cli/esx/update_encrypted_vmdk_args.py
+++ b/brkt_cli/esx/update_encrypted_vmdk_args.py
@@ -73,6 +73,7 @@ def setup_update_vmdk_args(parser):
     esx_args.add_no_verify_cert(parser)
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_use_esx_host(parser)
     esx_args.add_http_s3_proxy(parser)
     esx_args.add_encryptor_vmdk(parser)

--- a/brkt_cli/esx/update_with_esx_host_args.py
+++ b/brkt_cli/esx/update_with_esx_host_args.py
@@ -50,6 +50,7 @@ def setup_update_with_esx_host_args(parser):
     esx_args.add_ovftool_path(parser)
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_console_file_name(parser)
     esx_args.add_disk_type(parser)
     esx_args.add_encryptor_vmdk(parser)

--- a/brkt_cli/esx/wrap_with_esx_host_args.py
+++ b/brkt_cli/esx/wrap_with_esx_host_args.py
@@ -36,6 +36,7 @@ def setup_wrap_with_esx_host_args(parser):
     )
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_disk_type(parser)
     esx_args.add_encryptor_vmdk(parser)
     esx_args.add_ssh_public_key(parser)

--- a/brkt_cli/esx/wrap_with_vcenter_args.py
+++ b/brkt_cli/esx/wrap_with_vcenter_args.py
@@ -59,6 +59,7 @@ def setup_wrap_with_vcenter_args(parser):
     esx_args.add_no_verify_cert(parser)
     esx_args.add_ovf_source_directory(parser)
     esx_args.add_metavisor_ovf_image_name(parser)
+    esx_args.add_metavisor_version(parser)
     esx_args.add_disk_type(parser)
     esx_args.add_http_s3_proxy(parser)
     esx_args.add_encryptor_vmdk(parser)

--- a/brkt_cli/mv_version.py
+++ b/brkt_cli/mv_version.py
@@ -1,0 +1,165 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for discovering metavisor version"""
+
+import logging
+import re
+from distutils.version import LooseVersion
+
+import boto3
+from botocore.handlers import disable_signing
+
+
+log = logging.getLogger(__name__)
+logging.getLogger('boto3').setLevel(logging.FATAL)
+logging.getLogger('botocore').setLevel(logging.FATAL)
+logging.getLogger('s3transfer').setLevel(logging.FATAL)
+
+
+AWS_PROD_BUCKET_DEFAULT='solo-brkt-prod-net'
+RE_METAVISOR_VERSION=re.compile(r'(metavisor)-(\d+)-(\d+)-(\d+)-(g.*?)(-.*)?$')
+RE_MAJOR_VERSION_ARG=re.compile(r'^(\d+)$')
+RE_MINOR_VERSION_ARG=re.compile(r'^(\d+)-(\d+)$')
+RE_PATCH_VERSION_ARG=re.compile(r'^(\d+)-(\d+)-(\d+)$')
+
+
+class MetavisorVersionNotFoundError(Exception):
+    pass
+
+
+def get_s3_versions(bucket):
+    """Return available metavisor versions in S3 bucket
+
+    Return a list of possible metavisor versions from provided AWS bucket.
+
+    Args:
+       bucket: AWS bucket where metavisor versions are pubished (str)
+
+    Returns:
+       versions: List of metavisor version prefix's for AWS bucket (list)
+
+    """
+    log.info('Fetching Metavisor version from S3')
+    versions = []
+
+    # Check for dev bucket
+    if bucket == 'packages.int.brkt.net':
+        version_prefix = 'metavisor/metavisor-'
+    else:
+        version_prefix = 'metavisor-'
+
+    s3 = boto3.resource('s3')
+    s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+    s3bucket = s3.Bucket(bucket)
+    s3results = s3bucket.meta.client.list_objects(Bucket=bucket,
+                                                  Delimiter='/',
+                                                  Prefix=version_prefix)
+
+    if s3results.get('CommonPrefixes'):
+        versions = [ v.get('Prefix').rstrip('/') for v in s3results.get('CommonPrefixes') ]
+
+    return versions
+
+
+def get_version(version, bucket):
+    """Return a single published metavisor version
+
+    Returns the latest version of metavisor if no specific version is
+    provided.
+
+    Args:
+       version: Semantic or exact match metavisor version (str)
+       bucket: AWS bucket where metavisor versions are pubished (str)
+
+    Returns:
+       mversion: Metavisor version prefix for AWS bucket (str)
+
+    """
+    mversion = None
+    mv_regex = version_regex(version)
+
+    versions = get_s3_versions(bucket)
+    mversions = sorted([LooseVersion(v) for v in versions], reverse=True)
+    for mv in mversions:
+        vcandidate = re.search(mv_regex, mv.vstring)
+        if vcandidate:
+            # Return exact version matches (e.g. -debug builds)
+            if mv_regex.pattern.rstrip('$') == version:
+                mversion = mv.vstring
+                break
+            # Return only official metavisor versions (e.g. no suffix)
+            # ('metavisor', '1', '3', '106', 'g0cbdb5597', None)
+            mvsearch = re.search(RE_METAVISOR_VERSION, mv.vstring)
+            if mvsearch.groups()[-1] == None:
+                mversion = mv.vstring
+                break
+
+    if not mversion:
+        log.exception("Exception determining metavisor version in %s (%s)",
+                      bucket, mv_regex.pattern)
+        raise MetavisorVersionNotFoundError()
+
+    log.info("Found metavisor version %s", mversion)
+
+    return mversion
+
+
+def get_amis_url(version, bucket):
+    """Return url to amis.json for specified metavisor version
+
+    Args:
+       version: Semantic or exact match metavisor version (str)
+       bucket: AWS bucket where metavisor versions are pubished (str)
+
+    Returns:
+       url: Location to amis.json for given metavisor version (str)
+
+    """
+    mversion = get_version(version, bucket)
+    url = 'http://%(bucket)s.s3.amazonaws.com/%(mversion)s/amis.json' % locals()
+
+    return url
+
+
+def version_regex(version):
+    """Return a metavisor long version regex for a given version string
+
+    Transforms short semantic version strings (e.g. 1, 1.2, 1.2.3) into
+    metavisor long form version strings. If no supported semantic version
+    string is provided, default to an exact match.
+
+    Args:
+        version: Semantic or exact match version (str)
+
+    Returns:
+        version_regex: Compiled regex object (_sre.SRE_Pattern)
+    """
+
+    if not version:
+        return  RE_METAVISOR_VERSION
+
+    # Be lenient with . vs - version input
+    version = version.replace('.','-')
+
+    if re.search(RE_PATCH_VERSION_ARG, version):
+        vr = r'metavisor-%s-(g.*?)(-.*)?$' % version
+    elif re.search(RE_MINOR_VERSION_ARG, version):
+        vr = r'metavisor-%s-(\d+)-(g.*?)(-.*)?$' % version
+    elif re.search(RE_MAJOR_VERSION_ARG, version):
+        vr = r'metavisor-%s-(\d+)-(\d+)-(g.*?)(-.*)?$' % version
+    else:
+        vr = r'%s$' % version
+
+    return re.compile(vr)

--- a/brkt_cli/test_mv_version.py
+++ b/brkt_cli/test_mv_version.py
@@ -1,0 +1,40 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import unittest
+
+from brkt_cli import mv_version
+
+
+class TestMetavisorVersionCheck(unittest.TestCase):
+
+    def test_version_regex_found(self):
+        v = 'metavisor-1-3-20-gc90f6f77d-special'
+        version_args = [ '1.3', '1', '1-3', '1-3-20',
+                         'metavisor-1-3-20-gc90f6f77d-special']
+
+        for version in version_args:
+            vr = mv_version.version_regex(version)
+            self.assertIsNotNone(re.search(vr, v))
+
+
+    def test_version_regex_not_found(self):
+        v = 'metavisor-1-3-20-gc90f6f77d-special'
+        version_args = [ '1.2', '2', '1-5', '1.3.21',
+                         'metavisor-1-3-20-gc90f6f77d' ]
+
+        for version in version_args:
+            vr = mv_version.version_regex(version)
+            self.assertIsNone(re.search(vr, v))


### PR DESCRIPTION
Add support for determining metavisor version through published
version artifacts in AWS.

- Add mv_version module to brkt_cli

- Update esx provider to fetch OVF objects from S3 using metavisor
  version

- Update esx provider to fetch amis.json using metavisor version