### PR TITLE
Trim guest disk name to max supported length

### DIFF
--- a/brkt_cli/gcp/wrap_gcp_image.py
+++ b/brkt_cli/gcp/wrap_gcp_image.py
@@ -4,6 +4,8 @@ import logging
 
 from googleapiclient import errors
 
+from brkt_cli.util import append_suffix
+from brkt_cli.gcp.gcp_service import GCP_NAME_MAX_LENGTH
 
 log = logging.getLogger(__name__)
 
@@ -28,9 +30,12 @@ def wrap_guest_image(gcp_svc, image_id, encryptor_image, zone,
 
         if not instance_name:
             instance_name = 'brkt-guest-' + gcp_svc.get_session_id()
-            guest_disk_name = instance_name + '-unencrypted'
+            guest_disk_name = append_suffix(instance_name, '-unencrypted',
+                                            GCP_NAME_MAX_LENGTH)
         else:
-            guest_disk_name = instance_name + gcp_svc.get_session_id()
+            guest_disk_name = append_suffix(instance_name,
+                                            gcp_svc.get_session_id(),
+                                            GCP_NAME_MAX_LENGTH)
         
         gcp_svc.disk_from_image(zone, image_id, guest_disk_name, image_project)
         log.info('Waiting for guest root disk to become ready')


### PR DESCRIPTION
Since the guest disk is generated based off the instance name, if
the user specified instance name is <=63 characters, we need to
ensure that the generated name for the guest_disk does not exceed
the 63 character limit enforced by GCP.