### PR TITLE
Fix --metavisor-version to return exact version for OVF images

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -97,8 +97,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
         if use_esx is False and values.template_vm_name is None:
             raise ValidationError("Missing template-vm-name for the "
                                   "template VM")
-    if (values.source_image_path is not None and values.image_name is None):
-        raise ValidationError("Specify the Metavisor OVF file.")
+    if values.source_image_path is None and values.image_name is not None:
+        raise ValidationError("Specify OVF image location with --ovf-source-directory")
     if use_esx:
         _check_env_vars_set('ESX_USER_NAME')
     else:
@@ -295,8 +295,8 @@ def run_update(values, parsed_config, log, use_esx=False):
                                   "updation on a single ESX host")
         if (values.template_vm_name is None):
             raise ValidationError("Encrypted image not provided")
-    if (values.source_image_path is not None and values.image_name is None):
-        raise ValidationError("Specify the Metavisor OVF file.")
+    if values.source_image_path is None and values.image_name is not None:
+        raise ValidationError("Specify OVF image location with --ovf-source-directory")
     if use_esx:
         _check_env_vars_set('ESX_USER_NAME')
     else:
@@ -427,8 +427,8 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
 
     if not use_esx and values.vm_name is None:
         raise ValidationError("Missing vm-name for the VM")
-    if (values.source_image_path is not None and values.image_name is None):
-        raise ValidationError("Specify the Metavisor OVF file.")
+    if values.source_image_path is None and values.image_name is not None:
+        raise ValidationError("Specify OVF image location with --ovf-source-directory")
     if use_esx:
         _check_env_vars_set('ESX_USER_NAME')
     else:

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -1225,7 +1225,8 @@ def download_ovf_from_s3(bucket_name, version=None, proxy=None):
                                     bucket=bucket_name)
 
         bucket = s3.Bucket(bucket_name)
-        blist = list(bucket.objects.filter(Prefix=mv))
+        prefix = mv + '/'
+        blist = list(bucket.objects.filter(Prefix=prefix))
 
         ovfs = [ o for o in blist if o.key.endswith('.ovf') ]
         if ovfs:


### PR DESCRIPTION
We were not anchoring our bucket filter prefix for OVF images, which
caused us to return unofficial versions (e.g. -debug).

Also tweaked the error handling for users that are specifying both
--metavisor-version and --metavisor-ovf-image-name. The latter now
only refers to local .ovf files.