### PR TITLE
Fix typo in Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ binaries.  To download the **brkt-cli** source and build the `brkt` container:
 ```
 $ wget https://github.com/brkt/brkt-cli/archive/brkt-cli-<RELEASE-NUMBER>.zip
 $ unzip brkt-cli-<RELEASE-NUMBER>.zip
-$ cd brkt-cli-brkt-cli-<RELEASE-NUMBER>
+$ cd brkt-cli-<RELEASE-NUMBER>
 $ docker build -t brkt .
 ```
 


### PR DESCRIPTION
The instructions had a superfluous "brkt-cli" in the change directory
command.