### PR TITLE
Add optional CDROM configuration to encryptor VM

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -153,6 +153,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             network_name=values.network_name,
             nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
+            cdrom=values.cdrom,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -579,6 +580,7 @@ def run_rescue_metavisor(values, parsed_config, log):
             network_name=None,
             nic_type=None,
             verify=values.validate,
+            cdrom=values.cdrom,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter ", e)

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -69,6 +69,10 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         else:
             encrypted_guest_size = (2 * size) + (1024*1024)
         vc_swc.add_disk(vm, disk_size=encrypted_guest_size, unit_number=1)
+        # Add CDROM if required
+        if vc_swc.cdrom:
+            log.info("Adding CDROM configuration")
+            vc_swc.add_cdrom(vm)
         # Configure Static IP for the encryptor VM
         if static_ip:
             vc_swc.configure_static_ip(vm, static_ip)
@@ -254,6 +258,10 @@ def encrypt_from_vmdk(vc_swc, enc_svc_cls, guest_vmdk, crypto_policy,
         vm = vc_swc.create_vm()
         # Attach metavisor vmdk as root disk
         vc_swc.add_disk(vm, filename=metavisor_vmdk_path, unit_number=0)
+        # Add CDROM if required
+        if vc_swc.cdrom:
+            log.info("Adding CDROM configuration")
+            vc_swc.add_cdrom(vm)
     except Exception as e:
         log.exception("Failed to launch metavisor VMDK (%s)", e)
         if (vm is not None):

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -66,3 +66,4 @@ def setup_encrypt_vmdk_args(parser):
     esx_args.add_nic_type(parser)
     esx_args.add_crypto_policy(parser)
     esx_args.add_no_cleanup(parser)
+    esx_args.add_cdrom(parser)

--- a/brkt_cli/esx/encrypt_with_esx_host_args.py
+++ b/brkt_cli/esx/encrypt_with_esx_host_args.py
@@ -57,3 +57,4 @@ def setup_encrypt_with_esx_host_args(parser):
     esx_args.add_http_s3_proxy(parser)
     esx_args.add_crypto_policy(parser)
     esx_args.add_no_cleanup(parser)
+    esx_args.add_cdrom(parser)

--- a/brkt_cli/esx/esx_args.py
+++ b/brkt_cli/esx/esx_args.py
@@ -425,3 +425,15 @@ def add_no_cleanup(parser, help=argparse.SUPPRESS):
         action='store_false',
         help=help
     )
+
+
+# Optional argument to attach a CDROM device to the launched VM
+# Used currently only for PCF deployments
+def add_cdrom(parser, help=argparse.SUPPRESS):
+    parser.add_argument(
+        '--cdrom',
+        dest='cdrom',
+        default=False,
+        action='store_true',
+        help=help
+    )


### PR DESCRIPTION
Provided an optional (hidden) CDROM flag which can be used to
attach a CDROM device to the encryptor instance which is required
for PCF integration.