### PR TITLE
Try to use GCP private IPs

### DIFF
--- a/brkt_cli/gcp/encrypt_gcp_image.py
+++ b/brkt_cli/gcp/encrypt_gcp_image.py
@@ -84,8 +84,14 @@ def do_encryption(gcp_svc,
                          tags=gcp_tags)
 
     try:
+        host_ips = []
         ip = gcp_svc.get_instance_ip(encryptor, zone)
-        enc_svc = enc_svc_cls([ip], port=status_port)
+        if ip:
+            host_ips.append(ip)
+        pvt_ip = gcp_svc.get_private_ip(encryptor, zone)
+        if pvt_ip:
+            host_ips.append(pvt_ip)
+        enc_svc = enc_svc_cls(host_ips, port=status_port)
         wait_for_encryptor_up(enc_svc, Deadline(600))
         log.info(
             'Waiting for encryption service on %s (%s:%s)',

--- a/brkt_cli/gcp/gcp_service.py
+++ b/brkt_cli/gcp/gcp_service.py
@@ -113,6 +113,10 @@ class BaseGCPService(object):
         pass
 
     @abc.abstractmethod
+    def get_private_ip(self, name, zone):
+        pass
+
+    @abc.abstractmethod
     def detach_disk(self, zone, instance, diskName):
         pass
 
@@ -406,6 +410,15 @@ class GCPService(BaseGCPService):
             except:
                 pass
         self.log.info("Couldn't find an IP address for this instance.")
+
+    def get_private_ip(self, name, zone):
+        nw = 'networkInterfaces'
+        instance_req = self.compute.instances().get(project=self.project,
+                zone=zone, instance=name)
+        instance = retry(execute_gcp_api_call)(instance_req)
+        if instance[nw][0]['networkIP']:
+            return instance[nw][0]['networkIP']
+        self.log.info("Couldn't find private IP address for this instance.")
 
     def write_serial_console_file(self, zone, instance):
         try:

--- a/brkt_cli/gcp/update_gcp_image.py
+++ b/brkt_cli/gcp/update_gcp_image.py
@@ -72,9 +72,15 @@ def update_gcp_image(gcp_svc, enc_svc_cls, image_id, encryptor_image,
                              delete_boot=False,
                              metadata=user_data,
                              tags=gcp_tags)
+        host_ips = []
         ip = gcp_svc.get_instance_ip(updater, zone)
+        if ip:
+            host_ips.append(ip)
+        pvt_ip = gcp_svc.get_private_ip(updater, zone)
+        if pvt_ip:
+            host_ips.append(pvt_ip)
         updater_launched = True
-        enc_svc = enc_svc_cls([ip], port=status_port)
+        enc_svc = enc_svc_cls(host_ips, port=status_port)
 
         # wait for updater to finish and guest root disk
         wait_for_encryptor_up(enc_svc, Deadline(600))

--- a/test_gce.py
+++ b/test_gce.py
@@ -136,6 +136,9 @@ class DummyGCPService(gcp_service.BaseGCPService):
     def get_instance_ip(self, name, zone):
         return
 
+    def get_private_ip(self, name, zone):
+        return
+
     def detach_disk(self, zone, instance, diskName):
         return self.wait_for_detach(zone, diskName)
 


### PR DESCRIPTION
Instances by default have an ephemeral public IP. However in cases
where we have a site-to-site VPN or the ephemeral IP is explicitly
disabled due to policy, the brkt-cli should try to use the
private IP. With this change, brkt-cli checks the encryptor status
on both the public and private IPs during encryption and updates,
much similar to AWS.