### PR TITLE
Support launch and API token expiry

### DIFF
--- a/brkt_cli/argutil.py
+++ b/brkt_cli/argutil.py
@@ -40,6 +40,14 @@ def add_brkt_tag(parser):
     )
 
 
+def add_exp(parser):
+    parser.add_argument(
+        '--exp',
+        metavar='DURATION',
+        help='Token expiry time duration in the format N[dhms] (e.g. 12h)'
+    )
+
+
 def add_root_url(parser, cli_config):
     """ Add the --root-url argument, for specifying the Yeti public API
     endpoint. """

--- a/brkt_cli/auth.py
+++ b/brkt_cli/auth.py
@@ -57,6 +57,7 @@ class AuthSubcommand(Subcommand):
             metavar='ADDRESS',
             help='If not specified, show a prompt.'
         )
+        argutil.add_exp(parser)
         argutil.add_out(parser)
         parser.add_argument(
             '--password',
@@ -93,6 +94,10 @@ class AuthSubcommand(Subcommand):
                 raise ValidationError(
                     'Invalid email or password for %s' % values.root_url)
             raise ValidationError(e.message)
+
+        if values.exp:
+            dt = util.parse_duration(values.exp)
+            token = y.create_api_token(expiry=dt)
 
         util.write_to_file_or_stdout(token, path=values.out)
 

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -276,7 +276,7 @@ def get_launch_token(values, cli_config):
         brkt_env = brkt_cli.brkt_env_from_values(values, cli_config)
         y = yeti_service_from_brkt_env(brkt_env)
         tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
-        token = y.get_launch_token(tags=tags)
+        token = y.create_launch_token(tags=tags)
 
     return token
 

--- a/brkt_cli/test_util.py
+++ b/brkt_cli/test_util.py
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 import unittest
 
@@ -173,3 +173,23 @@ class TestTimestamp(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             util.parse_timestamp('abc')
+
+    def test_parse_duration(self):
+        self.assertEqual(
+            timedelta(seconds=5),
+            util.parse_duration('5s')
+        )
+        self.assertEqual(
+            timedelta(minutes=10),
+            util.parse_duration('10m')
+        )
+        self.assertEqual(
+            timedelta(hours=12),
+            util.parse_duration('12h')
+        )
+        self.assertEqual(
+            timedelta(days=2),
+            util.parse_duration('2d')
+        )
+        with self.assertRaises(ValidationError):
+            util.parse_duration('10')


### PR DESCRIPTION
Add an --exp option to the auth command, which allows the user to
specify the lifetime of the token as a time duration.  Enable make-token
--exp when getting the launch token from the Bracket service.

Deprecate specifying token expiry in years, since the number of days in
a year can vary.

Deprecate specifying token expiry as a timestamp.  The Bracket token
service does not allow the client to specify a timestamp, so that the
server timestamp is the source of truth.  We also want expiry behavior
to be consistent for both locally-generated and server-generated tokens.