### PR TITLE
Log Metavisor version fetch message at debug level

### DIFF
--- a/brkt_cli/mv_version.py
+++ b/brkt_cli/mv_version.py
@@ -51,7 +51,7 @@ def get_s3_versions(bucket):
        versions: List of metavisor version prefix's for AWS bucket (list)
 
     """
-    log.info('Fetching Metavisor version from S3')
+    log.debug('Fetching Metavisor version from S3')
     versions = []
 
     # Check for dev bucket


### PR DESCRIPTION
Drop this message down from info to debug.  It's an implementation
detail, and isn't interesting in the normal case.