### PR TITLE
Clean up terminate_instance_callback

### DIFF
--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -188,9 +188,6 @@ class DummyAWSService(aws_service.BaseAWSService):
             self.terminate_instance_callback(instance_id)
 
         instance = self.instances[instance_id]
-        if self.terminate_instance_callback:
-            self.terminate_instance_callback(instance)
-
         instance._state.code = 48
         instance._state.name = 'terminated'
         return instance


### PR DESCRIPTION
Don't call terminate_instance_callback twice.  Callsites expect the
argument to be the instance ID, not the instance object.