### PR TITLE
Validate the Bracket service URL during auth

### DIFF
--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -166,3 +166,12 @@ class YetiService(object):
             json=payload
         )
         return d['jwt']
+
+
+def is_yeti(root_url, timeout=10.0):
+    """ Return True if the root_url points to Yeti.
+    :raise IOError if the url cannot be accessed
+    """
+    url = root_url + '/health_check'
+    r = requests.get(url, timeout=timeout)
+    return r.status_code == 200


### PR DESCRIPTION
Before authenticating against the Bracket service, make sure that the
root URL points to the right place.

-------------
```
$ ./brkt auth --root-url http://www.google.com
http://www.google.com is not the Bracket service

$ ./brkt auth --root-url https://this.is.a.bogus.name
Unable to reach the Bracket service: HTTPSConnectionPool(host='this.is.a.bogus.name', port=443): Max retries exceeded with url: /health_check (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x109b2aa50>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))
```