### PR TITLE
Handle error in find-vm

### DIFF
--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -95,7 +95,12 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
             log.error("Failed to re-connect to vCenter after encryption. "
                       "Please cleanup VM %s manually.", mv_vm_name)
             raise
-        vm = vc_swc.find_vm(mv_vm_name)
+        for retry in range(10):
+            # This should not fail, if it fails, then retry
+            # 10 times before giving up
+            vm = vc_swc.find_vm(mv_vm_name)
+            if vm:
+                break
         # detach unencrypted guest root
         vc_swc.power_off(vm)
         vc_swc.detach_disk(vm, unit_number=2)

--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -465,13 +465,16 @@ class VCenterService(BaseVCenterService):
         container = content.viewManager.CreateContainerView(
             content.rootFolder, vimtype, True)
         for c in container.view:
-            if name:
-                if c.name == name:
+            try:
+                if name:
+                    if c.name == name:
+                        obj = c
+                        break
+                else:
                     obj = c
                     break
-            else:
-                obj = c
-                break
+            except:
+                pass
         return obj
 
     def __wait_for_task(self, task):


### PR DESCRIPTION
1. get_obj sometimes gets exceptions when someone in
parallel is deleting other vms. Handle such exceptions.
2. Get vm in encrypt code should not fail. Retry on failure
10 times before giving up.