### PR TITLE
Improve unit testing of attach/detach volume

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -190,7 +190,7 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def detach_volume(self, vol_id, instance_id=None, force=True):
+    def detach_volume(self, vol_id, instance_id, force=True):
         pass
 
     @abc.abstractmethod
@@ -515,7 +515,7 @@ class AWSService(BaseAWSService):
             block_device_mapping=block_device_mapping
         )
 
-    def detach_volume(self, vol_id, instance_id=None, force=True):
+    def detach_volume(self, vol_id, instance_id, force=True):
         detach_volume = self.retry(self.conn.detach_volume)
         return detach_volume(
             vol_id, instance_id=instance_id, force=force)

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -332,25 +332,6 @@ class TestRunEncryption(unittest.TestCase):
 
         self.assertTrue(self.terminate_instance_called)
 
-    def test_register_ami_hvm(self):
-        """ Test the new (non-legacy) code path in register_ami().
-        """
-        aws_svc, encryptor_image, guest_image = build_aws_service()
-        encryptor_instance = aws_svc.run_instance(encryptor_image.id)
-        guest_instance = aws_svc.run_instance(guest_image.id)
-        mv_bdm = encryptor_instance.block_device_mapping
-        mv_root_volume_id = mv_bdm['/dev/sda1'].volume_id
-        encrypt_ami._register_ami(
-            aws_svc,
-            encryptor_instance,
-            encryptor_image,
-            'Name',
-            'Description',
-            legacy=False,
-            guest_instance=guest_instance,
-            mv_root_id=mv_root_volume_id
-        )
-
     def test_clean_up_root_snapshot(self):
         """ Test that we clean up the root snapshot if an exception is
         raised while waiting for it to complete.


### PR DESCRIPTION
When detaching a volume during a unit test, remove it from the
instance's block device mapping.  Add a check for attempting to attach a
volume when the device name is already in use.  Update the
detach_volume() function signature, so that the instance ID is required.

Remove test_register_ami_hvm.  This test started failing because
_register_ami() assumes that the root device has already been removed
from the instance.  I verified that the existing tests cover the
non-legacy code path.