### PR TITLE
Improve error reporting when CLI can't talk to encryptor

### DIFF
--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -452,6 +452,7 @@ def main():
 
     # Run the subcommand.
     allow_debug_log = True
+    error_msg = None
     try:
         result = subcommand.run(values)
         if not isinstance(result, (int, long)):
@@ -460,10 +461,10 @@ def main():
         log.debug('%s returned %d', subcommand.name(), result)
     except ValidationError as e:
         allow_debug_log = False
-        print(e, file=sys.stderr)
+        error_msg = e.message
     except util.BracketError as e:
         log.debug('', exc_info=1)
-        log.error(e.message)
+        error_msg = e.message
     except KeyboardInterrupt:
         allow_debug_log = False
         log.debug('', exc_info=1)
@@ -478,6 +479,10 @@ def main():
                 log.info('Debug log is available at %s', debug_log_file.name)
             else:
                 os.remove(debug_log_file.name)
+
+    if error_msg:
+        print(error_msg, file=sys.stderr)
+
     return result
 
 

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -251,10 +251,15 @@ def _snapshot_encrypted_instance(
             os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
 
     enc_svc = enc_svc_cls(host_ips, port=status_port)
-    try:
-        log.info('Waiting for encryption service on %s (port %s on %s)',
+    log.info('Waiting for encryption service on %s (port %s on %s)',
              encryptor_instance.id, enc_svc.port, ', '.join(host_ips))
+    try:
         encryptor_service.wait_for_encryptor_up(enc_svc, Deadline(600))
+    except:
+        log.error('Unable to connect to encryptor instance.')
+        raise
+
+    try:
         log.info('Creating encrypted root drive.')
         encryptor_service.wait_for_encryption(enc_svc)
     except (BracketError, encryptor_service.EncryptionError) as e:

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -149,7 +149,12 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
         enc_svc = enc_svc_class(host_ips, port=status_port)
         log.info('Waiting for updater service on %s (port %s on %s)',
                  updater.id, enc_svc.port, ', '.join(host_ips))
-        wait_for_encryptor_up(enc_svc, Deadline(600))
+        try:
+            wait_for_encryptor_up(enc_svc, Deadline(600))
+        except:
+            log.error('Unable to connect to encryptor instance.')
+            raise
+
         try:
             wait_for_encryption(enc_svc)
         except Exception as e:

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -149,8 +149,8 @@ def wait_for_encryptor_up(enc_svc, deadline):
             return
         sleep(5)
     raise BracketError(
-        'Unable to contact encryptor instance at %s.' %
-        ', '.join(enc_svc.hostnames)
+        'Unable to contact encryptor instance at %s, port %d.' %
+        (', '.join(enc_svc.hostnames), enc_svc.port)
     )
 
 


### PR DESCRIPTION
Handle waiting for the encryptor instance separately from other
encryption errors.  Log an clear error when we're unable to get a
response from the encryption service.

New error output format: when an error occurs, write it at the very
bottom of the stderr output without a timestamp, to differentiate it
from logs.

Sample output:

$ ./brkt aws encrypt ami-45224425
...
16:01:25 Launching encryptor instance i-0cda6417445c92a46
16:01:36 Adding 172.31.5.227 to NO_PROXY environment variable
16:01:36 Waiting for encryption service on i-0cda6417445c92a46 (port 80
on 52.43.210.11, 172.31.5.227)
16:01:45 Unable to connect to encryptor instance.
16:01:47 Terminating instance i-039542e92360f9612
16:01:47 Terminating instance i-0cda6417445c92a46
16:01:48 Deleting snapshot snap-0d9edceff69ec8d0c
16:01:48 Waiting for instance i-0cda6417445c92a46 to terminate.
16:04:06 Waiting for instance i-039542e92360f9612 to terminate.
16:04:06 Deleting volume vol-0b262d834ee4a1703
16:04:06 Deleting volume vol-07f157d99e0c206d2
16:04:06 Deleting security group sg-95c595ee
16:04:07 Debug log is available at
/var/folders/tz/k2yndc9j5bj5dgzngb1g67rc0000gn/T/brkt_cli53G2M3
Unable to contact encryptor instance at 52.43.210.11, 172.31.5.227, port
80.