### PR TITLE
Improve handling of errors from Bracket service

### DIFF
--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -29,8 +29,9 @@ class Customer(object):
 class YetiError(Exception):
     def __init__(self, http_status, message=None):
         if not message:
-            if http_status == 401:
-                message = httplib.responses[http_status]
+            message = 'Bracket service returned error %d: %s' % (
+                http_status, httplib.responses[http_status]
+            )
 
         super(YetiError, self).__init__(message)
         self.http_status = http_status


### PR DESCRIPTION
When the Bracket service returns an HTTP error and the message isn't
specified, generate a human-readable message that explains what went
wrong.