### PR TITLE
Paginate file list in GCP buckets

### DIFF
--- a/brkt_cli/gcp/gcp_service.py
+++ b/brkt_cli/gcp/gcp_service.py
@@ -591,7 +591,13 @@ class GCPService(BaseGCPService):
             return old
 
     def get_image_file(self, bucket):
-        files = self.storage.objects().list(bucket=bucket).execute()['items']
+        files = []
+        request = self.storage.objects().list(bucket=bucket)
+        # Paginate thru' the list of files in the bucket
+        while request:
+            resp = request.execute()
+            files += resp['items']
+            request = self.storage.objects().list_next(request, resp)
         # if LATEST_IMAGE exists return that
         for f in files:
             if f['name'] == LATEST_IMAGE:


### PR DESCRIPTION
The GCP bucket list command returns the first 1000 items by default.
In the case where a bucket contains more than 1000 items, we do not
paginate thru' the entire list of files and as a result only
operate on the first 1000 entries. This especially causes problems
when you specify an encryptor bucket with more than 1000 files as
it incorrectly picks an older Metavisor image.