### PR TITLE
brkt auth usage improvements

### DIFF
--- a/brkt_cli/auth.py
+++ b/brkt_cli/auth.py
@@ -11,12 +11,12 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import argparse
 import getpass
 import logging
 
 import sys
 
-import brkt_cli
 from brkt_cli import argutil, ValidationError, util
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.yeti import YetiService, YetiError
@@ -41,28 +41,27 @@ class AuthSubcommand(Subcommand):
         parser = subparsers.add_parser(
             self.name(),
             description=(
-                'Authenticate with the Bracket service. On success, print '
-                'the API token (JSON Web Token) that is used for making '
-                'calls to Bracket REST API endpoints. You must set the '
-                'BRKT_API_TOKEN environment variable to this value, to '
-                'allow other brkt-cli commands to communicate with the '
-                'Bracket service.'
+                'Authenticate with the Bracket service. On success, print the API token (JSON\n'  # noqa
+                'Web Token) that is used for making calls to Bracket REST API endpoints. You \n'  # noqa
+                'must set the BRKT_API_TOKEN environment variable to this value, to allow other\n'  # noqa
+                'brkt-cli commands to communicate with the Bracket service:\n'
+                '\n'
+                '$ export BRKT_API_TOKEN=$(brkt auth)'
             ),
             help='Authenticate with the Bracket service',
-            formatter_class=brkt_cli.SortingHelpFormatter
+            formatter_class=argparse.RawDescriptionHelpFormatter
         )
         parser.add_argument(
             '--email',
             metavar='ADDRESS',
             help='If not specified, show a prompt.'
         )
+        argutil.add_out(parser)
         parser.add_argument(
             '--password',
             help='If not specified, show a prompt.'
         )
-
         argutil.add_root_url(parser, parsed_config)
-        argutil.add_out(parser)
 
     def run(self, values):
         email = values.email


### PR DESCRIPTION
Update the brkt auth usage description.  Add an example of setting the
BRKT_API_TOKEN environment variable.  Use RawDescriptionHelpFormatter,
so that argparse doesn't remove newlines.

```
$ brkt auth -h
usage: brkt auth [-h] [--email ADDRESS] [--out PATH] [--password PASSWORD]
                 [--root-url URL]

Authenticate with the Bracket service. On success, print the API token (JSON
Web Token) that is used for making calls to Bracket REST API endpoints. You
must set the BRKT_API_TOKEN environment variable to this value, to allow other
brkt-cli commands to communicate with the Bracket service:

$ export BRKT_API_TOKEN=$(brkt auth)

optional arguments:
  -h, --help           show this help message and exit
  --email ADDRESS      If not specified, show a prompt.
  --out PATH           Write to a file instead of stdout. This can be used to
                       avoid character encoding issues when redirecting output
                       on Windows.
  --password PASSWORD  If not specified, show a prompt.
  --root-url URL       Bracket service root URL
```