### PR TITLE
Cleanup ESX code

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -157,7 +157,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params(use_esx)
+    vc_swc.validate_vcenter_params()
     # Validate that template does not already exist
     if values.template_vm_name:
         if vc_swc.find_vm(values.template_vm_name):
@@ -355,7 +355,7 @@ def run_update(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params(use_esx)
+    vc_swc.validate_vcenter_params()
     if values.template_vm_name:
         if vc_swc.find_vm(values.template_vm_name) is None:
             raise ValidationError("Template VM %s not found" %
@@ -491,7 +491,7 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
     # Validate vCenter parameters
-    vc_swc.validate_vcenter_params(use_esx)
+    vc_swc.validate_vcenter_params()
     # Validate that template does not already exist
     if values.vm_name:
         if vc_swc.find_vm(values.vm_name):

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -27,7 +27,6 @@ Before running brkt encrypt-vmdk, do "pip install pyvmomi".
 """
 
 import logging
-import threading
 from brkt_cli.encryptor_service import (
     wait_for_encryptor_up,
     wait_for_encryption,
@@ -69,8 +68,6 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         vc_swc.add_disk(vm, disk_size=encrypted_guest_size, unit_number=1)
         # Configure Static IP for the encryptor VM
         if static_ip:
-            vc_swc.power_on(vm)
-            vc_swc.power_off(vm)
             vc_swc.configure_static_ip(vm, static_ip)
         # Reconfigure VM with serial port
         if serial_port_file_name:
@@ -159,12 +156,6 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
                 if vm is not None:
                     vc_swc.destroy_vm(vm)
         log.info("Done")
-        # Temporary hack to debug hung threads
-        t_list = threading.enumerate()
-        for thread_e in t_list:
-            log.info("Thread name: %s Daemon: %d IsAlive %d",
-                     thread_e.name, thread_e.daemon,
-                     thread_e.is_alive())
 
 
 def encrypt_from_s3(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import logging
 import os
-import threading
 from brkt_cli.encryptor_service import (
     wait_for_encryptor_up,
     wait_for_encryption,
@@ -116,12 +115,6 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
         vc_swc.destroy_vm(guest_vm)
         vc_swc.destroy_vm(mv_vm)
     log.info("Done")
-    # Temporary hack to debug hung threads
-    t_list = threading.enumerate()
-    for thread_e in t_list:
-        log.info("Thread name: %s Daemon: %d IsAlive %d",
-                 thread_e.name, thread_e.daemon,
-                 thread_e.is_alive())
 
 
 def launch_guest_vm(vc_swc, template_vm_name, target_path, ovf_name,

--- a/brkt_cli/esx/wrap_image.py
+++ b/brkt_cli/esx/wrap_image.py
@@ -52,8 +52,6 @@ def wrap_from_s3(vc_swc, guest_vmdk, vm_name=None,
             vc_swc.send_userdata(vm, user_data_str)
         vc_swc.reconfigure_vm_cpu_ram(vm)
         if static_ip:
-            vc_swc.power_on(vm)
-            vc_swc.power_off(vm)
             vc_swc.configure_static_ip(vm, static_ip)
         vc_swc.power_on(vm)
         ip_addr = vc_swc.get_ip_address(vm)
@@ -89,8 +87,6 @@ def wrap_from_local_ovf(vc_swc, guest_vmdk, vm_name=None,
             vc_swc.send_userdata(vm, user_data_str)
         vc_swc.reconfigure_vm_cpu_ram(vm)
         if static_ip:
-            vc_swc.power_on(vm)
-            vc_swc.power_off(vm)
             vc_swc.configure_static_ip(vm, static_ip)
         vc_swc.power_on(vm)
         ip_addr = vc_swc.get_ip_address(vm)
@@ -123,8 +119,6 @@ def wrap_from_vmdk(vc_swc, guest_vmdk, vm_name=None,
             vc_swc.send_userdata(vm, user_data_str)
         vc_swc.reconfigure_vm_cpu_ram(vm)
         if static_ip:
-            vc_swc.power_on(vm)
-            vc_swc.power_off(vm)
             vc_swc.configure_static_ip(vm, static_ip)
         vc_swc.power_on(vm)
         ip_addr = vc_swc.get_ip_address(vm)


### PR DESCRIPTION
1. Since power-on and power-off for MV VMs is always
needed to configure static IP, move from the caller to
inside the configuration of static IP function.
Also add a comment to explain.
2. Remove the temporary hack to debug hung threads.
3. During vcenter valdation, remove the redundant
input use_esx.