### PR TITLE
Fix incorrect thumbprint generation for public keys

### DIFF
--- a/brkt_cli/brkt_jwt/jwk.py
+++ b/brkt_cli/brkt_jwt/jwk.py
@@ -18,12 +18,21 @@ import logging
 
 log = logging.getLogger(__name__)
 
+EC384_KEY_LEN_BYTES = 48
 
-def _long_to_byte_array(long_int):
+# If the length of the bytearray created is less than 48, pad it with leading
+# zeros. EC384 are 384bits i.e. 48byte keys. so both x and y need to be 48bytes
+# with leading zeros wherever required
+
+
+def _long_to_byte_array(long_int, pad_to_len=EC384_KEY_LEN_BYTES):
     bys = bytearray()
     while long_int:
         long_int, r = divmod(long_int, 256)
         bys.insert(0, r)
+    if len(bys) < pad_to_len:
+        # pad with leading zeros
+        bys = bytearray(pad_to_len - len(bys)) + bys
     return bys
 
 

--- a/brkt_cli/brkt_jwt/test_jwt.py
+++ b/brkt_cli/brkt_jwt/test_jwt.py
@@ -111,8 +111,12 @@ class TestJWK(unittest.TestCase):
 
     def test_long_to_byte_array(self):
         l = long('deadbeef', 16)
-        ba = brkt_jwt.jwk._long_to_byte_array(l)
+        ba = brkt_jwt.jwk._long_to_byte_array(l, pad_to_len=4)
         self.assertEqual(bytearray.fromhex('deadbeef'), ba)
+        ba = brkt_jwt.jwk._long_to_byte_array(l, pad_to_len=50)
+        self.assertEqual(bytearray(46) + bytearray.fromhex('deadbeef'), ba)
+        ba = brkt_jwt.jwk._long_to_byte_array(l)
+        self.assertEqual(bytearray(44) + bytearray.fromhex('deadbeef'), ba)
 
 
 class TestNameValueToDict(unittest.TestCase):


### PR DESCRIPTION
Sometimes the EC keypairs generated are a byte shorter.
Either x or y could be 47 bytes instead of 48 which is
mathematically valid. But when computing thumbprint,
these need to be padded with leading zeros.
Added this change.
Generated such a keypair and uploaded it to Yeti.
Made sure the KeyId computed by yeti matches the one
computed by brkt-cli

Jira: YETI-2778 #resolve