### PR TITLE
Make esx keepalive threads be daemons

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -937,6 +937,7 @@ class VCenterService(BaseVCenterService):
                 target_file = os.path.join(target_path, file_name)
                 keepalive_thread = Thread(target=self.keep_lease_alive,
                                           args=(lease,), name="keepalive-export")
+                keepalive_thread.daemon = True
                 keepalive_thread.start()
                 # Disable verification as VMDK download happens directly
                 # from the ESX host.
@@ -1097,6 +1098,7 @@ class VCenterService(BaseVCenterService):
                 raise Exception("Failed to get lease to upload OVF")
         keepalive_thread = Thread(target=self.keep_lease_alive, args=(lease,),
                                   name="keepalive-upload")
+        keepalive_thread.daemon = True
         keepalive_thread.start()
         try:
             count = 0


### PR DESCRIPTION
We were seeing brkt-cli timeouts after a successful encryption.
Logs were indicating that keepalive-upload thread was preventing exit:
Thread name: MainThread Daemon: 0 IsAlive 1
Thread name: keepalive-upload Daemon: 0 IsAlive 1

Testing: Ran esx encryption successfully