### PR TITLE
Added Brkt CLI Shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python: "2.7"
 install: >-
   pip install boto boto3 google-api-python-client iso8601 oauthlib
-  pyjwt pyvmomi PyYAML pyflakes requests
+  pyjwt pyvmomi PyYAML pyflakes requests prompt_toolkit pygments termcolor
 script: ./test-travis
 cache: pip

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -34,6 +34,7 @@ from brkt_cli.validation import ValidationError
 # the brkt command and CSP-specific code.
 SUBCOMMAND_MODULE_PATHS = [
     'brkt_cli.auth',
+    'brkt_cli.shell',
     'brkt_cli.aws',
     'brkt_cli.make_token',
     'brkt_cli.config',
@@ -449,6 +450,9 @@ def main():
         config.save_config()
 
     result = 1
+
+    if subcommand.name() == 'shell':
+        subcommand.set_subparsers(subparsers)
 
     # Run the subcommand.
     allow_debug_log = True

--- a/brkt_cli/__init__.py
+++ b/brkt_cli/__init__.py
@@ -452,7 +452,7 @@ def main():
     result = 1
 
     if subcommand.name() == 'shell':
-        subcommand.set_subparsers(subparsers)
+        subcommand.subparsers = subparsers
 
     # Run the subcommand.
     allow_debug_log = True

--- a/brkt_cli/shell/__init__.py
+++ b/brkt_cli/shell/__init__.py
@@ -27,15 +27,16 @@ SUBCOMMAND_NAME = 'shell'
 
 
 class ShellSubcommand(Subcommand):
+    """
+    :type subparsers: argparse._SubParsersAction
+    """
 
     def __init__(self):
+        self.subparsers = None
         self.cfg = None
 
     def name(self):
         return SUBCOMMAND_NAME
-
-    def set_subparsers(self, subparsers):
-        self.subparsers = subparsers
 
     def register(self, subparsers, parsed_config):
         self.cfg = parsed_config
@@ -58,9 +59,18 @@ class ShellSubcommand(Subcommand):
             help=argparse.SUPPRESS
         )
 
+        parser.add_argument(
+            '--foo',
+            dest='foo',
+            action='store',
+            default=False,
+            type=int,
+            help=argparse.SUPPRESS
+        )
+
     def run(self, values):
-        brkt_cmd = traverse_tree("brkt", self.subparsers, None, "", "", None)
-        brkt_app = App(ShellCompleter(brkt_cmd))
+        brkt_cmd = traverse_tree('brkt', self.subparsers, None, '', '', None, '', None)
+        brkt_app = App(ShellCompleter(brkt_cmd), brkt_cmd)
         brkt_app.dummy = values.dummy
         brkt_app.run()
 

--- a/brkt_cli/shell/__init__.py
+++ b/brkt_cli/shell/__init__.py
@@ -59,10 +59,27 @@ class ShellSubcommand(Subcommand):
             help=argparse.SUPPRESS
         )
 
+        parser.add_argument(
+            '--mouse-support',
+            dest='mouse_support',
+            action='store_true',
+            default=False,
+            help='Enables mouse support in the shell'
+        )
+
+        parser.add_argument(
+            '--dev',
+            dest='dev_mode',
+            action='store_true',
+            default=False,
+            help='Enables dev mode'
+        )
+
     def run(self, values):
         brkt_cmd = traverse_tree('brkt', self.subparsers, None, '', '', None, '', None)
-        brkt_app = App(ShellCompleter(brkt_cmd), brkt_cmd)
+        brkt_app = App(ShellCompleter(brkt_cmd), brkt_cmd, mouse_support=values.mouse_support)
         brkt_app.dummy = values.dummy
+        brkt_app.dev_mode = values.dev_mode
         brkt_app.run()
 
         return 0

--- a/brkt_cli/shell/__init__.py
+++ b/brkt_cli/shell/__init__.py
@@ -1,0 +1,75 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import unicode_literals
+import argparse
+import logging
+
+from brkt_cli.shell.app import App
+from brkt_cli.shell.completer import ShellCompleter
+from brkt_cli.shell.raw_commands import traverse_tree
+from brkt_cli.subcommand import Subcommand
+
+log = logging.getLogger(__name__)
+
+
+SUBCOMMAND_NAME = 'shell'
+
+
+class ShellSubcommand(Subcommand):
+
+    def __init__(self):
+        self.cfg = None
+
+    def name(self):
+        return SUBCOMMAND_NAME
+
+    def set_subparsers(self, subparsers):
+        self.subparsers = subparsers
+
+    def register(self, subparsers, parsed_config):
+        self.cfg = parsed_config
+
+        parser = subparsers.add_parser(
+            self.name(),
+            description=(
+                'Brkt CLI Shell'
+            ),
+            help='Brkt CLI Shell',
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+
+        # Dummy will just pretend to run command but not actually run it. Used for development and testing.
+        parser.add_argument(
+            '--dummy',
+            dest='dummy',
+            action='store_true',
+            default=False,
+            help=argparse.SUPPRESS
+        )
+
+    def run(self, values):
+        brkt_cmd = traverse_tree("brkt", self.subparsers, None, "", "", None)
+        brkt_app = App(ShellCompleter(brkt_cmd))
+        brkt_app.dummy = values.dummy
+        brkt_app.run()
+
+        return 0
+
+
+def can_get_docs(app):
+    return True
+
+
+def get_subcommands():
+    return [ShellSubcommand()]

--- a/brkt_cli/shell/__init__.py
+++ b/brkt_cli/shell/__init__.py
@@ -59,15 +59,6 @@ class ShellSubcommand(Subcommand):
             help=argparse.SUPPRESS
         )
 
-        parser.add_argument(
-            '--foo',
-            dest='foo',
-            action='store',
-            default=False,
-            type=int,
-            help=argparse.SUPPRESS
-        )
-
     def run(self, values):
         brkt_cmd = traverse_tree('brkt', self.subparsers, None, '', '', None, '', None)
         brkt_app = App(ShellCompleter(brkt_cmd), brkt_cmd)

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -53,6 +53,8 @@ class App(object):
     :type set_args: dict[unicode, dict[unicode, Any]]
     :type saved_commands: dict[unicode, unicode]
     :type _vi_mode: bool
+    :type mouse_support: bool
+    :type dev_mode: bool
     :type _cli: prompt_toolkit.CommandLineInterface
     """
 
@@ -71,14 +73,13 @@ class App(object):
         COMMAND_PREFIX + u'set': set_inner_command,
         COMMAND_PREFIX + u'get': get_inner_command,
         COMMAND_PREFIX + u'del': del_inner_command,
-        COMMAND_PREFIX + u'dev': dev_inner_command,
         COMMAND_PREFIX + u'alias': alias_inner_command,
         COMMAND_PREFIX + u'get_alias': get_alias_inner_command,
         COMMAND_PREFIX + u'unalias': unalias_inner_command,
         COMMAND_PREFIX + u'setting': setting_inner_command,
     }
 
-    def __init__(self, completer, cmd):
+    def __init__(self, completer, cmd, mouse_support=False):
         """
         The app that controls the console UI and anything relating to the shell.
         :param completer: the completer to suggest words
@@ -95,6 +96,8 @@ class App(object):
         self.set_args = {}
         self.saved_commands = {}
         self._vi_mode = False
+        self.mouse_support = mouse_support
+        self.dev_mode = False
 
         def manpage_on_changed(val):
             self._has_manpage = val
@@ -275,6 +278,8 @@ class App(object):
             (Token.Toolbar.Separator, ' | '),
             (Token.Toolbar.Help, 'Editing Mode: ' + ('VI' if self._vi_mode else 'Emacs')),
         ]
+        if self.dev_mode:
+            ret.extend([(Token.Toolbar.Separator, ' | '), (Token.Toolbar.Help, 'Dev Mode: ON')])
         if self.dummy:
             ret.extend([(Token.Toolbar.Separator, ' | '), (Token.Toolbar.Help, 'Dummy Mode: ON')])
         return ret
@@ -362,7 +367,7 @@ class App(object):
             on_abort=AbortAction.RETRY,
             layout=self.make_layout(),
             editing_mode=EditingMode.VI if self._vi_mode else EditingMode.EMACS,
-            mouse_support=False,
+            mouse_support=self.mouse_support,
         )
 
     def make_cli_interface(self):

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -325,18 +325,17 @@ class App(object):
         # the text
         try:  # Try to parse the manually specified arguments via the actual raw argparse function
             existing_args = command.parse_args(args_text.split())
-        except:
-            existing_args = Namespace()
+        except Exception as err:
+            if err.message == 'print_help':
+                existing_args = Namespace(help=True)
+            else:
+                existing_args = Namespace()
 
         set_args_dict = self.set_args[command.path]  # Get the set arguments from the app
         positional_idx = 0  # Count the number of positional (required too) arguments there are in a argparse command
         final_args = []
         final_arg_texts = []
-        for arg in command.optional_arguments + command.positionals:  # Go through every argument in a command that is
-            # not help or version or dev mode when dev mode is off
-            if arg.type == arg.Type.Help or arg.type == arg.Type.Version:
-                continue
-
+        for arg in command.optional_arguments + command.positionals:  # Go through every argument in a command
             if arg.dev is True and self.dev_mode is False:
                 continue
 
@@ -402,6 +401,8 @@ class App(object):
                 final_arg_texts.append(' '.join([arg.tag] * final_opt_arg['value']))
             elif arg.type == arg.Type.AppendConst and final_opt_arg['value'] is True:
                 final_arg_texts.append(arg.tag)  # Adds the tag if the value passed says it can be specified: `{tag}`
+            elif arg.type == arg.Type.Help or arg.type == arg.Type.Version:
+                final_arg_texts.append(arg.tag)  # Adds the tag if it is help or version: `{tag}`
 
         final_arg_texts.extend(map(lambda x: x['value'],
                                    sorted(filter(lambda x: x['positional'] is not None, final_args),

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -35,16 +35,15 @@ from pygments.token import Token
 from brkt_cli.shell.enum import Enum
 from brkt_cli.shell.get_set_inner_commmands import set_inner_command, get_inner_command, del_inner_command
 from brkt_cli.shell.inner_commands import exit_inner_command, InnerCommandError, \
-    help_inner_command
+    help_inner_command, dev_inner_command
 from brkt_cli.shell.manpage import Manpage
 from brkt_cli.shell.save_command import alias_inner_command, get_alias_inner_command, unalias_inner_command
-from brkt_cli.shell.settings import Setting, setting_inner_command, bool_parse_value
+from brkt_cli.shell.settings import Setting, setting_inner_command, bool_parse_value, bool_validate_change
 
 
 class App(object):
     """
     :type COMMAND_PREFIX: unicode
-    :type INNER_COMMANDS: dict[unicode, brkt_cli.shell.inner_commands.InnerCommand]
     :type completer: brkt_cli.shell.completer.ShellCompleter
     :type cmd: brkt_cli.shell.raw_commands.CommandPromptToolkit
     :type _has_manpage: bool
@@ -56,6 +55,7 @@ class App(object):
     :type _vi_mode: bool
     :type mouse_support: bool
     :type dev_mode: bool
+    :type inner_commands: dict[unicode, brkt_cli.shell.inner_commands.InnerCommand]
     :type _cli: prompt_toolkit.CommandLineInterface
     """
 
@@ -68,17 +68,6 @@ class App(object):
         Unknown, Exit = range(2)
 
     COMMAND_PREFIX = u'/'
-    INNER_COMMANDS = {
-        COMMAND_PREFIX + u'exit': exit_inner_command,
-        COMMAND_PREFIX + u'help': help_inner_command,
-        COMMAND_PREFIX + u'set': set_inner_command,
-        COMMAND_PREFIX + u'get': get_inner_command,
-        COMMAND_PREFIX + u'del': del_inner_command,
-        COMMAND_PREFIX + u'alias': alias_inner_command,
-        COMMAND_PREFIX + u'get_alias': get_alias_inner_command,
-        COMMAND_PREFIX + u'unalias': unalias_inner_command,
-        COMMAND_PREFIX + u'setting': setting_inner_command,
-    }
 
     def __init__(self, completer, cmd, mouse_support=False):
         """
@@ -99,6 +88,19 @@ class App(object):
         self._vi_mode = False
         self.mouse_support = mouse_support
         self.dev_mode = False
+        self.inner_commands = {
+            self.COMMAND_PREFIX + u'exit': exit_inner_command,
+            self.COMMAND_PREFIX + u'help': help_inner_command,
+            self.COMMAND_PREFIX + u'set': set_inner_command,
+            self.COMMAND_PREFIX + u'get': get_inner_command,
+            self.COMMAND_PREFIX + u'del': del_inner_command,
+            self.COMMAND_PREFIX + u'alias': alias_inner_command,
+            self.COMMAND_PREFIX + u'get_alias': get_alias_inner_command,
+            self.COMMAND_PREFIX + u'unalias': unalias_inner_command,
+            self.COMMAND_PREFIX + u'setting': setting_inner_command,
+        }
+        if self.dev_mode:
+            self.inner_commands[self.COMMAND_PREFIX + u'dev'] = dev_inner_command
 
         def token_on_changed(val):
             token_list = []
@@ -107,11 +109,11 @@ class App(object):
                 if got_cmd is None or got_cmd.has_subcommands() is True:
                     continue
                 token_list.extend(map(lambda x: (path, x.get_name()),
-                                  filter(lambda x: x.type is not x.Type.Help and x.type is not x.Type.Version and
-                                         x.get_name() == 'token' and
-                                         x.dev is False or (x.dev is True and self.dev_mode is True),
-                                         got_cmd.optional_arguments + got_cmd.positionals))
-                                 )  # Get All arguments that are not help or version and get their names and add them
+                                      filter(lambda x: x.type is not x.Type.Help and x.type is not x.Type.Version and
+                                                       x.get_name() == 'token' and
+                                                       x.dev is False or (x.dev is True and self.dev_mode is True),
+                                             got_cmd.optional_arguments + got_cmd.positionals))
+                                  )  # Get All arguments that are not help or version and get their names and add them
                 # to their command paths. This creates bunch of full paths
             for cmd_path, token_arg in token_list:
                 if cmd_path not in self.set_args:
@@ -123,6 +125,7 @@ class App(object):
                 for k in val.keys():
                     if k == 'token':
                         del self.set_args[cmd_path][k]
+
         self.manual_args = {
             'app': {
                 'token': (token_on_changed, token_on_delete),
@@ -131,6 +134,7 @@ class App(object):
 
         def manpage_on_changed(val):
             self._has_manpage = val
+
         def editing_mode_on_changed(val):
             if val == 'vi':
                 self._vi_mode = True
@@ -140,12 +144,15 @@ class App(object):
                 self._vi_mode = False
                 self._cli.application.editing_mode = EditingMode.EMACS
                 self._cli.editing_mode = EditingMode.EMACS
+
         self.settings = {
             'manpage': Setting('manpage', self._has_manpage, on_changed=manpage_on_changed,
                                str_acceptable_values=['true', 'false'],
                                parse_value=bool_parse_value,
+                               validate_change=bool_validate_change,
                                description='If "true" the manpage will be enabled so you can see command descriptions'),
-            'editing_mode': Setting('editing_mode', 'vi' if self._vi_mode else 'emacs', on_changed=editing_mode_on_changed,
+            'editing_mode': Setting('editing_mode', 'vi' if self._vi_mode else 'emacs',
+                                    on_changed=editing_mode_on_changed,
                                     str_acceptable_values=['vi', 'emacs'],
                                     description='The editing mode type for the prompt'),
         }
@@ -179,15 +186,15 @@ class App(object):
 
                 try:
                     cmd_text = self.parse_command(ret_doc).replace('\\$', '$').replace('\\(', '(').replace('\\)', ')')
-                except Exception as err:
-                    print InnerCommandError.format(err.message)
+                except InnerCommandError as err:
+                    print err.format_error()
                     continue
 
                 if cmd_text.startswith(self.COMMAND_PREFIX):
                     try:
-                        inner_cmd = self.INNER_COMMANDS[ret_doc.text.split()[0]]
+                        inner_cmd = self.inner_commands[ret_doc.text.split()[0]]
                     except KeyError:
-                        print "Error: Unknown command."
+                        print UnknownCommandError().format_error()
                     else:
                         try:
                             machine_cmd = inner_cmd.run_action(cmd_text, self)
@@ -201,7 +208,8 @@ class App(object):
                             print InnerCommandError.format(err.message)
                         except:
                             exec_info = sys.exc_info()
-                            print InnerCommandError.format("unknown error - %s\n%s\n%s" % (exec_info[0], exec_info[1], exec_info[2]))
+                            print InnerCommandError.format(
+                                "unknown error - %s\n%s\n%s" % (exec_info[0], exec_info[1], exec_info[2]))
                     continue
 
                 if self.dummy:
@@ -219,113 +227,164 @@ class App(object):
             pickle.dump(app_info, f, pickle.HIGHEST_PROTOCOL)
 
     def parse_command(self, ret_doc):
+        """
+        Parses and formats a raw command. This is the function that makes commands use aliases and embedded commands.
+        It also is responsible for replacing arguments with set arguments.
+        :param ret_doc: the document gotten from the returned command
+        :type ret_doc: prompt_toolkit.document.Document
+        :return: the parsed command
+        :rtype: unicode
+        :raises: InnerCommandError
+        :raises: UnknownCommandError
+        """
         cmd_text = ret_doc.text
-        embedded_commands = self.parse_embedded_commands(cmd_text)
+        embedded_commands = self.parse_embedded_command_text(cmd_text)  # Parse embedded commands
 
         if len(embedded_commands) > 0:
-            mod_len = 0
-            for emb_cmd in embedded_commands:
-                adj_cmd_start = emb_cmd[0] - mod_len
-                adj_cmd_end = emb_cmd[1] - mod_len
-                in_text = cmd_text[adj_cmd_start + 2:adj_cmd_end]
-                parsed_emb_cmd = self.parse_command(Document(text=in_text))
-                if parsed_emb_cmd is None:
-                    raise Exception('Unknown embedded command: $(%s)' % cmd_text[adj_cmd_start+2:adj_cmd_end])
-                if self.dummy:
-                    new_text = sys.argv[0] + ' ' + parsed_emb_cmd
-                else:
-                    p = subprocess.Popen(sys.argv[0] + ' ' + parsed_emb_cmd, shell=False, env=os.environ.copy(),
-                                         stdout=subprocess.PIPE)
-                    out, err = p.communicate()
-                    if err is not None:
-                        raise Exception('Could not run embedded command: $(%s)' % cmd_text[adj_cmd_start+2:adj_cmd_end])
-                    new_text = out
+            cmd_text = self._parse_embedded_commands(cmd_text, embedded_commands)
 
-                cmd_text = cmd_text[:adj_cmd_start] + new_text + cmd_text[adj_cmd_end + 1:]
-                cmd_len = emb_cmd[1] - emb_cmd[0] + 1
-                mod_len += cmd_len - len(new_text)
-
-        if cmd_text.startswith(self.COMMAND_PREFIX):
+        if cmd_text.startswith(self.COMMAND_PREFIX):  # If it is an inner command
             return cmd_text
-        elif cmd_text in self.saved_commands:
+        elif cmd_text in self.saved_commands:  # If it is a saved command, run again with the saved command
             return self.parse_command(Document(text=self.saved_commands[cmd_text]))
-        else:
-            command = self.completer.get_current_command(ret_doc, text_done=True)
-            if command is None:
-                return None
+        else:  # If it is a command
+            cmd_text_doc = Document(cmd_text)  # Make another document with the new parsed command
+            command = self.completer.get_current_command(cmd_text_doc, text_done=True)
+            if command is None:  # If command is none, error
+                raise UnknownCommandError()
 
-            if command.path in self.set_args:
-                args_text = ret_doc.text[self.completer.get_current_command_location(ret_doc)[1]:].strip()
-                try:
-                    existing_args = command.parse_args(args_text.split())
-                except:
-                    existing_args = Namespace()
-                set_args_dict = self.set_args[command.path]
-                positional_idx = 0
-                final_args = []
-                final_arg_texts = []
-                for arg in command.optional_arguments + command.positionals:
-                    new_arg = {
-                        'positional': None,
-                        'arg': arg,
-                        'value': None,
-                        'specified': False,
-                    }
-                    if arg.type == arg.Type.Help or arg.type == arg.Type.Version:
-                        continue
-
-                    if arg.__class__.__name__ == 'PositionalArgumentPromptToolkit':
-                        new_arg['positional'] = positional_idx
-                        positional_idx += 1
-
-                    if hasattr(existing_args, arg.dest):
-                        spec_arg_val = getattr(existing_args, arg.dest)
-
-                        if arg.default == spec_arg_val and spec_arg_val is not None:
-                            if new_arg['positional'] is None:
-                                new_arg['specified'] = arg.tag in args_text
-                            else:
-                                new_arg['specified'] = spec_arg_val in args_text
-                        else:
-                            new_arg['specified'] = True
-                        new_arg['value'] = spec_arg_val
-                    if arg.get_name() in set_args_dict and (not (
-                                hasattr(existing_args, arg.dest) and getattr(existing_args, arg.dest) is not None) or not
-                    new_arg['specified']):
-                        new_arg['value'] = set_args_dict[arg.get_name()]
-                        new_arg['specified'] = True
-
-                    if new_arg['value'] is not None and new_arg['specified']:
-                        final_args.append(new_arg)
-
-                # FIXME: THIS DOESNT WORK WITH APPEND CONST
-
-                for final_opt_arg in filter(lambda x: x['positional'] is None, final_args):
-                    arg = final_opt_arg['arg']
-                    if arg.type == arg.Type.Store:
-                        final_arg_texts.append(arg.tag + ' ' + str(final_opt_arg['value']))
-                    elif arg.type == arg.Type.StoreConst and final_opt_arg['value'] is True:
-                        final_arg_texts.append(arg.tag)
-                    elif arg.type == arg.Type.StoreFalse and final_opt_arg['value'] is False:
-                        final_arg_texts.append(arg.tag)
-                    elif arg.type == arg.Type.StoreTrue and final_opt_arg['value'] is True:
-                        final_arg_texts.append(arg.tag)
-                    elif arg.type == arg.Type.Append:
-                        final_arg_texts.append(
-                            ' '.join(map(lambda val: arg.tag + ' ' + val, final_opt_arg['value'])))
-                    elif arg.type == arg.Type.AppendConst or arg.type == arg.Type.Count:
-                        final_arg_texts.append(' '.join(map(lambda val: arg.tag, final_opt_arg['value'])))
-
-                final_arg_texts.extend(map(lambda x: x['value'],
-                                           sorted(filter(lambda x: x['positional'] is not None, final_args),
-                                                  key=lambda x: x['positional'])))
-
-                cmd_text = ret_doc.text[:self.completer.get_current_command_location(ret_doc)[1]] + ' ' + ' '.join(
-                    final_arg_texts)
+            if command.path in self.set_args:  # if there is the possibility of set args in this command, parse it
+                cmd_text = self._parse_set_args_commands(cmd_text_doc, command)
             return cmd_text
+
+    def _parse_embedded_commands(self, cmd_text, embedded_commands):
+        """
+        Parses embedded commands (`$(COMMAND)`) from a text.
+        :param cmd_text: the raw command text with raw embedded command
+        :type cmd_text: unicode
+        :param embedded_commands: the list of embedded commands
+        :type embedded_commands: list[(int, int)]
+        :return: the command text with the embedded commands replaced with their outputs
+        :rtype: unicode
+        :raises: InnerCommandError
+        """
+        mod_len = 0  # The modified length index of the text. This is because the output of an embedded command could 
+        # be smaller or larger than the raw embedded command. For example, `$(foo)` is smaller than `helloworld`
+        for emb_cmd in embedded_commands:
+            adj_cmd_start = emb_cmd[0] - mod_len  # Adjusted command indexes based on the modified length
+            adj_cmd_end = emb_cmd[1] - mod_len
+            in_text = cmd_text[adj_cmd_start + 2:adj_cmd_end]  # The text inside of the `$()`
+            try:  # Try to parse the inner command
+                parsed_emb_cmd = self.parse_command(Document(text=in_text))
+            except UnknownCommandError:  # If you find an unknown command error, make it a bit more verbose
+                raise InnerCommandError('Unknown embedded command: $(%s)' % cmd_text[adj_cmd_start + 2:adj_cmd_end])
+
+            if self.dummy:  # If dummy mode enabled, don't acutually run the command
+                new_text = sys.argv[0] + ' ' + parsed_emb_cmd
+            else:
+                p = subprocess.Popen(sys.argv[0] + ' ' + parsed_emb_cmd, shell=False, env=os.environ.copy(),
+                                     stdout=subprocess.PIPE)  # Run the command and get the output
+                out, err = p.communicate()
+                if err is not None:
+                    raise InnerCommandError(
+                        'Could not run embedded command: $(%s)' % cmd_text[adj_cmd_start + 2:adj_cmd_end])
+                new_text = out
+
+            cmd_text = cmd_text[:adj_cmd_start] + new_text + cmd_text[adj_cmd_end + 1:]  # Replace the `$()` in the
+            # command text with the output of the command
+            cmd_len = emb_cmd[1] - emb_cmd[0] + 1
+            mod_len += cmd_len - len(new_text)  # Adjust the modified length index
+        return cmd_text
+
+    def _parse_set_args_commands(self, doc, command):
+        """
+        Parses the command and builds the set arguments into the command
+        :param doc: the document with the raw text. Usually manually created for this function to parse.
+        :type doc: prompt_toolkit.document.Document
+        :param command: the command of the text
+        :type command: brkt_cli.shell.raw_commands.CommandPromptToolkit
+        :return: the parsed text
+        :rtype: unicode
+        """
+        args_text = doc.text[self.completer.get_current_command_location(doc)[1]:].strip()  # Get the arguments part of
+        # the text
+        try:  # Try to parse the manually specified arguments via the actual raw argparse function
+            existing_args = command.parse_args(args_text.split())
+        except:
+            existing_args = Namespace()
+
+        set_args_dict = self.set_args[command.path]  # Get the set arguments from the app
+        positional_idx = 0  # Count the number of positional (required too) arguments there are in a argparse command
+        final_args = []
+        final_arg_texts = []
+        for arg in command.optional_arguments + command.positionals:
+            new_arg = {
+                'positional': None,
+                'arg': arg,
+                'value': None,
+                'specified': False,
+            }
+            if arg.type == arg.Type.Help or arg.type == arg.Type.Version:
+                continue
+
+            if arg.dev is True and self.dev_mode is False:
+                continue
+
+            if arg.__class__.__name__ == 'PositionalArgumentPromptToolkit':
+                new_arg['positional'] = positional_idx
+                positional_idx += 1
+
+            if hasattr(existing_args, arg.dest):
+                spec_arg_val = getattr(existing_args, arg.dest)
+                if arg.default == spec_arg_val and spec_arg_val is not None:
+                    if new_arg['positional'] is None:
+                        new_arg['specified'] = arg.tag in args_text
+                    else:
+                        new_arg['specified'] = spec_arg_val in args_text
+                else:
+                    new_arg['specified'] = True
+
+                new_arg['value'] = spec_arg_val
+                if arg.type == arg.Type.AppendConst and new_arg['value'] is not None:
+                    new_arg['value'] = arg.raw.const in new_arg['value']
+                elif arg.type == arg.Type.StoreFalse:
+                    new_arg['value'] = True
+            if arg.get_name() in set_args_dict and (not (
+                        hasattr(existing_args, arg.dest) and getattr(existing_args, arg.dest) is not None) or not
+                        new_arg['specified']):
+                new_arg['value'] = set_args_dict[arg.get_name()]
+                new_arg['specified'] = True
+
+            if new_arg['value'] is not None and new_arg['specified']:
+                final_args.append(new_arg)
+
+        for final_opt_arg in filter(lambda x: x['positional'] is None, final_args):
+            arg = final_opt_arg['arg']
+            if arg.type == arg.Type.Store:
+                final_arg_texts.append(arg.tag + ' ' + str(final_opt_arg['value']))
+            elif arg.type == arg.Type.StoreConst and final_opt_arg['value'] is not None:
+                final_arg_texts.append(arg.tag)
+            elif arg.type == arg.Type.StoreFalse and final_opt_arg['value'] is True:
+                final_arg_texts.append(arg.tag)
+            elif arg.type == arg.Type.StoreTrue and final_opt_arg['value'] is True:
+                final_arg_texts.append(arg.tag)
+            elif arg.type == arg.Type.Append:
+                final_arg_texts.append(
+                    ' '.join(map(lambda val: arg.tag + ' ' + val, final_opt_arg['value'])))
+            elif arg.type == arg.Type.Count:
+                final_arg_texts.append(' '.join([arg.tag] * final_opt_arg['value']))
+            elif arg.type == arg.Type.AppendConst and final_opt_arg['value'] is True:
+                final_arg_texts.append(arg.tag)
+
+        final_arg_texts.extend(map(lambda x: x['value'],
+                                   sorted(filter(lambda x: x['positional'] is not None, final_args),
+                                          key=lambda x: x['positional'])))
+
+        return doc.text[:self.completer.get_current_command_location(doc)[1]] + ' ' + ' '.join(
+            final_arg_texts)
 
     @staticmethod
-    def parse_embedded_commands(text):
+    def parse_embedded_command_text(text):
         """
         Parses embedded commands (`foo $(embedded) bar`) and returns the locations of them.
         :param text: the text to parse
@@ -490,3 +549,8 @@ class App(object):
         app = self.make_app(self.completer)
 
         return CommandLineInterface(application=app, eventloop=loop)
+
+
+class UnknownCommandError(InnerCommandError):
+    def __init__(self):
+        super(UnknownCommandError, self).__init__('Unknown command')

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -361,6 +361,14 @@ class App(object):
             """
             event.cli.set_return_value(self.MachineCommands.Exit)
 
+        @self.key_manager.registry.add_binding(Keys.ControlD, eager=True)
+        def exit_(event):
+            """
+            When ctrl d is pressed, return the EXIT machine_command to the cli.run() command.
+            :param event:
+            """
+            event.cli.set_return_value(self.MachineCommands.Exit)
+
         return Application(
             buffer=self.make_buffer(completer),
             key_bindings_registry=self.key_manager.registry,

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -1,0 +1,226 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+import subprocess
+from prompt_toolkit import Application, AbortAction, CommandLineInterface, filters
+from prompt_toolkit.buffer import Buffer, AcceptAction
+from prompt_toolkit.document import Document
+from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.filters import IsDone, Always, RendererHeightIsKnown
+from prompt_toolkit.key_binding.manager import KeyBindingManager
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import HSplit, ConditionalContainer, Window, FillControl, BufferControl, TokenListControl
+from prompt_toolkit.layout.dimension import LayoutDimension
+from prompt_toolkit.layout.screen import Char
+from prompt_toolkit.shortcuts import create_prompt_layout, create_eventloop
+from pygments.token import Token
+
+from brkt_cli.shell.enum import enum
+from brkt_cli.shell.inner_commands import exit_inner_command, manpage_inner_command, InnerCommandError, \
+    help_inner_command
+
+
+class App:
+    """
+    The app that controls the console UI and anything relating to the shell.
+    :param completer: the completer to suggest words
+    """
+    MACHINE_COMMANDS = enum(UNKNOWN=0, EXIT=1)
+    COMMAND_PREFIX = '/'
+    INNER_COMMANDS = {
+        COMMAND_PREFIX + 'exit': exit_inner_command,
+        COMMAND_PREFIX + 'manpage': manpage_inner_command,
+        COMMAND_PREFIX + 'help': help_inner_command,
+    }
+
+    def __init__(self, completer):
+        self.completer = completer
+        self.manpage = u''
+        self.has_manpage = True
+        self.key_manager = None
+        self.dummy = False
+        self._cli = self.make_cli_interface()
+
+    def run(self):
+        """
+        Runs the app in a while True loop. The app can only be broken from an error or EXIT machine_command. It catches
+        all inner commands and runs them. At the end of a command, it clears the manpage screen.
+        """
+        while True:
+            try:
+                ret = self._cli.run(reset_current_buffer=True)
+            except (KeyboardInterrupt, EOFError):
+                self._cli.eventloop.close()
+                break
+            else:
+                if ret is self.MACHINE_COMMANDS.EXIT:
+                    self._cli.eventloop.close()
+                    break
+                if ret.text.startswith(self.COMMAND_PREFIX):
+                    try:
+                        cmd = self.INNER_COMMANDS[ret.text.split()[0]]
+                        mac_cmd = cmd.run_action(ret.text, self)
+                        if mac_cmd == self.MACHINE_COMMANDS.EXIT:
+                            self._cli.eventloop.close()
+                            break
+                    except KeyError:
+                        print "Error: Unknown command."
+                    except InnerCommandError as err:
+                        print err.format_error()
+                    continue
+                self.manpage = u''
+                self._cli.buffers['manpage'].reset(initial_document=Document(self.manpage, cursor_position=0))
+                self._cli.request_redraw()
+
+                if not self.dummy:
+                    p = subprocess.Popen(sys.argv[0] + ' ' + ret.text, shell=True, env=os.environ.copy())
+                    p.communicate()
+
+    def get_bottom_toolbar_tokens(self, _):
+        """
+        Constructs the bottom toolbar
+        :param _:
+        :return: A list of all elements in the toolbar
+        """
+        ret = [
+            (Token.Toolbar.Help, 'Press ctrl q to quit'),
+            (Token.Toolbar.Separator, ' | '),
+            (Token.Toolbar.Help, 'Manpage Window: ' + ('ON' if self.has_manpage else 'OFF')),
+        ]
+        if self.dummy:
+            ret.extend([(Token.Toolbar.Separator, ' | '), (Token.Toolbar.Help, 'Dummy Mode: ON')])
+        return ret
+
+    def make_layout(self):
+        """
+        Constructs the layout of the CLI UI
+        :return: The layout in horizontal sections
+        """
+        return HSplit([
+            create_prompt_layout(
+                message=u'brkt> ',
+                reserve_space_for_menu=8,
+                wrap_lines=True,
+            ),  # The command prompt
+            ConditionalContainer(
+                content=Window(height=LayoutDimension.exact(1),
+                               content=FillControl(u'\u2500',
+                                                   token=Token.Separator)),
+                filter=~IsDone() & filters.Condition(lambda _: self.has_manpage)
+            ),  # A separator between the command prompt and the manpage view. This disappears when
+            # self.has_manpage is False
+            ConditionalContainer(
+                content=Window(
+                    content=BufferControl(
+                        buffer_name='manpage',
+                    ),
+                    height=LayoutDimension(max=15),
+                ),
+                filter=~IsDone() & filters.Condition(lambda _: self.has_manpage),
+            ),  # The manpage help display. This disappears when self.has_manpage is False
+            ConditionalContainer(
+                content=Window(
+                    TokenListControl(
+                        self.get_bottom_toolbar_tokens,
+                        default_char=Char(' ', Token.Toolbar)
+                    ),
+                    height=LayoutDimension.exact(1)
+                ),
+                filter=~IsDone() & RendererHeightIsKnown()
+            )  # The bottom toolbar, which displays useful info to the user
+        ])
+
+    def make_buffer(self, completer):
+        """
+        This function makes a buffer for the app to use
+        :param completer: the completer to suggest words
+        :return: the generated buffer
+        """
+        return Buffer(
+            enable_history_search=True,  # Allows the user to search through command history via the up and down arrows
+            completer=completer,  # The completer to suggest words to the user
+            complete_while_typing=Always(),  # Always give suggestions while typing
+            accept_action=AcceptAction.RETURN_DOCUMENT,  # Return the document (and the text) on enter/
+            on_text_changed=self.on_text_changed  # If the text in the user prompt is changed, run this function
+        )
+
+    def on_text_changed(self, buff):
+        """
+        Called every time the user changes the text (via input, delete, etc.) in the prompt.
+        It gets the manpage of the command in progress and writes it to the manpage buffer area
+        :param buff: the buffer that is changed
+        """
+        document = buff.document
+        if document.text.strip() and document.text_before_cursor != '':  # If there is text in prompt
+            arg = self.completer.get_current_argument(document)  # Get current argument (if there is one)
+            if arg is not None:  # If there is a current argument, display the description
+                self.manpage = unicode(arg.description)
+            elif document.text_before_cursor.split()[-1].startswith('-'):  # While typing an argument, don't show any
+                # manpage description
+                self.manpage = u''
+            else:  # If a command is in the prompt (and no argument), display the manpage of the command
+                command = self.completer.get_current_command(document)
+                if command is not None:
+                    self.manpage = u''
+                    self.manpage += command.description
+                    self.manpage += u'\n\n' + command.usage
+                else:  # If there is no valid command, clear manpage
+                    self.manpage = u''
+        else:  # If there is no text in prompt, clear manpage
+            self.manpage = u''
+
+        # Update the manpage UI with the values
+        self._cli.buffers['manpage'].reset(
+            initial_document=Document(self.manpage, cursor_position=0))
+        self._cli.request_redraw()
+
+    def make_app(self, completer):
+        """
+        Makes the application needed for the App. Creates a KeyBindingManager that traps key commands and pipes them to
+        functions.
+        :param completer: the completer to suggest words
+        :return: Application
+        """
+        self.key_manager = KeyBindingManager()
+
+        @self.key_manager.registry.add_binding(Keys.ControlQ, eager=True)
+        def exit_(event):
+            """
+            When ctrl q is pressed, return the EXIT machine_command to the cli.run() command.
+            :param event:
+            """
+            event.cli.set_return_value(self.MACHINE_COMMANDS.EXIT)
+
+        return Application(
+            buffer=self.make_buffer(completer),
+            buffers={
+                'manpage': Buffer(read_only=True)
+            },
+            key_bindings_registry=self.key_manager.registry,
+            on_abort=AbortAction.RETRY,
+            layout=self.make_layout(),
+            editing_mode=EditingMode.EMACS,
+        )
+
+    def make_cli_interface(self):
+        """
+        Makes the CLI interface needed for the App
+        :return: CommandLineInterface
+        """
+        loop = create_eventloop()
+        app = self.make_app(self.completer)
+
+        return CommandLineInterface(application=app, eventloop=loop)

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -110,8 +110,8 @@ class App(object):
                     continue
                 token_list.extend(map(lambda x: (path, x.get_name()),
                                       filter(lambda x: x.type is not x.Type.Help and x.type is not x.Type.Version and
-                                                       x.get_name() == 'token' and
-                                                       x.dev is False or (x.dev is True and self.dev_mode is True),
+                                             x.get_name() == 'token' and
+                                             x.dev is False or (x.dev is True and self.dev_mode is True),
                                              got_cmd.optional_arguments + got_cmd.positionals))
                                   )  # Get All arguments that are not help or version and get their names and add them
                 # to their command paths. This creates bunch of full paths
@@ -515,17 +515,10 @@ class App(object):
         self.key_manager = KeyBindingManager()
 
         @self.key_manager.registry.add_binding(Keys.ControlQ, eager=True)
-        def exit_(event):
-            """
-            When ctrl q is pressed, return the EXIT machine_command to the cli.run() command.
-            :param event:
-            """
-            event.cli.set_return_value(self.MachineCommands.Exit)
-
         @self.key_manager.registry.add_binding(Keys.ControlD, eager=True)
         def exit_(event):
             """
-            When ctrl d is pressed, return the EXIT machine_command to the cli.run() command.
+            When ctrl q or ctrl d is pressed, return the EXIT machine_command to the cli.run() command.
             :param event:
             """
             event.cli.set_return_value(self.MachineCommands.Exit)

--- a/brkt_cli/shell/app.py
+++ b/brkt_cli/shell/app.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and
 # limitations under the License.
 import os
-import re
 import sys
 
 import subprocess
@@ -179,7 +178,7 @@ class App(object):
                     continue
 
                 try:
-                    cmd_text = self.parse_command(ret_doc)
+                    cmd_text = self.parse_command(ret_doc).replace('\\$', '$').replace('\\(', '(').replace('\\)', ')')
                 except Exception as err:
                     print InnerCommandError.format(err.message)
                     continue
@@ -228,7 +227,8 @@ class App(object):
             for emb_cmd in embedded_commands:
                 adj_cmd_start = emb_cmd[0] - mod_len
                 adj_cmd_end = emb_cmd[1] - mod_len
-                parsed_emb_cmd = self.parse_command(Document(text=cmd_text[adj_cmd_start + 2:adj_cmd_end]))
+                in_text = cmd_text[adj_cmd_start + 2:adj_cmd_end]
+                parsed_emb_cmd = self.parse_command(Document(text=in_text))
                 if parsed_emb_cmd is None:
                     raise Exception('Unknown embedded command: $(%s)' % cmd_text[adj_cmd_start+2:adj_cmd_end])
                 if self.dummy:
@@ -324,9 +324,10 @@ class App(object):
                     final_arg_texts)
             return cmd_text
 
-    def parse_embedded_commands(self, text):
+    @staticmethod
+    def parse_embedded_commands(text):
         """
-
+        Parses embedded commands (`foo $(embedded) bar`) and returns the locations of them.
         :param text: the text to parse
         :type text: unicode
         :return: a list of embedded command start and end indexes
@@ -357,7 +358,6 @@ class App(object):
             raise Exception('Parentheses do not match and close')
 
         return embedded_commands
-
 
     def get_app_info(self):
         try:

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -37,6 +37,8 @@ class ShellCompleter(Completer):
         Gets all suggested options in the completer
         :param document: the document of the UI (has the text, etc.)
         :type document: prompt_toolkit.document.Document
+        :param include_aliases: include command aliases in list
+        :type include_aliases: bool
         :return: a list of all completions
         :rtype: list[unicode]
         """

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -57,15 +57,16 @@ class ShellCompleter(Completer):
 
         if all_text.startswith(App.COMMAND_PREFIX):
             if len(split_text) > 1 or all_text.endswith(' '):
-                if split_text[0] in App.INNER_COMMANDS:
-                    completions = App.INNER_COMMANDS[split_text[0]].completer(len(full_split_text) - 1, self.app,
-                                                                              full_split_text[1:], document)
+                if split_text[0] in self.app.inner_commands:
+                    completions = self.app.inner_commands[split_text[0]].completer(len(full_split_text) - 1, self.app,
+                                                                                   full_split_text[1:], document)
                 else:
                     completions = []
             else:
-                completions = App.INNER_COMMANDS.keys()
+                completions = self.app.inner_commands.keys()
         else:
-            completions = self._top_command.list_subcommand_names()+(self.app.saved_commands.keys() if include_aliases else [])  # Possible completion values
+            completions = self._top_command.list_subcommand_names() + (
+                self.app.saved_commands.keys() if include_aliases else [])  # Possible completion values
 
             tree_location = self._top_command  # Tree location is the current selected command that is narrowed down to
             # the exact command the user has typed in the prompt
@@ -93,8 +94,6 @@ class ShellCompleter(Completer):
                         # tree) to the new one that has been found
                         if tree_location.has_subcommands():  # If there are subcommands, list them
                             completions = tree_location.list_subcommand_names()
-                        elif len(full_split_text) == 0:
-                            completions = []
                         else:  # If there are no subcommands, suggest optional arguments
                             completions = []  # Reset completions because they are gonna be arguments now
                             for arg in tree_location.optional_arguments:  # Go through all arguments in the command and
@@ -111,13 +110,13 @@ class ShellCompleter(Completer):
                                         arg_specified = True
                                 if not arg_specified:  # If the argument hasn't been specified, add it to the suggested
                                     # list and go to next argument
-                                    if arg.dev is False or (arg.dev is True and self.app.dev_mode is True):  # Filter
-                                        # out dev mode args when not in dev mode
+                                    if arg.dev is False or self.app.dev_mode is True:  # Filter out dev mode args when
+                                        # not in dev mode
                                         completions.append(arg.tag)
                                     continue
-                                if arg.type is arg.Type.Append or arg.type is arg.Type.AppendConst or \
-                                                arg.type is arg.Type.Count:  # If the argument is an append or count
-                                    # type, add it regardless of if it has been specified by the user already
+                                if arg.type is arg.Type.Append or arg.type is arg.Type.Count:  # If the argument is an
+                                    # append or count type, add it regardless of if it has been specified by the
+                                    # user already
                                     completions.append(arg.tag)
                                     continue
                                 if arg.type is arg.Type.Help or arg.type is arg.Type.Version:  # If a death
@@ -126,10 +125,10 @@ class ShellCompleter(Completer):
                                     completions = []
                                     break
 
-                            last_full_arg = full_split_text[-1]  # Get the last fully specified argument in the list
-                            if last_full_arg and last_full_arg.startswith(
-                                    '-'):  # If there is a last argument and it is an
-                                # argument (this _should_ always be the case), then change some suggestions
+                            if len(full_split_text) > 0 and full_split_text[-1].startswith(
+                                    '-'):  # If there is a last argument and it is an argument,
+                                # then change some suggestions
+                                last_full_arg = full_split_text[-1]  # Get the last fully specified argument in the list
                                 try:
                                     arg = tree_location.make_tag_to_args_dict()[
                                         last_full_arg]  # Get the argument object
@@ -236,6 +235,7 @@ class ShellCompleter(Completer):
             return 0, 0
 
         # FIXME: This will break if the user inputs a double space or a different whitespace character
+        # because it's returning info that differs from the original text
         return 0, len(' '.join(all_text.split()[:cmd_end_word_index+1]))
 
     def get_current_argument(self, document):
@@ -256,7 +256,7 @@ class ShellCompleter(Completer):
         split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
         full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that
         # are complete.
-        if not all_text.endswith(' ') and not split_text[-1].startswith('-'):  # If the last word is unfinished and the
+        if not all_text.endswith(' ') and len(split_text) > 0 and not split_text[-1].startswith('-'):  # If the last word is unfinished and the
             # last word is not an argument, shorten the full text by one. This is to keep the manpage suggestions for
             # arguments with values. For example, `aws encrypt --aws-tag foob` (with `foob` being unfinished for
             # `foobar`), the manpage would be "--aws-tag" the entire time.

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -256,10 +256,10 @@ class ShellCompleter(Completer):
         split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
         full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that
         # are complete.
-        if not all_text.endswith(' ') and len(split_text) > 0 and not split_text[-1].startswith('-'):  # If the last word is unfinished and the
-            # last word is not an argument, shorten the full text by one. This is to keep the manpage suggestions for
-            # arguments with values. For example, `aws encrypt --aws-tag foob` (with `foob` being unfinished for
-            # `foobar`), the manpage would be "--aws-tag" the entire time.
+        if not all_text.endswith(' ') and len(split_text) > 0 and not split_text[-1].startswith('-'):  # If the last
+            # word is unfinished and the last word is not an argument, shorten the full text by one. This is to keep
+            # the manpage suggestions for arguments with values. For example, `aws encrypt --aws-tag foob` (with `foob`
+            # being unfinished for `foobar`), the manpage would be "--aws-tag" the entire time.
             del full_split_text[-1]
         # The difference between these two is shown in this example:
         # In `aws encrypt --aws-tag foob` (with `foob` being unfinished for `foobar`), the result of split_text would

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -11,6 +11,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+from copy import copy
+
 from prompt_toolkit.completion import Completer, Completion
 
 from brkt_cli.shell import App
@@ -18,25 +20,34 @@ from brkt_cli.shell import App
 
 class ShellCompleter(Completer):
     """
-    The completer for the brkt-cli
-    :param command: the overall brkt command as a CommandPromptToolkit object
+    :type _top_command: brkt_cli.shell.raw_commands.CommandPromptToolkit
+    :type app: brkt_cli.shell.app.App
     """
-    def __init__(self, command):
-        self.command = command
+    def __init__(self, top_command):
+        """
+        The completer for the brkt-cli
+        :param top_command: the overall brkt command
+        :type top_command: brkt_cli.shell.raw_commands.CommandPromptToolkit
+        """
+        self._top_command = top_command
+        self.app = None
 
     def get_completions(self, document, complete_event):
         """
         Called when the App needs to suggest words for the user
         :param document: the document of the UI (has the text, etc.)
-        :param complete_event:
+        :type document: prompt_toolkit.document.Document
+        :param complete_event: the completed event
+        :type complete_event: prompt_toolkit.completion.CompleteEvent
         :return: Completion objects that contain all matching suggestions
+        :rtype: prompt_toolkit.completion.Completion
         """
         word_before_cursor = document.get_word_before_cursor(WORD=True).lower()
         all_text = document.text_before_cursor
 
         split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
-        full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that
-        # are complete.
+        full_split_text = copy(split_text)  # full_split_text is all values (see above for example) separated by space
+        # that are complete.
         if not all_text.endswith(' ') and full_split_text:
             del full_split_text[-1]
         # The difference between these two is shown in this example:
@@ -45,12 +56,19 @@ class ShellCompleter(Completer):
         # would be `['aws', 'encrypt', '--aws-tag', 'foo']`
 
         if all_text.startswith(App.COMMAND_PREFIX):
-            completions = App.INNER_COMMANDS.keys()
+            if len(split_text) > 1 or all_text.endswith(' '):
+                if split_text[0] in App.INNER_COMMANDS:
+                    completions = App.INNER_COMMANDS[split_text[0]].completer(len(full_split_text)-1, self.app,
+                                                                              full_split_text[1:], document)
+                else:
+                    completions = []
+            else:
+                completions = App.INNER_COMMANDS.keys()
         else:
-            completions = self.command.list_subcommand_names()  # Possible completion values
+            completions = self._top_command.list_subcommand_names()  # Possible completion values
 
-            tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
-            #  command the user has typed in the prompt
+            tree_location = self._top_command  # Tree location is the current selected command that is narrowed down to
+            # the exact command the user has typed in the prompt
 
             has_started_args = False  # Flag to see if the prompt has started to list arguments
             for word_idx, word in enumerate(split_text):  # iterate through all words
@@ -63,10 +81,10 @@ class ShellCompleter(Completer):
                         # with '-'
                         has_started_args = True
                     if (word_idx != len(split_text) - 1 or word_before_cursor == '') \
-                            and idx is None and not has_started_args:  # if (the word is not last or the word right before
-                        # the curser is blank) and there is no index and we have not started parsing arguments, set
-                        # completions to blank. This is to catch any unknown command that would have been in the prompt.
-                        # For example, `aws foobar` would return no completions because foobar is not a command.
+                            and idx is None and not has_started_args:  # If (the word is not last or the word right
+                        # before the curser is blank) and there is no index and we have not started parsing arguments,
+                        # set completions to blank. This is to catch any unknown command that would have been in the
+                        # prompt. For example, `aws foobar` would return no completions because foobar is not a command.
                         completions = []
                         break
                     if idx is not None:  # If an index was found
@@ -75,29 +93,32 @@ class ShellCompleter(Completer):
                         # tree) to the new one that has been found
                         if tree_location.has_subcommands():  # If there are subcommands, list them
                             completions = tree_location.list_subcommand_names()
+                        elif len(full_split_text) == 0:
+                            completions = []
                         else:  # If there are no subcommands, suggest optional arguments
                             completions = []  # Reset completions because they are gonna be arguments now
-                            for arg in tree_location.optional_arguments:  # Go through all arguments in the command and add
-                                # the arguments allowed to the suggested completions. Arguments are disallowed if they are
-                                # specified already. The exception to that is if the argument is a type that can be
-                                # specified multiple times. No arguments are suggested if there is a death argument
-                                # (one that does something completely different than what the command is supposed to do,
-                                # and therefore kills all the other arguments. An example of this is "--help").
+                            for arg in tree_location.optional_arguments:  # Go through all arguments in the command and
+                                # add the arguments allowed to the suggested completions. Arguments are disallowed if
+                                # they are specified already. The exception to that is if the argument is a type that
+                                # can be specified multiple times. No arguments are suggested if there is a death
+                                # argument (one that does something completely different than what the command is
+                                # supposed to do, and therefore kills all the other arguments. An example of this is
+                                # "--help").
                                 arg_specified = False  # Flag to see if an argument has been specified yet by the user
                                 # in the prompt
                                 for parts in split_text:
                                     if parts.startswith('-') and parts == arg.tag:
                                         arg_specified = True
-                                if not arg_specified:  # If the argument hasn't been specified, add it to the suggested list
-                                    #  and go to next argument
+                                if not arg_specified:  # If the argument hasn't been specified, add it to the suggested
+                                    # list and go to next argument
                                     completions.append(arg.tag)
                                     continue
-                                if arg.type is arg.TYPE_ENUM.APPEND or arg.type is arg.TYPE_ENUM.APPEND_CONST or \
-                                                arg.type is arg.TYPE_ENUM.COUNT:  # If the argument is an append or count type, add
-                                    # it regardless of if it has been specified by the user already
+                                if arg.type is arg.Type.Append or arg.type is arg.Type.AppendConst or \
+                                        arg.type is arg.Type.Count:  # If the argument is an append or count
+                                    # type, add it regardless of if it has been specified by the user already
                                     completions.append(arg.tag)
                                     continue
-                                if arg.type is arg.TYPE_ENUM.HELP or arg.type is arg.TYPE_ENUM.VERSION:  # If a death
+                                if arg.type is arg.Type.Help or arg.type is arg.Type.Version:  # If a death
                                     # argument has been specified ("--help" or "--version"), then delete all suggested
                                     # completions and break the loop.
                                     completions = []
@@ -111,16 +132,16 @@ class ShellCompleter(Completer):
                                     arg = tree_location.make_tag_to_args_dict()[
                                         last_full_arg]  # Get the argument object
                                     # from the tag
-                                    if arg.type is arg.TYPE_ENUM.STORE or arg.type is arg.TYPE_ENUM.APPEND \
-                                            or arg.type is arg.TYPE_ENUM.COUNT:  # If an argument is one where you manually
-                                        # specify the value (most arguments, just not the death arguments or the constant
-                                        # arguments)
-                                        if arg.choices is not None:  # If the argument has specified choices, suggest those
+                                    if arg.type is arg.Type.Store or arg.type is arg.Type.Append:  # If an
+                                        # argument is one where you manually specify the value (most arguments, just not
+                                        #  the death arguments, count argument, or the constant arguments)
+                                        if arg.choices is not None:  # If the argument has specified choices, suggest
+                                            # those
                                             completions = arg.choices
                                         else:  # Otherwise, suggest nothing
                                             completions = []
-                                except KeyError:  # Do nothing if the argument is wrong/unknown. Nothing in this case would
-                                    # suggest the arguments for the command.
+                                except KeyError:  # Do nothing if the argument is wrong/unknown. Nothing in this case
+                                    # would suggest the arguments for the command.
                                     pass
                 except KeyError:  # If there is a key error somewhere, make the completions be empty
                     if completions is None:
@@ -134,19 +155,23 @@ class ShellCompleter(Completer):
                 yield Completion(completion, -len(word_before_cursor))  # Return (yield) all completions with the
                 # completion name and the start position of the completion
 
-    def get_current_command(self, document):
+    def get_current_command(self, document, text_done):
         """
         Gets the current command that the user is in. For example, if the user enters `aws encrypt`, the command would
         be the AWS Encrypt command object. Does not matter if arguments are specified in the text. If the user enters
         `aws enc` (`enc` as in an unfinished command or an unknown subcommand), the command would be AWS. However, if
         the user enters an unknown top level command `foo`, for example, the command would be None.
         :param document: the object containing useful stuff like text
+        :param text_done: if the document is done and has been entered, ignore where the cursor is
         :return: CommandPromptToolkit object with the current and selected command
         """
-        all_text = document.text_before_cursor
+        if text_done:
+            all_text = document.text
+        else:
+            all_text = document.text_before_cursor
 
-        tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
-        #  command the user has typed in the prompt
+        tree_location = self._top_command  # Tree location is the current selected command that is narrowed down to
+        # the exact command the user has typed in the prompt
 
         for word in all_text.split():  # Go through all words in the prompt and attempt to narrow down to the exact
             # command being used
@@ -154,14 +179,48 @@ class ShellCompleter(Completer):
             for index, name in enumerate(tree_location.list_subcommand_names()):
                 if name == word:
                     idx = index
-            if idx is not None:
+            if idx is None:
+                break
+            else:
                 tree_location = tree_location.subcommands[idx]
 
-        if tree_location == self.command:  # If there was no command that could be found and tree_location is still at
-            # the top command, return None
+        if tree_location == self._top_command:  # If there was no command that could be found and tree_location is
+            # still at the top command, return None
             return None
 
         return tree_location
+
+    def get_current_command_location(self, document):
+        """
+        Gets the location in the string where the current command starts and ends
+        :param document: the object containing useful stuff like text
+        :type document: prompt_toolkit.document.Document
+        :return: A tuple with the start and finish indexes
+        :rtype: (int, int)
+        """
+        all_text = document.text
+
+        tree_location = self._top_command  # Tree location is the current selected command that is narrowed down to the
+        # exact command the user has typed in the prompt
+
+        cmd_end_word_index = 0
+
+        for word_idx, word in enumerate(all_text.split()):  # Go through all words in the prompt and attempt to narrow
+            # down to the exact command being used
+            idx = None
+            for index, name in enumerate(tree_location.list_subcommand_names()):
+                if name == word:
+                    idx = index
+            if idx is not None:
+                tree_location = tree_location.subcommands[idx]
+                cmd_end_word_index = word_idx
+
+        if tree_location == self._top_command:  # If there was no command that could be found and tree_location is
+            # still at the top command, return None
+            return 0, 0
+
+        # FIXME: This will break if the user inputs a double space or a different whitespace character
+        return 0, len(' '.join(all_text.split()[:cmd_end_word_index+1]))
 
     def get_current_argument(self, document):
         """
@@ -169,12 +228,14 @@ class ShellCompleter(Completer):
         would be the Auth Password argument object. If the user enters `auth --password --email`, the argument is Email.
         If the user enters `auth --password --ema` (`--ema` as in an unfinished parameter), the argument is None.
         :param document: the object containing useful stuff like text
+        :type document: prompt_toolkit.document.Document
         :return: ArgumentPromptToolkit object with the current and selected argument
+        :rtype: brkt_cli.shell.raw_commands.ArgumentPromptToolkit
         """
         all_text = document.text_before_cursor
 
-        tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
-        #  command the user has typed in the prompt
+        tree_location = self._top_command  # Tree location is the current selected command that is narrowed down to the
+        # exact command the user has typed in the prompt
 
         split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
         full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -109,7 +109,9 @@ class ShellCompleter(Completer):
                                         arg_specified = True
                                 if not arg_specified:  # If the argument hasn't been specified, add it to the suggested
                                     # list and go to next argument
-                                    completions.append(arg.tag)
+                                    if arg.dev is False or (arg.dev is True and self.app.dev_mode is True): # Filter out
+                                        # dev mode args when not in dev mode
+                                        completions.append(arg.tag)
                                     continue
                                 if arg.type is arg.Type.Append or arg.type is arg.Type.AppendConst or \
                                                 arg.type is arg.Type.Count:  # If the argument is an append or count

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -109,8 +109,8 @@ class ShellCompleter(Completer):
                                         arg_specified = True
                                 if not arg_specified:  # If the argument hasn't been specified, add it to the suggested
                                     # list and go to next argument
-                                    if arg.dev is False or (arg.dev is True and self.app.dev_mode is True): # Filter out
-                                        # dev mode args when not in dev mode
+                                    if arg.dev is False or (arg.dev is True and self.app.dev_mode is True):  # Filter
+                                        # out dev mode args when not in dev mode
                                         completions.append(arg.tag)
                                     continue
                                 if arg.type is arg.Type.Append or arg.type is arg.Type.AppendConst or \

--- a/brkt_cli/shell/completer.py
+++ b/brkt_cli/shell/completer.py
@@ -1,0 +1,207 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+from prompt_toolkit.completion import Completer, Completion
+
+from brkt_cli.shell import App
+
+
+class ShellCompleter(Completer):
+    """
+    The completer for the brkt-cli
+    :param command: the overall brkt command as a CommandPromptToolkit object
+    """
+    def __init__(self, command):
+        self.command = command
+
+    def get_completions(self, document, complete_event):
+        """
+        Called when the App needs to suggest words for the user
+        :param document: the document of the UI (has the text, etc.)
+        :param complete_event:
+        :return: Completion objects that contain all matching suggestions
+        """
+        word_before_cursor = document.get_word_before_cursor(WORD=True).lower()
+        all_text = document.text_before_cursor
+
+        split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
+        full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that
+        # are complete.
+        if not all_text.endswith(' ') and full_split_text:
+            del full_split_text[-1]
+        # The difference between these two is shown in this example:
+        # In `aws encrypt --aws-tag foo --encry` (with `--encry` being unfinished for `--encryptor-ami`), the result of
+        # split_text would be `['aws', 'encrypt', '--aws-tag', 'foo', '--encry']`, while the result of full_split_text
+        # would be `['aws', 'encrypt', '--aws-tag', 'foo']`
+
+        if all_text.startswith(App.COMMAND_PREFIX):
+            completions = App.INNER_COMMANDS.keys()
+        else:
+            completions = self.command.list_subcommand_names()  # Possible completion values
+
+            tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
+            #  command the user has typed in the prompt
+
+            has_started_args = False  # Flag to see if the prompt has started to list arguments
+            for word_idx, word in enumerate(split_text):  # iterate through all words
+                try:
+                    idx = None  # If the selected word is a subcommand, mark that by setting idx
+                    for index, name in enumerate(tree_location.list_subcommand_names()):
+                        if name == word:
+                            idx = index
+                    if word.startswith('-'):  # Mark that we have started parsing arguments if the selected word starts
+                        # with '-'
+                        has_started_args = True
+                    if (word_idx != len(split_text) - 1 or word_before_cursor == '') \
+                            and idx is None and not has_started_args:  # if (the word is not last or the word right before
+                        # the curser is blank) and there is no index and we have not started parsing arguments, set
+                        # completions to blank. This is to catch any unknown command that would have been in the prompt.
+                        # For example, `aws foobar` would return no completions because foobar is not a command.
+                        completions = []
+                        break
+                    if idx is not None:  # If an index was found
+                        tree_location = tree_location.subcommands[
+                            idx]  # Set the new tree location (aka current command in
+                        # tree) to the new one that has been found
+                        if tree_location.has_subcommands():  # If there are subcommands, list them
+                            completions = tree_location.list_subcommand_names()
+                        else:  # If there are no subcommands, suggest optional arguments
+                            completions = []  # Reset completions because they are gonna be arguments now
+                            for arg in tree_location.optional_arguments:  # Go through all arguments in the command and add
+                                # the arguments allowed to the suggested completions. Arguments are disallowed if they are
+                                # specified already. The exception to that is if the argument is a type that can be
+                                # specified multiple times. No arguments are suggested if there is a death argument
+                                # (one that does something completely different than what the command is supposed to do,
+                                # and therefore kills all the other arguments. An example of this is "--help").
+                                arg_specified = False  # Flag to see if an argument has been specified yet by the user
+                                # in the prompt
+                                for parts in split_text:
+                                    if parts.startswith('-') and parts == arg.tag:
+                                        arg_specified = True
+                                if not arg_specified:  # If the argument hasn't been specified, add it to the suggested list
+                                    #  and go to next argument
+                                    completions.append(arg.tag)
+                                    continue
+                                if arg.type is arg.TYPE_ENUM.APPEND or arg.type is arg.TYPE_ENUM.APPEND_CONST or \
+                                                arg.type is arg.TYPE_ENUM.COUNT:  # If the argument is an append or count type, add
+                                    # it regardless of if it has been specified by the user already
+                                    completions.append(arg.tag)
+                                    continue
+                                if arg.type is arg.TYPE_ENUM.HELP or arg.type is arg.TYPE_ENUM.VERSION:  # If a death
+                                    # argument has been specified ("--help" or "--version"), then delete all suggested
+                                    # completions and break the loop.
+                                    completions = []
+                                    break
+
+                            last_full_arg = full_split_text[-1]  # Get the last fully specified argument in the list
+                            if last_full_arg and last_full_arg.startswith(
+                                    '-'):  # If there is a last argument and it is an
+                                # argument (this _should_ always be the case), then change some suggestions
+                                try:
+                                    arg = tree_location.make_tag_to_args_dict()[
+                                        last_full_arg]  # Get the argument object
+                                    # from the tag
+                                    if arg.type is arg.TYPE_ENUM.STORE or arg.type is arg.TYPE_ENUM.APPEND \
+                                            or arg.type is arg.TYPE_ENUM.COUNT:  # If an argument is one where you manually
+                                        # specify the value (most arguments, just not the death arguments or the constant
+                                        # arguments)
+                                        if arg.choices is not None:  # If the argument has specified choices, suggest those
+                                            completions = arg.choices
+                                        else:  # Otherwise, suggest nothing
+                                            completions = []
+                                except KeyError:  # Do nothing if the argument is wrong/unknown. Nothing in this case would
+                                    # suggest the arguments for the command.
+                                    pass
+                except KeyError:  # If there is a key error somewhere, make the completions be empty
+                    if completions is None:
+                        completions = []
+
+        completions.sort()  # Alphabetize the completions
+
+        for completion in completions:  # Go through suggested completions
+            if completion.startswith(word_before_cursor):  # If a suggested completion starts with the unfinished word
+                # that is being written by the user right now, use it
+                yield Completion(completion, -len(word_before_cursor))  # Return (yield) all completions with the
+                # completion name and the start position of the completion
+
+    def get_current_command(self, document):
+        """
+        Gets the current command that the user is in. For example, if the user enters `aws encrypt`, the command would
+        be the AWS Encrypt command object. Does not matter if arguments are specified in the text. If the user enters
+        `aws enc` (`enc` as in an unfinished command or an unknown subcommand), the command would be AWS. However, if
+        the user enters an unknown top level command `foo`, for example, the command would be None.
+        :param document: the object containing useful stuff like text
+        :return: CommandPromptToolkit object with the current and selected command
+        """
+        all_text = document.text_before_cursor
+
+        tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
+        #  command the user has typed in the prompt
+
+        for word in all_text.split():  # Go through all words in the prompt and attempt to narrow down to the exact
+            # command being used
+            idx = None
+            for index, name in enumerate(tree_location.list_subcommand_names()):
+                if name == word:
+                    idx = index
+            if idx is not None:
+                tree_location = tree_location.subcommands[idx]
+
+        if tree_location == self.command:  # If there was no command that could be found and tree_location is still at
+            # the top command, return None
+            return None
+
+        return tree_location
+
+    def get_current_argument(self, document):
+        """
+        Gets the current argument that the user is in. For example, if the user enters `auth --password`, the argument
+        would be the Auth Password argument object. If the user enters `auth --password --email`, the argument is Email.
+        If the user enters `auth --password --ema` (`--ema` as in an unfinished parameter), the argument is None.
+        :param document: the object containing useful stuff like text
+        :return: ArgumentPromptToolkit object with the current and selected argument
+        """
+        all_text = document.text_before_cursor
+
+        tree_location = self.command  # Tree location is the current selected command that is narrowed down to the exact
+        #  command the user has typed in the prompt
+
+        split_text = all_text.split()  # list of all values (commands, subcommands, arguments, etc.) separated by space
+        full_split_text = split_text  # full_split_text is all values (see above for example) separated by space that
+        # are complete.
+        if not all_text.endswith(' ') and not split_text[-1].startswith('-'):  # If the last word is unfinished and the
+            # last word is not an argument, shorten the full text by one. This is to keep the manpage suggestions for
+            # arguments with values. For example, `aws encrypt --aws-tag foob` (with `foob` being unfinished for
+            # `foobar`), the manpage would be "--aws-tag" the entire time.
+            del full_split_text[-1]
+        # The difference between these two is shown in this example:
+        # In `aws encrypt --aws-tag foob` (with `foob` being unfinished for `foobar`), the result of split_text would
+        # be `['aws', 'encrypt', '--aws-tag', 'foob']`, while the result of full_split_text would
+        # be `['aws', 'encrypt', '--aws-tag']`
+
+        for word in split_text:  # Go through all words in the prompt and attempt to narrow down to the exact
+            # command being used
+            idx = None
+            for index, name in enumerate(tree_location.list_subcommand_names()):
+                if name == word:
+                    idx = index
+            if idx is not None:
+                tree_location = tree_location.subcommands[idx]
+
+        if full_split_text and full_split_text[-1].startswith('-'):  # If the last full word exists and is an argument,
+            # return the argument object the word/tag matched
+            for arg in tree_location.optional_arguments:  # Go though each argument and match it to the word/tag
+                if full_split_text[-1] == arg.tag:  # If the last word is equal to the argument tag, return it
+                    return arg
+
+        return None

--- a/brkt_cli/shell/enum.py
+++ b/brkt_cli/shell/enum.py
@@ -1,26 +1,13 @@
-# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-# https://github.com/brkt/brkt-cli/blob/master/LICENSE
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and
-# limitations under the License.
-
-
-def enum(**enums):
-    """
-    Creates an enumeration in Python.
-    Example usage would be:
-        `foo = enum(ZERO=0, ONE=1, TWO=2)`
-    You would be able to match enums like this:
-        `if var == foo.ONE:`
-    :param enums: the enumerations matched to the number identifier
-    :return: an enum type
-    """
-    return type(str('Enum'), (), enums)
+class Enum:
+    @classmethod
+    def format_enum(cls, enum):
+        """
+        Formats an enum as a string
+        :param enum: the enum integer
+        :type enum: int
+        :return: the string name of the enum
+        :rtype: unicode
+        """
+        for val in filter((lambda (key, value): not key.startswith('__')), cls.__dict__.items()):
+            if val[1] == enum:
+                return val[0]

--- a/brkt_cli/shell/enum.py
+++ b/brkt_cli/shell/enum.py
@@ -1,3 +1,16 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
 class Enum:
     @classmethod
     def format_enum(cls, enum):

--- a/brkt_cli/shell/enum.py
+++ b/brkt_cli/shell/enum.py
@@ -1,0 +1,26 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+def enum(**enums):
+    """
+    Creates an enumeration in Python.
+    Example usage would be:
+        `foo = enum(ZERO=0, ONE=1, TWO=2)`
+    You would be able to match enums like this:
+        `if var == foo.ONE:`
+    :param enums: the enumerations matched to the number identifier
+    :return: an enum type
+    """
+    return type(str('Enum'), (), enums)

--- a/brkt_cli/shell/enum.py
+++ b/brkt_cli/shell/enum.py
@@ -11,6 +11,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+
+
 class Enum:
     @classmethod
     def format_enum(cls, enum):

--- a/brkt_cli/shell/get_set_inner_commmands.py
+++ b/brkt_cli/shell/get_set_inner_commmands.py
@@ -249,8 +249,7 @@ def parse_set_command_arg(val, arg):
     if arg.type is arg.Type.Store:
         return _parse_argument_type(val, arg)
     elif arg.type is arg.Type.StoreConst or arg.type is arg.Type.StoreTrue or arg.type is arg.Type.StoreFalse or \
-                    arg.type is arg.Type.AppendConst:  # If the argument is one of these, it must be either
-        # true or false
+            arg.type is arg.Type.AppendConst:  # If the argument is one of these, it must be either true or false
         if val.lower() not in ['true', 'false']:
             raise InnerCommandError('Unknown value type. Can be either: "true", "false"')
         return val.lower() == 'true'

--- a/brkt_cli/shell/get_set_inner_commmands.py
+++ b/brkt_cli/shell/get_set_inner_commmands.py
@@ -1,0 +1,189 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+from brkt_cli.shell.inner_commands import InnerCommand, InnerCommandError
+
+
+def set_inner_command(params, app):
+    """
+    Sets an argument value for the shell session
+    :param params: command parameters. Should have two parameters: path and value
+    :type params: list[unicode]
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
+    :raises: InnerCommandError
+    """
+    assert len(params) == 2
+    arg_name = params[0]
+    arg_val = params[1]
+    arg_name_split = arg_name.split('.')
+    cmd_path = '.'.join(arg_name_split[:-1])  # Get the just command path, not the full path with the argument
+
+    if cmd_path not in app.cmd.get_all_paths():
+        raise InnerCommandError('Unknown command in path key')
+    sc = app.cmd.get_subcommand_from_path(cmd_path)
+    if arg_name_split[-1] not in map(lambda x: x.get_name(),
+                                     filter(lambda v: v.type is not v.Type.Help and v.type is not v.Type.Version,
+                                            sc.optional_arguments + sc.positionals)):  # Make sure the selected
+        # argument is not a help or version argument
+        raise InnerCommandError('Unknown argument in path key')
+
+    if cmd_path not in app.set_args:  # If there is no command path set in the app, set it!
+        app.set_args[cmd_path] = {}
+
+    app.set_args[cmd_path][arg_name_split[-1]] = parse_set_command_arg(
+        arg_val, sc.make_pos_and_arg_name_to_dict()[arg_name_split[-1]])  # Set the value
+
+
+def complete_set_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Do completion for the /set command
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    if arg_idx == 0:  # If the user is on the first argument, suggest full paths (ones with commands and the argument)
+        arg_list = []
+        for path in app.cmd.get_all_paths():
+            got_cmd = app.cmd.get_subcommand_from_path(path)
+            if got_cmd is None or got_cmd.has_subcommands() is True:
+                continue
+            arg_list.extend(map(lambda x: path + '.' + x,
+                                map(lambda x: x.get_name(),
+                                    filter(lambda x: x.type is not x.Type.Help and x.type is not x.Type.Version,
+                                           got_cmd.optional_arguments + got_cmd.positionals)
+                                    )
+                                ))  # Get All arguments that are not help or version and get their names and add them
+            # to their command paths. This creates bunch of full paths
+        return arg_list
+    elif arg_idx == 1:  # If the user is on the second (and last) argument, suggest options if options are available or
+        # nothing if they are not
+        arg = app.cmd.get_argument_from_full_path(full_args_text[0])
+        if arg is not None and arg.choices is not None and len(arg.choices) > 0:
+            return arg.choices
+        else:
+            return []
+    else:
+        return []
+
+
+def get_inner_command(params, app):
+    """
+    Gets an argument value for the shell session
+    :param params: command parameters. Should have one parameter: a path to the command argument
+    :type params: list[unicode]
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
+    :raises: InnerCommandError
+    """
+    assert len(params) == 1
+    arg_name = params[0]
+    arg_name_split = arg_name.split('.')
+    cmd_path = '.'.join(arg_name_split[:-1])  # Get the just command path, not the full path with the argument
+
+    # Validate the command
+    if cmd_path not in app.cmd.get_all_paths():
+        raise InnerCommandError('Unknown command in path')
+    sc = app.cmd.get_subcommand_from_path(cmd_path)
+    if arg_name_split[-1] not in map(lambda x: x.get_name(),
+                                     filter(lambda v: v.type is not v.Type.Help and v.type is not v.Type.Version,
+                                            sc.optional_arguments + sc.positionals)):  # Make sure the selected
+        # argument is not a help or version argument
+        raise InnerCommandError('Unknown argument in path')
+
+    if cmd_path not in app.set_args or arg_name_split[-1] not in app.set_args[cmd_path]:  # Check to see the passed
+        # argument is in the app database
+        print '%s: %s' % (arg_name, 'None')
+    else:
+        print '%s: %s' % (arg_name, app.set_args[cmd_path][arg_name_split[-1]])
+
+
+def complete_get_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Do completion for the /get command
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    if arg_idx == 0:  # If it is the first argument, list all keys in the app
+        arg_list = []
+        for key, cmd in app.set_args.iteritems():
+            arg_list.extend(map(lambda x: key + '.' + x, cmd.keys()))
+        return arg_list
+    else:
+        return []
+
+
+def parse_set_command_arg(val, arg):
+    """
+    Parse values that the /set command gives
+    :param val: the value that was gotten by the /set command
+    :type val: unicode
+    :param arg: the argument that that value must be connected to
+    :type arg: brkt_cli.shell.raw_commands.ArgumentPromptToolkit
+    :return: the parsed value
+    :rtype: Any
+    """
+    if arg.type is arg.Type.Store:
+        return _parse_argument_type(val, arg)
+    elif arg.type is arg.Type.StoreConst or arg.type is arg.Type.StoreTrue or arg.Type.StoreFalse or \
+            arg.type == arg.Type.AppendConst:  # If the argument is one of these, it must be either true or false
+        if val.lower() not in ['true', 'false']:
+            raise InnerCommandError('Unknown value type. Can be either: "true", "false"')
+        return val.lower() == 'true'
+    elif arg.type == arg.Type.Append:
+        return map(lambda x: _parse_argument_type(x.trim(), arg), val.split(','))
+    else:
+        return InnerCommandError('Unsupported argument type')
+
+
+def _parse_argument_type(val, arg):
+    """
+    The meat of parse_set_command_arg. This does the parsing
+    :param val: the value that was gotten by the /set command
+    :type val: unicode
+    :param arg: the argument that that value must be connected to
+    :type arg: brkt_cli.shell.raw_commands.ArgumentPromptToolkit
+    :return: the parsed value
+    :rtype: Any
+    """
+    if arg.raw.type is not None:
+        return arg.raw.type(val)
+    else:
+        return val
+
+
+set_inner_command = InnerCommand('set', 'Sets an argument for a command', 'set path value', set_inner_command)
+set_inner_command.completer = complete_set_inner_command
+get_inner_command = InnerCommand('get', 'Gets an argument for a command', 'get path', get_inner_command)
+get_inner_command.completer = complete_get_inner_command

--- a/brkt_cli/shell/get_set_inner_commmands.py
+++ b/brkt_cli/shell/get_set_inner_commmands.py
@@ -260,7 +260,7 @@ def _parse_argument_type(val, arg):
 
 set_inner_command = InnerCommand('set', 'Sets an argument for a command', 'set PATH VALUE', set_inner_command_func,
                                  completer=complete_set_inner_command,
-                                 param_regex=r'^(.+) (.+)$')
+                                 param_regex=r'^([^ ]+) (.+)$')
 get_inner_command = InnerCommand('get', 'Gets an argument for a command', 'get PATH', get_inner_command_func,
                                  completer=complete_get_inner_command,
                                  param_regex=r'^([^ ]+)$')

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -183,4 +183,4 @@ def dev_inner_command_func(params, app):
 exit_inner_command = InnerCommand('exit', 'Exits the shell.', 'exit', exit_inner_command_func)
 help_inner_command = InnerCommand('help', 'Get help for inner commands', 'help', help_inner_command_func)
 dev_inner_command = InnerCommand('dev', 'Under the hood access for developers', 'dev', dev_inner_command_func,
-                                 param_regex='^(.+)$')
+                                 param_regex=r'^(.+)$')

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -179,7 +179,6 @@ def dev_inner_command_func(params, app):
         for arg in got_cmd.optional_arguments+got_cmd.positionals:
             print arg.raw
 
-
 # Commands that are prebuilt for the CLI
 exit_inner_command = InnerCommand('exit', 'Exits the shell.', 'exit', exit_inner_command_func)
 help_inner_command = InnerCommand('help', 'Get help for inner commands', 'help', help_inner_command_func)

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -14,7 +14,7 @@
 from termcolor import colored
 
 
-class InnerCommand:
+class InnerCommand(object):
     """
     :type name: unicode
     :type description: unicode
@@ -198,6 +198,26 @@ def dev_inner_command_func(params, app):
         for arg in got_cmd.optional_arguments+got_cmd.positionals:
             print arg.raw
 
+
+def editing_mode_inner_command_func(params, app):
+    """
+    Modify the app._vi_mode field depending on the parameters. If there are no parameters, error. If a
+    parameter is specified and is either 'vi or 'emacs', set it to that. If it isn't, throw error
+    :param params: command parameters
+    :type params: list[unicode]
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
+    :raises: InnerCommandError
+    """
+    assert len(params) == 1
+    if params[0].lower() not in ['vi', 'emacs']:
+        raise InnerCommandError('Unknown option entered')
+    app.vi_mode = params[0].lower() == 'vi'
+
+
 # Commands that are prebuilt for the CLI
 exit_inner_command = InnerCommand('exit', 'Exits the shell.', 'exit', exit_inner_command_func)
 manpage_inner_command = InnerCommand('manpage', 'Passing "true" will enable the manpage, while "false" will disable '
@@ -206,3 +226,7 @@ manpage_inner_command = InnerCommand('manpage', 'Passing "true" will enable the 
 manpage_inner_command.completer = inner_command_completer_static([['true', 'false']])
 help_inner_command = InnerCommand('help', 'Get help for inner commands', 'help', help_inner_command_func)
 dev_inner_command = InnerCommand('dev', 'Under the hood access for developers', 'dev', dev_inner_command_func)
+editing_mode_inner_command = InnerCommand('editing_mode', 'Sets the keybinding type for the prompt. Can either be '
+                                                          'emacs or vi', 'editing_mode [emacs | vi]',
+                                     editing_mode_inner_command_func)
+editing_mode_inner_command.completer = inner_command_completer_static([['emacs', 'vi']])

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -152,7 +152,7 @@ def help_inner_command_func(params, app):
     :rtype: None
     """
     print colored('Brkt CLI Shell Inner Command Help', attrs=['bold'])
-    for _, cmd in app.INNER_COMMANDS.iteritems():
+    for _, cmd in app.inner_commands.iteritems():
         print cmd.name + '\t' + cmd.description
         print '\t' + app.COMMAND_PREFIX + cmd.usage
 

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -1,0 +1,104 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+from termcolor import colored
+
+
+class InnerCommand:
+    """
+    The command type for commands in the shell itself (e.g. `/exit`)
+    :param name: the name of the command without the identifier (in this case `/`) in front of it
+    :param description: the description of the command
+    :param action: the action to be run when the command is entered.
+    """
+    def __init__(self, name, description, usage, action):
+        self.name = name
+        self.description = description
+        self.usage = usage
+        self._action = action
+
+    def run_action(self, cmd, app):
+        """
+        Run the action of the inner command
+        :param cmd: the entire command string
+        :param app: the app it is running from
+        :return: the result of the action, which will be a machine_command or None
+        """
+        params = cmd.split()
+        del params[0]
+        return self._action(params, app)
+
+
+class InnerCommandError(Exception):
+    """
+    An error that an inner command can throw.
+    """
+    def __init__(self, message):
+        super(InnerCommandError, self).__init__(message)
+        pass
+
+    def format_error(self):
+        """
+        Formats the error to be displayed in the CLI
+        :return: the formatted error
+        """
+        return 'Error: %s' % self.message
+
+
+def exit_inner_command_func(_, app):
+    """
+    Run exit command
+    :param _: command parameters
+    :param app: the app it is running from
+    :return: the exit machine_command
+    """
+    return app.MACHINE_COMMANDS.EXIT
+
+
+def manpage_inner_command_func(params, app):
+    """
+    Modify the app.has_manpage field depending on the parameters. If there are no parameters, toggle the field. If a
+    parameter is specified and is either 'true or 'false', set it to that. If it isn't, throw error
+    :param params: command parameters
+    :param app: the app it is running from
+    :return: None
+    :raise: InnerCommandError
+    """
+    if params and len(params) > 0:
+        if params[0].lower() == 'true':
+            app.has_manpage = True
+        elif params[0].lower() == 'false':
+            app.has_manpage = False
+        else:
+            raise InnerCommandError('Unknown option entered')
+    else:
+        app.has_manpage = not app.has_manpage
+
+
+def help_inner_command_func(params, app):
+    """
+    Prints help for the inner commands
+    :param params: command parameters
+    :param app: the app it is running from
+    :return: None
+    """
+    print colored('Brkt CLI Shell Inner Command Help', attrs=['bold'])
+    for _, cmd in app.INNER_COMMANDS.iteritems():
+        print cmd.name + '\t' + cmd.description
+        print '\t' + app.COMMAND_PREFIX + cmd.usage
+
+# Commands that are prebuilt for the CLI
+exit_inner_command = InnerCommand('exit', 'Exits the shell.', 'exit', exit_inner_command_func)
+manpage_inner_command = InnerCommand('manpage', 'Passing "true" will enable the manpage, while "false" will disable it.'
+                                                ' Passing nothing will toggle it.', 'manpage [true | false]', manpage_inner_command_func)
+help_inner_command = InnerCommand('help', 'Get help for inner commands', 'help', help_inner_command_func)

--- a/brkt_cli/shell/inner_commands.py
+++ b/brkt_cli/shell/inner_commands.py
@@ -16,23 +16,39 @@ from termcolor import colored
 
 class InnerCommand:
     """
-    The command type for commands in the shell itself (e.g. `/exit`)
-    :param name: the name of the command without the identifier (in this case `/`) in front of it
-    :param description: the description of the command
-    :param action: the action to be run when the command is entered.
+    :type name: unicode
+    :type description: unicode
+    :type usage: unicode
+    :type _action: (list[unicode], brkt_cli.shell.app.App) -> (int | None)
+    :type completer: (int, brkt_cli.shell.app.App, list[unicode], prompt_toolkit.document.Document) -> list[unicode]
     """
     def __init__(self, name, description, usage, action):
+        """
+        The command type for commands in the shell itself (e.g. `/exit`)
+        :param name: the name of the command without the identifier (in this case `/`) in front of it
+        :type name: unicode
+        :param description: the description of the command
+        :type description: unicode
+        :param usage: the usage information of the command
+        :type usage: unicode
+        :param action: the action to be run when the command is entered.
+        :type action: (list[unicode], brkt_cli.shell.app.App) -> (int | None)
+        """
         self.name = name
         self.description = description
         self.usage = usage
         self._action = action
+        self.completer = inner_command_completer_static(completions=[])
 
     def run_action(self, cmd, app):
         """
         Run the action of the inner command
-        :param cmd: the entire command string
+        :param cmd: the entire command text
+        :type cmd: unicode
         :param app: the app it is running from
-        :return: the result of the action, which will be a machine_command or None
+        :type app: brkt_cli.shell.app.App
+        :return: the result of the action
+        :rtype: brkt_cli.shell.app.App.MachineCommands | None
         """
         params = cmd.split()
         del params[0]
@@ -40,29 +56,82 @@ class InnerCommand:
 
 
 class InnerCommandError(Exception):
-    """
-    An error that an inner command can throw.
-    """
     def __init__(self, message):
+        """
+        An error that an inner command can throw.
+        :param message: the error message
+        :type message: unicode
+        """
         super(InnerCommandError, self).__init__(message)
         pass
+
+    @classmethod
+    def format(cls, message):
+        """
+        Formats the error to be displayed in the CLI
+        :param message: the error message
+        :type message: unicode
+        :return: the formatted error
+        :rtype: unicode
+        """
+        return 'Error: %s' % message
 
     def format_error(self):
         """
         Formats the error to be displayed in the CLI
         :return: the formatted error
+        :rtype: unicode
         """
-        return 'Error: %s' % self.message
+        return self.format(self.message)
 
 
-def exit_inner_command_func(_, app):
+def inner_command_completer_static(completions=None):
+    """
+    Generate a command completer with static values
+    :param completions: a list of a list of possible values for each argument. The possible values in the first
+    argument would be a list of unicode strings as the first element in the top list. For example, completions[0] would
+    get the fist set of values
+    :type completions: list[list[unicode]]
+    :return: a list of possible values to suggest
+    :rtype: (int, brkt_cli.shell.app.App, list[unicode], prompt_toolkit.document.Document) -> list[unicode]
+    """
+    if completions is None:
+        completions = []
+
+    def complete(arg_idx, app, full_args_text, document):
+        """
+        The completer function
+        :param arg_idx: the index of the current and selected argument
+        :type arg_idx: int
+        :param app: the app that is running
+        :type app: brkt_cli.shell.app.App
+        :param full_args_text: the text arguments that are finished
+        :type full_args_text: list[unicode]
+        :param document: the document of the current prompt/buffer
+        :type document: prompt_toolkit.document.Document
+        :return: a list of acceptable suggestions
+        :rtype: list[unicode]
+        """
+        if arg_idx >= len(completions):
+            return []
+        return completions[arg_idx]
+
+    return complete
+
+
+def exit_inner_command_func(params, app):
     """
     Run exit command
-    :param _: command parameters
+    :param params: command parameters
+    :type params: list[unicode]
     :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
     :return: the exit machine_command
+    :rtype: int
+    :raises: AssertionError
     """
-    return app.MACHINE_COMMANDS.EXIT
+    assert len(params) == 0
+    return app.MachineCommands.Exit
 
 
 def manpage_inner_command_func(params, app):
@@ -70,10 +139,15 @@ def manpage_inner_command_func(params, app):
     Modify the app.has_manpage field depending on the parameters. If there are no parameters, toggle the field. If a
     parameter is specified and is either 'true or 'false', set it to that. If it isn't, throw error
     :param params: command parameters
+    :type params: list[unicode]
     :param app: the app it is running from
-    :return: None
-    :raise: InnerCommandError
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
+    :raises: InnerCommandError
     """
+    assert len(params) <= 1
     if params and len(params) > 0:
         if params[0].lower() == 'true':
             app.has_manpage = True
@@ -89,16 +163,46 @@ def help_inner_command_func(params, app):
     """
     Prints help for the inner commands
     :param params: command parameters
+    :type params: list[unicode]
     :param app: the app it is running from
-    :return: None
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
     """
+    assert len(params) == 0
     print colored('Brkt CLI Shell Inner Command Help', attrs=['bold'])
     for _, cmd in app.INNER_COMMANDS.iteritems():
         print cmd.name + '\t' + cmd.description
         print '\t' + app.COMMAND_PREFIX + cmd.usage
 
+
+def dev_inner_command_func(params, app):
+    """
+    Under the hood developer tools to aid developers
+    :param params: command parameters
+    :type params: list[unicode]
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: AssertionError
+    :raises: InnerCommandError
+    """
+    assert len(params) >= 1
+    if params[0] == 'list_args':
+        assert len(params) >= 2
+        got_cmd = app.cmd.get_subcommand_from_path(params[1])
+        if got_cmd is None:
+            raise InnerCommandError('Unknown path subcommand')
+        for arg in got_cmd.optional_arguments+got_cmd.positionals:
+            print arg.raw
+
 # Commands that are prebuilt for the CLI
 exit_inner_command = InnerCommand('exit', 'Exits the shell.', 'exit', exit_inner_command_func)
-manpage_inner_command = InnerCommand('manpage', 'Passing "true" will enable the manpage, while "false" will disable it.'
-                                                ' Passing nothing will toggle it.', 'manpage [true | false]', manpage_inner_command_func)
+manpage_inner_command = InnerCommand('manpage', 'Passing "true" will enable the manpage, while "false" will disable '
+                                                'it. Passing nothing will toggle it.', 'manpage [true | false]',
+                                     manpage_inner_command_func)
+manpage_inner_command.completer = inner_command_completer_static([['true', 'false']])
 help_inner_command = InnerCommand('help', 'Get help for inner commands', 'help', help_inner_command_func)
+dev_inner_command = InnerCommand('dev', 'Under the hood access for developers', 'dev', dev_inner_command_func)

--- a/brkt_cli/shell/manpage.py
+++ b/brkt_cli/shell/manpage.py
@@ -97,7 +97,7 @@ class Manpage(UIControl):
                 # manpage description
                 manpage = u''
             else:  # If a command is in the prompt (and no argument), display the manpage of the command
-                command = self.app.completer.get_current_command(document, False)
+                command = self.app.completer.get_current_command(document)
                 if command is not None:
                     manpage = u''
                     manpage += command.description

--- a/brkt_cli/shell/manpage.py
+++ b/brkt_cli/shell/manpage.py
@@ -1,3 +1,16 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
 from pygments.token import Text
 from math import ceil
 from prompt_toolkit.layout.controls import UIControl, UIContent

--- a/brkt_cli/shell/manpage.py
+++ b/brkt_cli/shell/manpage.py
@@ -1,0 +1,96 @@
+from pygments.token import Text
+from math import ceil
+from prompt_toolkit.layout.controls import UIControl, UIContent
+from prompt_toolkit.layout.screen import Char
+from pygments.token import Token
+
+
+class Manpage(UIControl):
+    """
+    :type app: brkt_cli.shell.app.App
+    :type height: int
+    """
+    def __init__(self, app, height=10):
+        """
+        The manpage widget to give the user info about the command/argument they are running
+        :param app: the app that is running it
+        :type app: brkt_cli.shell.app.App
+        :param height: the height of the widget
+        :type height: int
+        """
+        self.app = app
+        self.height = height
+
+    def preferred_height(self, cli, width, max_available_height, wrap_lines):
+        """
+        Overrides function that sends the preferred height of the manpage
+        :param cli: the cli
+        :type cli: prompt_toolkit.CommandLineInterface
+        :param width: the width
+        :type width: int
+        :param max_available_height: the max height
+        :type max_available_height: int
+        :param wrap_lines: if wrapping lines
+        :type wrap_lines: bool
+        :return: the preferred height
+        :rtype: int
+        """
+        return self.height
+
+    def create_content(self, cli, width, height):
+        """
+        Creates the content of the manpage widget
+        :param cli: the cli
+        :type cli: prompt_toolkit.CommandLineInterface
+        :param width: the width of the widget
+        :type width: int
+        :param height: the height of the widget
+        :type height: int
+        :return: the content of the widget
+        :rtype: prompt_toolkit.layout.controls.UIContent
+        """
+        manpage_text = self.get_text(cli.current_buffer.document)  # Generate the text
+        manpage_split_newline = manpage_text.split('\n')  # Split all newlines
+        new_manpage_split = []  # If there are any lines that are longer than the width, make the widget wrap the lines
+        for txt in manpage_split_newline:
+            if len(txt) > width:
+                for x in range(int(ceil(float(len(txt))/width))):
+                    new_manpage_split.append(txt[width*x:width*(x+1)])
+            else:
+                new_manpage_split.append(txt)
+
+        token_manpage = map(lambda val: [(Text, val)], new_manpage_split)  # Put the content in the correct format
+
+        return UIContent(
+            get_line=lambda i: token_manpage[i],
+            line_count=len(token_manpage),  # The line count should match the lines in the text
+            show_cursor=False,
+            default_char=Char(' ', Token.Toolbar))
+
+    def get_text(self, document):
+        """
+        The generator that generates the widget text
+        :param document: the document of the cli prompt
+        :type document: prompt_toolkit.document.Document
+        :return: the text of the widget
+        :rtype: unicode
+        """
+        text_before_cursor = document.text_before_cursor.strip()
+        if document.text.strip() and text_before_cursor != '':  # If there is text in prompt
+            arg = self.app.completer.get_current_argument(document)  # Get current argument (if there is one)
+            if arg is not None:  # If there is a current argument, display the description
+                manpage = unicode(arg.description)
+            elif text_before_cursor.split()[-1].startswith('-'):  # While typing an argument, don't show any
+                # manpage description
+                manpage = u''
+            else:  # If a command is in the prompt (and no argument), display the manpage of the command
+                command = self.app.completer.get_current_command(document, False)
+                if command is not None:
+                    manpage = u''
+                    manpage += command.description
+                    manpage += u'\n\n' + command.usage
+                else:  # If there is no valid command, clear manpage
+                    manpage = u''
+        else:  # If there is no text in prompt, clear manpage
+            manpage = u''
+        return manpage

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -80,7 +80,7 @@ def traverse_tree(name, node, arguments, description, usage, positionals, path, 
     return new_node
 
 
-class CommandPromptToolkit:
+class CommandPromptToolkit(object):
     """
     :type name: unicode
     :type description: unicode
@@ -242,7 +242,7 @@ def _get_all_subpaths(cmd):
     return ret
 
 
-class ArgumentPromptToolkit:
+class ArgumentPromptToolkit(object):
     """
     :type raw: argparse.Action
     :type tag: unicode

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -1,0 +1,157 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+from brkt_cli.shell.enum import enum
+
+
+def traverse_tree(name, node, arguments, description, usage, positionals):
+    """
+    Traverse the entire raw command tree (raw command tree being the argparse tree generated in `brkt_cli/__init__.py`)
+    and convert each command and argument from the raw types to the types defined in this file.
+    :param name: the name of the command ("encrypt" in the `brkt aws encrypt`)
+    :param node: the node in the tree (aka the raw command)
+    :param arguments: the optional arguments (the ones that start with "--" of the raw command)
+    :param description: the description of the raw command
+    :param usage: the usage of the raw command
+    :param positionals: the positional arguments of the raw command (the ID in `brkt aws encrypt`)
+    :return: a new converted node tree
+    """
+    new_node = CommandPromptToolkit(name, description, usage)  # Create a new command for the inputted info
+    if arguments is not None:  # If there are optional arguments, add them to the new node
+        for argument in arguments:
+            new_arg = ArgumentPromptToolkit(argument)
+            new_node.optional_arguments.append(new_arg)
+    if positionals is not None:  # If there are positional arguments, add them to the new node
+        for positional in positionals:
+            if positional.__class__.__name__ == '_SubParsersAction':  # If those positional arguments are actually
+                # subcommands, don't include them
+                break
+            new_pos = PositionalArgumentPromptToolkit(positional)
+            new_node.positionals.append(new_pos)
+
+    if node and node.choices:  # If there is a node passed and that node (command) has subnodes (subcommands)
+        for choice in node.choices.items():  # Go through each subcommand
+            if choice[1]._subparsers and choice[1]._subparsers._group_actions:  # If there are subcommands to that
+                # subcommand, run the function again but this time with the new subcommand and include the
+                # subcommand's subcommands
+                new_node.subcommands.append(traverse_tree(choice[0], choice[1]._subparsers._group_actions[0],
+                                                          choice[1]._get_optional_actions(), choice[1].description,
+                                                          choice[1].format_usage(),
+                                                          choice[1]._positionals._group_actions))  # Append the new
+                # subcommand to the current command
+            else:  # If this subcommand has no subcommands (aka a leaf node), run the function again but this time only
+                # with the intention to create a new subcommand object, not to traverse
+                new_node.subcommands.append(
+                    traverse_tree(choice[0], None, choice[1]._get_optional_actions(), choice[1].description,
+                                  choice[1].format_usage(), choice[1]._positionals._group_actions))  # Append the new
+                # subcommand to the current command
+    return new_node
+
+
+class CommandPromptToolkit:
+    """
+    The new version of a command. Has a name, optional subcommands, description, usage, optional arguments, and
+    positional arguments.
+    :param name: the name of the command
+    :param description: the description of the command
+    :param usage: the usage of the command
+    """
+    def __init__(self, name, description, usage):
+        self.name = name
+        self.subcommands = []
+        self.description = description
+        self.usage = usage
+        self.optional_arguments = []
+        self.positionals = []
+
+    def list_subcommand_names(self):
+        """
+        Lists names of all subcommands
+        :return: a list of subcommand name strings
+        """
+        ret = []
+        for sc in self.subcommands:
+            ret.append(sc.name)
+
+        return ret
+
+    def has_subcommands(self):
+        """
+        Checks if command has subcommands
+        :return: boolean
+        """
+        return self.subcommands and len(self.subcommands) > 0
+
+    def list_argument_names(self):
+        """
+        Lists names of all optional arguments
+        :return: a list of optional argument name strings
+        """
+        ret = []
+        for arg in self.optional_arguments:
+            ret.append(arg.tag)
+        return ret
+
+    def make_tag_to_args_dict(self):
+        """
+        Makes the optional arguments into a dictionary of tags (names) as keys and the argument object as values
+        :return: dictionary of tag strings to argument ArgumentPromptToolkits
+        """
+        ret = {}
+        for arg in self.optional_arguments:
+            ret[arg.tag] = arg
+        return ret
+
+
+class ArgumentPromptToolkit:
+    """
+    The new version of arguments. Has a raw value, a tag (name), description, metavar, optional choices, and type.
+    :param raw: the raw value to be unpacked
+    """
+    TYPE_ENUM = enum(UNKNOWN=0, STORE=1, STORE_CONST=2, STORE_FALSE=3, STORE_TRUE=4, APPEND=5, APPEND_CONST=6, COUNT=7,
+                     HELP=8, VERSION=9)
+
+    def __init__(self, raw):
+        self.raw = raw
+        self.tag = raw.option_strings[-1]
+        self.description = raw.help
+        self.metavar = raw.metavar
+        self.choices = raw.choices  # choices can be either None or an array of strings. If it is not None, than the
+        # completer will suggest those choices
+
+        try:
+            raw_type = {
+                '_StoreAction': self.TYPE_ENUM.STORE,
+                '_StoreConstAction': self.TYPE_ENUM.STORE_CONST,
+                '_StoreFalseAction': self.TYPE_ENUM.STORE_FALSE,
+                '_StoreTrueAction': self.TYPE_ENUM.STORE_TRUE,
+                '_AppendAction': self.TYPE_ENUM.APPEND,
+                '_AppendConstAction': self.TYPE_ENUM.APPEND_CONST,
+                '_CountAction': self.TYPE_ENUM.COUNT,
+                '_HelpAction': self.TYPE_ENUM.HELP,
+                '_VersionAction': self.TYPE_ENUM.VERSION,
+            }[raw.__class__.__name__]  # Try to match the type of argument (found in the class name) to the enum type
+            self.type = raw_type
+        except KeyError:
+            self.type = self.TYPE_ENUM.UNKNOWN
+
+
+class PositionalArgumentPromptToolkit(ArgumentPromptToolkit):
+    """
+    The parameter type for positional arguments (like ID in `aws encrypt`)
+    :param raw: the raw value to be unpacked
+    """
+    def __init__(self, raw):
+        if len(raw.option_strings) == 0:
+            raw.option_strings = [""]
+        ArgumentPromptToolkit.__init__(self, raw)

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -11,22 +11,42 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-from brkt_cli.shell.enum import enum
+from copy import copy
+
+from argparse import ArgumentParser
+
+from brkt_cli.shell.enum import Enum
 
 
-def traverse_tree(name, node, arguments, description, usage, positionals):
+def traverse_tree(name, node, arguments, description, usage, positionals, path, parse_args):
     """
     Traverse the entire raw command tree (raw command tree being the argparse tree generated in `brkt_cli/__init__.py`)
     and convert each command and argument from the raw types to the types defined in this file.
     :param name: the name of the command ("encrypt" in the `brkt aws encrypt`)
+    :type name: unicode
     :param node: the node in the tree (aka the raw command)
+    :type node: argparse._SubParsersAction | None
     :param arguments: the optional arguments (the ones that start with "--" of the raw command)
+    :type arguments: list[argparse.Action] | None
     :param description: the description of the raw command
+    :type description: unicode
     :param usage: the usage of the raw command
+    :type usage: unicode
     :param positionals: the positional arguments of the raw command (the ID in `brkt aws encrypt`)
+    :type positionals: list[argparse.Action] | None
+    :param path: the command path. For example, `brkt.aws.encrypt`
+    :type path: unicode
+    :param parse_args: the raw argparse class parse_args function
+    :type parse_args: ((Any, Any) -> Any) | None
     :return: a new converted node tree
+    :rtype: CommandPromptToolkit
     """
-    new_node = CommandPromptToolkit(name, description, usage)  # Create a new command for the inputted info
+    if path == '' or path is None:
+        path = name
+    else:
+        path = path + '.' + name
+    new_node = CommandPromptToolkit(name, description, usage, path, parse_args)  # Create a new command for the
+    # inputted info
     if arguments is not None:  # If there are optional arguments, add them to the new node
         for argument in arguments:
             new_arg = ArgumentPromptToolkit(argument)
@@ -47,30 +67,51 @@ def traverse_tree(name, node, arguments, description, usage, positionals):
                 new_node.subcommands.append(traverse_tree(choice[0], choice[1]._subparsers._group_actions[0],
                                                           choice[1]._get_optional_actions(), choice[1].description,
                                                           choice[1].format_usage(),
-                                                          choice[1]._positionals._group_actions))  # Append the new
-                # subcommand to the current command
+                                                          choice[1]._positionals._group_actions, path,
+                                                          ShellArgumentParser.convert_to_shell(choice[1]).parse_args))
+                # Append the new subcommand to the current command
             else:  # If this subcommand has no subcommands (aka a leaf node), run the function again but this time only
                 # with the intention to create a new subcommand object, not to traverse
                 new_node.subcommands.append(
                     traverse_tree(choice[0], None, choice[1]._get_optional_actions(), choice[1].description,
-                                  choice[1].format_usage(), choice[1]._positionals._group_actions))  # Append the new
-                # subcommand to the current command
+                                  choice[1].format_usage(), choice[1]._positionals._group_actions, path,
+                                  ShellArgumentParser.convert_to_shell(choice[1]).parse_args))
+                # Append the new subcommand to the current command
     return new_node
 
 
 class CommandPromptToolkit:
     """
-    The new version of a command. Has a name, optional subcommands, description, usage, optional arguments, and
-    positional arguments.
-    :param name: the name of the command
-    :param description: the description of the command
-    :param usage: the usage of the command
+    :type name: unicode
+    :type description: unicode
+    :type usage: unicode
+    :type path: unicode
+    :type parse_args: (list[unicode], argparse.Namespace) -> argparse.Namespace
+    :type subcommands: list[CommandPromptToolkit]
+    :type optional_arguments: list[ArgumentPromptToolkit]
+    :type positionals: list[ArgumentPromptToolkit]
     """
-    def __init__(self, name, description, usage):
+    def __init__(self, name, description, usage, path, parse_args):
+        """
+        The new version of a command. Has a name, optional subcommands, description, usage, optional arguments, and
+        positional arguments.
+        :param name: the name of the command
+        :type name: unicode
+        :param description: the description of the command
+        :type description: unicode
+        :param usage: the usage of the command
+        :type usage: unicode
+        :param path: the path of the command. For example, `brkt.aws.encrypt`
+        :type path: unicode
+        :param parse_args: the parse arguments function from the raw argparse class
+        :type parse_args: (list[unicode], argparse.Namespace) -> argparse.Namespace
+        """
         self.name = name
-        self.subcommands = []
         self.description = description
         self.usage = usage
+        self.path = path
+        self.parse_args = parse_args
+        self.subcommands = []
         self.optional_arguments = []
         self.positionals = []
 
@@ -78,17 +119,75 @@ class CommandPromptToolkit:
         """
         Lists names of all subcommands
         :return: a list of subcommand name strings
+        :rtype: list[unicode]
         """
-        ret = []
-        for sc in self.subcommands:
-            ret.append(sc.name)
+        return map(lambda x: x.name, self.subcommands)
 
-        return ret
+    def get_all_paths(self):
+        """
+        Get all paths and subpaths of that command
+        :return: a list of path strings
+        :rtype: list[unicode]
+        """
+        return _get_all_subpaths(self)
+
+    def get_subcommand_from_path(self, path):
+        """
+        Gets a subcommand from the path specified. For example, it would return the aws encrypt command from
+        `brkt.aws.encrypt`
+        :param path: the path to the command. May NOT have an argument appended to the end of the path
+        :type path: unicode
+        :return: the subcommand or the closest the function could get to the subcommand. (so `brkt.aws.foobar` would
+        return the aws subcommand (path at `brkt.aws`)
+        :rtype: CommandPromptToolkit
+        """
+        path_split = path.split('.')
+        if len(path_split) <= 1:
+            return self
+        path_split = path_split[1:]
+        if self.has_subcommands():
+            for sc in self.subcommands:
+                if sc.name == path_split[0]:
+                    return sc.get_subcommand_from_path('.'.join(path_split))
+        else:
+            return self
+
+    def get_argument_from_full_path(self, path):
+        """
+        Gets an argument from the full path (`brkt.aws.encrypt.ID` is a full path as 'ID' is an argument)
+        :param path: the path to the argument
+        :type path: unicode
+        :return: the argument found
+        :rtype: ArgumentPromptToolkit | None
+        """
+        cmd = self.get_subcommand_from_path(path[:-1])
+        return cmd.__get_argument_from_direct_path(path)
+
+    def __get_argument_from_direct_path(self, path):
+        """
+        Private function to get an argument based on the path. The function MUST be run from the command that is the
+        direct parent to the child
+        :param path: the path to the argument
+        :type path: unicode
+        :return: the argument found
+        :rtype: ArgumentPromptToolkit | None
+        """
+        path_split = path.split('.')
+        if len(path_split) < 2:
+            return None
+        path_split = path_split[1:]
+        arg_name = path_split[-1]
+        args_dict = self.make_pos_and_arg_name_to_dict()
+        if arg_name in args_dict:
+            return args_dict[arg_name]
+        else:
+            return None
 
     def has_subcommands(self):
         """
         Checks if command has subcommands
-        :return: boolean
+        :return: if the command has subcommands
+        :rtype: bool
         """
         return self.subcommands and len(self.subcommands) > 0
 
@@ -96,16 +195,31 @@ class CommandPromptToolkit:
         """
         Lists names of all optional arguments
         :return: a list of optional argument name strings
+        :rtype: list[unicode]
         """
         ret = []
         for arg in self.optional_arguments:
             ret.append(arg.tag)
         return ret
 
+    def make_pos_and_arg_name_to_dict(self):
+        """
+        Makes the positional and optional arguments into a dictionary of names as keys and the argument object as values
+        :return: dictionary of names to arguments
+        :rtype: dict[unicode, ArgumentPromptToolkit]
+        """
+        ret = {}
+        for arg in self.optional_arguments:
+            ret[arg.get_name()] = arg
+        for arg in self.positionals:
+            ret[arg.get_name()] = arg
+        return ret
+
     def make_tag_to_args_dict(self):
         """
         Makes the optional arguments into a dictionary of tags (names) as keys and the argument object as values
-        :return: dictionary of tag strings to argument ArgumentPromptToolkits
+        :return: dictionary of tags to optional arguments
+        :rtype: dict[str, ArgumentPromptToolkit]
         """
         ret = {}
         for arg in self.optional_arguments:
@@ -113,45 +227,131 @@ class CommandPromptToolkit:
         return ret
 
 
+def _get_all_subpaths(cmd):
+    """
+    Recursive inner function that gets all subcommands based on a command.
+    :param cmd: the command to get subcommands from
+    :type cmd: CommandPromptToolkit
+    :return: list of subcommand paths
+    :rtype: list[unicode]
+    """
+    ret = [cmd.path]
+    for subcmd in cmd.subcommands:
+        ret.extend(_get_all_subpaths(subcmd))
+
+    return ret
+
+
 class ArgumentPromptToolkit:
     """
-    The new version of arguments. Has a raw value, a tag (name), description, metavar, optional choices, and type.
-    :param raw: the raw value to be unpacked
+    :type raw: argparse.Action
+    :type tag: unicode
+    :type description: unicode
+    :type metavar: unicode
+    :type dest: unicode
+    :type default: Any
+    :type choices: list[unicode] | None
+    :type type: int
     """
-    TYPE_ENUM = enum(UNKNOWN=0, STORE=1, STORE_CONST=2, STORE_FALSE=3, STORE_TRUE=4, APPEND=5, APPEND_CONST=6, COUNT=7,
-                     HELP=8, VERSION=9)
+    class Type(Enum):
+        """
+        An enumeration of the argument type
+        :type Unknown: int
+        :type Store: int
+        :type StoreConst: int
+        :type StoreFalse: int
+        :type StoreTrue: int
+        :type Append: int
+        :type AppendConst: int
+        :type Count: int
+        :type Help: int
+        """
+        Unknown, Store, StoreConst, StoreFalse, StoreTrue, Append, AppendConst, Count, Help, Version = range(10)
 
     def __init__(self, raw):
-        self.raw = raw
+        """
+        The new version of arguments. Has a raw value, a tag (name), description, metavar, optional choices, and type.
+        :param raw: the raw value to be unpacked
+        :type raw: argparse.Action
+        """
+        self.raw = copy(raw)
         self.tag = raw.option_strings[-1]
         self.description = raw.help
         self.metavar = raw.metavar
+        self.dest = raw.dest
+        self.default = raw.default
         self.choices = raw.choices  # choices can be either None or an array of strings. If it is not None, than the
         # completer will suggest those choices
 
         try:
             raw_type = {
-                '_StoreAction': self.TYPE_ENUM.STORE,
-                '_StoreConstAction': self.TYPE_ENUM.STORE_CONST,
-                '_StoreFalseAction': self.TYPE_ENUM.STORE_FALSE,
-                '_StoreTrueAction': self.TYPE_ENUM.STORE_TRUE,
-                '_AppendAction': self.TYPE_ENUM.APPEND,
-                '_AppendConstAction': self.TYPE_ENUM.APPEND_CONST,
-                '_CountAction': self.TYPE_ENUM.COUNT,
-                '_HelpAction': self.TYPE_ENUM.HELP,
-                '_VersionAction': self.TYPE_ENUM.VERSION,
+                '_StoreAction': self.Type.Store,
+                '_StoreConstAction': self.Type.StoreConst,
+                '_StoreFalseAction': self.Type.StoreFalse,
+                '_StoreTrueAction': self.Type.StoreTrue,
+                '_AppendAction': self.Type.Append,
+                '_AppendConstAction': self.Type.AppendConst,
+                '_CountAction': self.Type.Count,
+                '_HelpAction': self.Type.Help,
+                '_VersionAction': self.Type.Version,
             }[raw.__class__.__name__]  # Try to match the type of argument (found in the class name) to the enum type
             self.type = raw_type
         except KeyError:
-            self.type = self.TYPE_ENUM.UNKNOWN
+            self.type = self.Type.Unknown
+
+    def get_name(self):
+        """
+        Gets the name of the argument. If the argument is positional or has no tag (ID in `brkt.aws.encrypt`), the name
+        would be the metavar ('ID'). If it is an optional argument (--aws-tag in `brkt.aws.encrypt`), the name would be
+        a stripped tag ('aws-tag'). Else, it would be the destination.
+        :return: the name
+        :rtype: unicode
+        """
+        if (self.tag is None or self.tag == '') and self.metavar:
+            return self.metavar
+        elif self.tag.startswith('-'):
+            return self.tag[2 if self.tag.startswith('--') else 1:]
+        else:
+            return self.dest
 
 
 class PositionalArgumentPromptToolkit(ArgumentPromptToolkit):
     """
-    The parameter type for positional arguments (like ID in `aws encrypt`)
-    :param raw: the raw value to be unpacked
+    :type raw: argparse.Action
     """
     def __init__(self, raw):
-        if len(raw.option_strings) == 0:
-            raw.option_strings = [""]
-        ArgumentPromptToolkit.__init__(self, raw)
+        """
+        The parameter type for positional arguments (like ID in `aws encrypt`)
+        :param raw: the raw value to be unpacked
+        :type raw: argparse.Action
+        """
+        new_raw = copy(raw)
+        if len(new_raw.option_strings) == 0:
+            new_raw.option_strings = ['']
+        ArgumentPromptToolkit.__init__(self, new_raw)
+
+
+class ShellArgumentParser(ArgumentParser):
+    """
+    A wrapper around the argparse.ArgumentParser so that commands can be parsed without the default mechanics of
+    argparse being utilized
+    """
+    def error(self, message):
+        """
+        Silenced error method so it does not disturb the shell
+        :param message: The error message
+        :type message: str
+        """
+        pass
+
+    @classmethod
+    def convert_to_shell(cls, obj):
+        """
+        Converts an object to the ShellArgumentParser
+        :param obj: the old object which should be a regular ArgumentParser
+        :type obj: argparse.ArgumentParser
+        :return: the new object as a ShellArgumentParser
+        :rtype: ShellArgumentParser
+        """
+        obj.__class__ = ShellArgumentParser
+        return obj

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -340,6 +340,12 @@ class ShellArgumentParser(ArgumentParser):
     A wrapper around the argparse.ArgumentParser so that commands can be parsed without the default mechanics of
     argparse being utilized
     """
+    def print_help(self, file=None):
+        """
+        Silenced print help method so it does not disturb the shell
+        """
+        raise Exception('print_help')
+
     def error(self, message):
         """
         Silenced error method so it does not disturb the shell

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -104,7 +104,7 @@ class CommandPromptToolkit(object):
         :param path: the path of the command. For example, `brkt.aws.encrypt`
         :type path: unicode
         :param parse_args: the parse arguments function from the raw argparse class
-        :type parse_args: (list[unicode], argparse.Namespace) -> argparse.Namespace
+        :type parse_args: ((list[unicode], argparse.Namespace) -> argparse.Namespace) | None
         """
         self.name = name
         self.description = description
@@ -191,7 +191,7 @@ class CommandPromptToolkit(object):
         :return: if the command has subcommands
         :rtype: bool
         """
-        return self.subcommands and len(self.subcommands) > 0
+        return self.subcommands is not None and len(self.subcommands) > 0
 
     def list_argument_names(self):
         """

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -161,6 +161,8 @@ class CommandPromptToolkit(object):
         :rtype: ArgumentPromptToolkit | None
         """
         cmd = self.get_subcommand_from_path(path[:-1])
+        if cmd is None:
+            return None
         return cmd.__get_argument_from_direct_path(path)
 
     def __get_argument_from_direct_path(self, path):

--- a/brkt_cli/shell/raw_commands.py
+++ b/brkt_cli/shell/raw_commands.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from copy import copy
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, SUPPRESS
 
 from brkt_cli.shell.enum import Enum
 
@@ -250,6 +250,7 @@ class ArgumentPromptToolkit(object):
     :type metavar: unicode
     :type dest: unicode
     :type default: Any
+    :type dev: bool
     :type choices: list[unicode] | None
     :type type: int
     """
@@ -280,6 +281,7 @@ class ArgumentPromptToolkit(object):
         self.metavar = raw.metavar
         self.dest = raw.dest
         self.default = raw.default
+        self.dev = self.description == SUPPRESS
         self.choices = raw.choices  # choices can be either None or an array of strings. If it is not None, than the
         # completer will suggest those choices
 

--- a/brkt_cli/shell/save_command.py
+++ b/brkt_cli/shell/save_command.py
@@ -55,7 +55,8 @@ def complete_alias_inner_command(arg_idx, app, full_args_text, document):
         cursor = document.cursor_position - len(''.join(split_doc[:3]))
         if cursor < 0:
             cursor = 0
-        return app.completer.get_completions_list(Document(text=unicode(text), cursor_position=cursor), include_aliases=False)
+        return app.completer.get_completions_list(Document(text=unicode(text), cursor_position=cursor),
+                                                  include_aliases=False)
     return []
 
 
@@ -132,12 +133,12 @@ def complete_unalias_inner_command(arg_idx, app, full_args_text, document):
     else:
         return []
 
-alias_inner_command = InnerCommand('alias', 'Creates an alias to a command', 'alias NAME COMMAND', alias_inner_command_func,
-                                 completer=complete_alias_inner_command,
-                                 param_regex=r'^([^ ]+) (.+)$')
-get_alias_inner_command = InnerCommand('get_alias', 'Gets an alias to a command', 'get_alias NAME', get_alias_inner_command_func,
-                                 completer=complete_get_alias_inner_command,
-                                 param_regex=r'^(.+)$')
-unalias_inner_command = InnerCommand('unalias', 'Removes alias to a command', 'unalias NAME', unalias_inner_command_func,
-                                 completer=complete_unalias_inner_command,
-                                 param_regex=r'^(.+)$')
+alias_inner_command = InnerCommand('alias', 'Creates an alias to a command', 'alias NAME COMMAND',
+                                   alias_inner_command_func, completer=complete_alias_inner_command,
+                                   param_regex=r'^([^ ]+) (.+)$')
+get_alias_inner_command = InnerCommand('get_alias', 'Gets an alias to a command', 'get_alias NAME',
+                                       get_alias_inner_command_func, completer=complete_get_alias_inner_command,
+                                       param_regex=r'^(.+)$')
+unalias_inner_command = InnerCommand('unalias', 'Removes alias to a command', 'unalias NAME',
+                                     unalias_inner_command_func, completer=complete_unalias_inner_command,
+                                     param_regex=r'^(.+)$')

--- a/brkt_cli/shell/save_command.py
+++ b/brkt_cli/shell/save_command.py
@@ -1,0 +1,143 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.inner_commands import InnerCommand, InnerCommandError
+
+
+def alias_inner_command_func(params, app):
+    """
+    Creates an alias to a command
+    :param params: command parameters
+    :type params: _sre.SRE_Match
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: InnerCommandError
+    """
+    arg_name = params.group(1)
+    app.saved_commands[arg_name] = params.group(2)
+
+
+def complete_alias_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Suggests suggestions when typing in the alias command
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    split_doc = re.split(r'([ ]+)', document.text)
+    if len(split_doc) == 3:
+        return []
+    elif len(split_doc) >= 5:
+        text = ''.join(split_doc[3:])
+        cursor = document.cursor_position - len(''.join(split_doc[:3]))
+        if cursor < 0:
+            cursor = 0
+        return app.completer.get_completions_list(Document(text=unicode(text), cursor_position=cursor), include_aliases=False)
+    return []
+
+
+def get_alias_inner_command_func(params, app):
+    """
+    Gets an alias
+    :param params: command parameters
+    :type params: _sre.SRE_Match
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: InnerCommandError
+    """
+    arg_name = params.group(1)
+    if arg_name not in app.saved_commands:
+        raise InnerCommandError('Could not find the saved command')
+    print app.saved_commands[arg_name]
+
+
+def complete_get_alias_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Suggest an alias name
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    if arg_idx == 0:
+        return app.saved_commands.keys()
+    else:
+        return []
+
+
+def unalias_inner_command_func(params, app):
+    """
+    Delete an alias by alias name
+    :param params: command parameters
+    :type params: _sre.SRE_Match
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: InnerCommandError
+    """
+    arg_name = params.group(1)
+    if arg_name not in app.saved_commands:
+        raise InnerCommandError('Could not find the saved command')
+    del app.saved_commands[arg_name]
+
+
+def complete_unalias_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Suggest an alias name
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    if arg_idx == 0:
+        return app.saved_commands.keys()
+    else:
+        return []
+
+alias_inner_command = InnerCommand('alias', 'Creates an alias to a command', 'alias NAME COMMAND', alias_inner_command_func,
+                                 completer=complete_alias_inner_command,
+                                 param_regex=r'^([^ ]+) (.+)$')
+get_alias_inner_command = InnerCommand('get_alias', 'Gets an alias to a command', 'get_alias NAME', get_alias_inner_command_func,
+                                 completer=complete_get_alias_inner_command,
+                                 param_regex=r'^(.+)$')
+unalias_inner_command = InnerCommand('unalias', 'Removes alias to a command', 'unalias NAME', unalias_inner_command_func,
+                                 completer=complete_unalias_inner_command,
+                                 param_regex=r'^(.+)$')

--- a/brkt_cli/shell/settings.py
+++ b/brkt_cli/shell/settings.py
@@ -1,0 +1,168 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.inner_commands import InnerCommand, InnerCommandError
+
+
+class Setting(object):
+    """
+    :type name: unicode
+    :type default: T
+    :type _value: T
+    :type _on_changed: (T) -> None
+    :type _validate_change: (T) -> None
+    :type _parse_value: (unicode) -> T
+    :type type: type
+    :type description: unicode
+    :type str_acceptable_values: list[unicode]
+    :type suggestions: list[unicode]
+    """
+    def __init__(self, name, default, on_changed=None, validate_change=None, parse_value=None, description='',
+                 str_acceptable_values=None, suggestions=None):
+        """
+        An app setting
+        :param name: the name of the setting
+        :type name: unicode
+        :param default: the default value
+        :type default: T
+        :param on_changed: called when there is a change to the value
+        :type on_changed: (T) -> None
+        :param validate_change: called to validate the new change
+        :type validate_change: (T) -> None
+        :param parse_value: called to parse a new string as a value
+        :type parse_value: (unicode) -> T
+        :param description: description of setting
+        :type description: unicode
+        :param str_acceptable_values: only these values will be accepted
+        :type str_acceptable_values: list[unicode]
+        :param suggestions: things to suggest in the completer
+        :type suggestions: list[unicode]
+        """
+        self.name = name
+        self.default = default
+        self._value = default
+        self._on_changed = on_changed
+        self._validate_change = validate_change
+        self._parse_value = parse_value
+        self.type = type(default) if default is not None else unicode
+        self.description = description
+        self.str_acceptable_values = str_acceptable_values
+        if str_acceptable_values is not None:
+            suggestions = str_acceptable_values
+        self.suggestions = suggestions
+
+    @property
+    def value(self):
+        """
+        Getter for the value
+        :return: the value
+        :rtype: T
+        """
+        return self._value
+
+    @value.setter
+    def value(self, val):
+        """
+        Setter for the value
+        :param val: the new value
+        :type val: T
+        """
+        if self._validate_change is not None:
+            self._validate_change(val)
+        self._value = val
+        if self._on_changed is not None:
+            self._on_changed(self._value)
+
+    def set_value_with_str(self, val):
+        """
+        Sets the value of the setting from a unicode input
+        :param val: the new value string
+        :type val: T
+        """
+        if self.str_acceptable_values is not None and val.lower() not in self.str_acceptable_values:
+            raise InnerCommandError('Value is not an acceptable value')
+        if self._parse_value is not None:
+            self.value = self._parse_value(val)
+        else:
+            self.value = self.type(val)
+
+def bool_parse_value(val):
+    """
+    Setting parse for booleans. Must also make the str_acceptable_values=['true','false']
+    :param val: the string value
+    :type val: unicode
+    :return: the parsed value
+    :rtype: bool
+    """
+    return val.lower() == 'true'
+
+def setting_inner_command_func(params, app):
+    """
+    Displays or modifies a setting
+    :param params: command parameters
+    :type params: _sre.SRE_Match
+    :param app: the app it is running from
+    :type app: brkt_cli.shell.app.App
+    :return: nothing
+    :rtype: None
+    :raises: InnerCommandError
+    """
+    setting_name = params.group(1)
+    if setting_name not in app.settings:
+        raise InnerCommandError('Unknown setting name')
+    setting = app.settings[setting_name]
+    setting_value = params.group(2)
+    if setting_value is None or setting_value == '':
+        print '%s - %s\n    Suggestions: %s' % (
+            setting.name, 
+            setting.value + ('\n    Accepted Values: ' + ', '.join(setting.str_acceptable_values)
+                             if setting.str_acceptable_values is not None else ''),
+            ' ,'.join(setting.suggestions)
+        )
+    else:
+        setting.set_value_with_str(setting_value)
+
+
+def complete_setting_inner_command(arg_idx, app, full_args_text, document):
+    """
+    Suggests suggestions when typing in the setting command
+    :param arg_idx: the index of the current and selected argument
+    :type arg_idx: int
+    :param app: the app that is running
+    :type app: brkt_cli.shell.app.App
+    :param full_args_text: the text arguments that are finished
+    :type full_args_text: list[unicode]
+    :param document: the document of the current prompt/buffer
+    :type document: prompt_toolkit.document.Document
+    :return: a list of acceptable suggestions
+    :rtype: list[unicode]
+    """
+    if arg_idx == 0:
+        return app.settings.keys()
+    elif arg_idx == 1:
+        setting_name = full_args_text[0]
+        if setting_name not in app.settings:
+            return []
+        setting = app.settings[setting_name]
+        return setting.suggestions if setting.suggestions is not None else []
+    else:
+        return []
+
+
+setting_inner_command = InnerCommand('setting', 'Edit or view a setting', 'setting NAME [value]', setting_inner_command_func,
+                                 completer=complete_setting_inner_command,
+                                 param_regex=r'^([^ ]+)(?: (.+))?$')

--- a/brkt_cli/shell/settings.py
+++ b/brkt_cli/shell/settings.py
@@ -11,10 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-import re
-
-from prompt_toolkit.document import Document
-
 from brkt_cli.shell.inner_commands import InnerCommand, InnerCommandError
 
 
@@ -24,7 +20,7 @@ class Setting(object):
     :type default: T
     :type _value: T
     :type _on_changed: (T) -> None
-    :type _validate_change: (T) -> None
+    :type _validate_change: (Any) -> bool
     :type _parse_value: (unicode) -> T
     :type type: type
     :type description: unicode
@@ -42,7 +38,7 @@ class Setting(object):
         :param on_changed: called when there is a change to the value
         :type on_changed: (T) -> None
         :param validate_change: called to validate the new change
-        :type validate_change: (T) -> None
+        :type validate_change: (Any) -> bool
         :param parse_value: called to parse a new string as a value
         :type parse_value: (unicode) -> T
         :param description: description of setting
@@ -91,7 +87,6 @@ class Setting(object):
                 self._on_changed(self._value)
         else:
             raise InnerCommandError('Setting value was not validated')
-
 
     def set_value_with_str(self, val):
         """
@@ -184,6 +179,6 @@ def complete_setting_inner_command(arg_idx, app, full_args_text, document):
         return []
 
 
-setting_inner_command = InnerCommand('setting', 'Edit or view a setting', 'setting NAME [value]', setting_inner_command_func,
-                                 completer=complete_setting_inner_command,
-                                 param_regex=r'^([^ ]+)(?: (.+))?$')
+setting_inner_command = InnerCommand('setting', 'Edit or view a setting', 'setting NAME [value]',
+                                     setting_inner_command_func, completer=complete_setting_inner_command,
+                                     param_regex=r'^([^ ]+)(?: (.+))?$')

--- a/brkt_cli/shell/test_app.py
+++ b/brkt_cli/shell/test_app.py
@@ -13,29 +13,183 @@
 # limitations under the License.
 import unittest
 
-from brkt_cli.shell import ShellCompleter, App
-from brkt_cli.shell.inner_commands import InnerCommand
-from brkt_cli.shell.raw_commands import CommandPromptToolkit
+from prompt_toolkit.document import Document
 
-class TestAppClass(App):
+from brkt_cli.shell import App
+from brkt_cli.shell.test_utils import make_app
 
-    INNER_COMMANDS = {
-        u'/test': InnerCommand('test', 'tests with no arguments', 'test', None),
-        u'/test_arg': InnerCommand('test_arg', 'tests with an arguments', 'test ARG', None),
-    }
-
-    def make_cli_interface(self):
-        pass
-
-def generate_app():
-    cmd = CommandPromptToolkit('test', 'tester', 'test', 'test', None)
-    completer = ShellCompleter(cmd)
-    return TestAppClass(completer, cmd)
 
 class TestApp(unittest.TestCase):
+    def test_parse_command(self):
+        app = make_app()
+        app.saved_commands = {
+            'foo': u'shallow --optional_true',
+            'bar': u'foo'
+        }
+
+        ret = app.parse_command(Document(u'shallow --optional_true --optional_false --optional_store abc'))
+        self.assertEqual(ret, u'shallow --optional_true --optional_false --optional_store abc')
+
+        ret = app.parse_command(Document(u'foo'))
+        self.assertEqual(ret, u'shallow --optional_true')
+
+        ret = app.parse_command(Document(u'bar'))
+        self.assertEqual(ret, u'shallow --optional_true')
+
     def test_parse_embedded_commands(self):
+        app = make_app()
+
+        cmd_text = u'/set test $(shallow --optional_true)'
+        embedded_commands = App.parse_embedded_command_text(cmd_text)
+        ret = app._parse_embedded_commands(cmd_text, embedded_commands)
+        self.assertRegexpMatches(ret, r'^\/set test .+ shallow --optional_true$')
+
+        cmd_text = u'/set test $(shallow --optional_true) and $(deep semi_shallow)'
+        embedded_commands = App.parse_embedded_command_text(cmd_text)
+        ret = app._parse_embedded_commands(cmd_text, embedded_commands)
+        self.assertRegexpMatches(ret, r'^\/set test .+ shallow --optional_true and .+ deep semi_shallow$')
+
+        cmd_text = u'/set test $(shallow $(deep semi_shallow) --optional_true)'
+        embedded_commands = App.parse_embedded_command_text(cmd_text)
+        ret = app._parse_embedded_commands(cmd_text, embedded_commands)
+        self.assertRegexpMatches(ret, r'^\/set test .+ shallow .+ deep semi_shallow --optional_true$')
+
+    def test_parse_set_args_commands(self):
+        app = make_app()
+        super_shallow_cmd = app.cmd.get_subcommand_from_path('test.super_shallow')
+        shallow_cmd = app.cmd.get_subcommand_from_path('test.shallow')
+
+        # Test with no arguments specified
+        doc = Document(text=u'test super_shallow')
+        app.set_args['test.super_shallow'] = {}
+        ret = app._parse_set_args_commands(doc, super_shallow_cmd)
+        self.assertEqual(ret.strip(), u'test super_shallow')
+
+        # Test with only required arguments specified
+        doc = Document(text=u'test shallow tree king')
+        app.set_args['test.shallow'] = {}
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow tree king')
+
+        # Test with all arguments specified
+        doc = Document(text=u'test shallow --optional_true --optional_false --optional_store abc '
+                            u'--optional_store_int 81 --optional_store_default marker --optional_const '
+                            u'--optional_append foo --optional_append bar --optional_append baz '
+                            u'--optional_append_const_a --optional_append_const_b --optional_count '
+                            u'--optional_count tree king')
+        app.set_args['test.shallow'] = {}
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_true --optional_false --optional_store abc '
+                                      u'--optional_store_int 81 --optional_store_default marker --optional_const '
+                                      u'--optional_append foo --optional_append bar --optional_append baz '
+                                      u'--optional_append_const_a --optional_append_const_b --optional_count '
+                                      u'--optional_count tree king')
+
+        # Test with all arguments in set_args
+        doc = Document(text=u'test shallow')
+        app.set_args['test.shallow'] = {
+            'optional_false': True,
+            'optional_true': True,
+            'optional_store': 'xyz',
+            'optional_store_int': 64,
+            'optional_store_default': 'glass',
+            'optional_const': True,
+            'optional_append': ['hello', 'world'],
+            'optional_append_const_a': True,
+            'optional_append_const_b': True,
+            'optional_count': 4,
+            'POSITIONAL_1': 'stem',
+            'POSITIONAL_2': 'queen',
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_true --optional_false --optional_store xyz '
+                                      u'--optional_store_int 64 --optional_store_default glass --optional_const '
+                                      u'--optional_append hello --optional_append world '
+                                      u'--optional_append_const_a --optional_append_const_b --optional_count '
+                                      u'--optional_count --optional_count --optional_count stem queen')
+
+        # Test with all arguments in set_args and specified. This is to test override order: specified values should
+        # trump set_args
+        doc = Document(text=u'test shallow --optional_true --optional_false --optional_store abc '
+                            u'--optional_store_int 81 --optional_store_default marker --optional_const '
+                            u'--optional_append foo --optional_append bar --optional_append baz '
+                            u'--optional_append_const_a --optional_append_const_b --optional_count '
+                            u'--optional_count tree king')
+        app.set_args['test.shallow'] = {
+            'optional_false': False,
+            'optional_true': False,
+            'optional_store': 'xyz',
+            'optional_store_int': 64,
+            'optional_store_default': 'glass',
+            'optional_const': False,
+            'optional_append': ['hello', 'world'],
+            'optional_append_const_a': False,
+            'optional_append_const_b': False,
+            'optional_count': 4,
+            'POSITIONAL_1': 'stem',
+            'POSITIONAL_2': 'queen',
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_true --optional_false --optional_store abc '
+                                      u'--optional_store_int 81 --optional_store_default marker --optional_const '
+                                      u'--optional_append foo --optional_append bar --optional_append baz '
+                                      u'--optional_append_const_a --optional_append_const_b --optional_count '
+                                      u'--optional_count tree king')
+
+        # Test to make sure that optional_true and optional_false must be True in set_args to be in the command
+        doc = Document(text=u'test shallow')
+        app.set_args['test.shallow'] = {
+            'optional_false': True,
+            'optional_true': True,
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_true --optional_false')
+
+        # Test to make sure that optional_true and optional_false must be False in set_args to not be in the command
+        doc = Document(text=u'test shallow')
+        app.set_args['test.shallow'] = {
+            'optional_false': False,
+            'optional_true': False,
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow')
+
+        # Test that hidden commands do not work when dev mode is off
+        doc = Document(text=u'test shallow --optional_store_hidden word')
+        app.set_args['test.shallow'] = {}
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow')
+
+        # Test that hidden commands do not work when dev mode is off
+        doc = Document(text=u'test shallow')
+        app.set_args['test.shallow'] = {
+            'optional_store_hidden': 'phrase',
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow')
+
+        # Test that hidden commands work only when dev mode is on
+        app.dev_mode = True
+        doc = Document(text=u'test shallow --optional_store_hidden word')
+        app.set_args['test.shallow'] = {}
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_store_hidden word')
+
+        # Test that hidden commands work only when dev mode is on
+        app.dev_mode = True
+        doc = Document(text=u'test shallow')
+        app.set_args['test.shallow'] = {
+            'optional_store_hidden': 'phrase',
+        }
+        ret = app._parse_set_args_commands(doc, shallow_cmd)
+        self.assertEqual(ret.strip(), u'test shallow --optional_store_hidden phrase')
+
+        # Reset dev mode
+        app.dev_mode = False
+
+    def test_parse_embedded_command_text(self):
         def parse_text(text):
-            return [text[start+2:end] for start, end in App.parse_embedded_commands(text)]
+            return [text[start+2:end] for start, end in App.parse_embedded_command_text(text)]
 
         self.assertListEqual(parse_text('foo bar'), [])
         self.assertListEqual(parse_text(''), [])

--- a/brkt_cli/shell/test_app.py
+++ b/brkt_cli/shell/test_app.py
@@ -1,0 +1,52 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from brkt_cli.shell import ShellCompleter, App
+from brkt_cli.shell.inner_commands import InnerCommand
+from brkt_cli.shell.raw_commands import CommandPromptToolkit
+
+class TestAppClass(App):
+
+    INNER_COMMANDS = {
+        u'/test': InnerCommand('test', 'tests with no arguments', 'test', None),
+        u'/test_arg': InnerCommand('test_arg', 'tests with an arguments', 'test ARG', None),
+    }
+
+    def make_cli_interface(self):
+        pass
+
+def generate_app():
+    cmd = CommandPromptToolkit('test', 'tester', 'test', 'test', None)
+    completer = ShellCompleter(cmd)
+    return TestAppClass(completer, cmd)
+
+class TestApp(unittest.TestCase):
+    def test_parse_embedded_commands(self):
+        def parse_text(text):
+            return [text[start+2:end] for start, end in App.parse_embedded_commands(text)]
+
+        self.assertListEqual(parse_text('foo bar'), [])
+        self.assertListEqual(parse_text(''), [])
+        self.assertListEqual(parse_text('foo $(hello world) bar'), ['hello world'])
+        self.assertListEqual(parse_text('$(hello world) foo bar'), ['hello world'])
+        self.assertListEqual(parse_text('foo bar $(hello world)'), ['hello world'])
+        self.assertListEqual(parse_text('foo $(hello) bar $(world) baz'), ['hello','world'])
+        self.assertListEqual(parse_text('foo $(hello $(inserted) world) bar'), ['hello $(inserted) world'])
+        self.assertListEqual(parse_text('foo $(hello) \$\(world\) bar'), ['hello'])
+        self.assertListEqual(parse_text('foo $(hel\)lo) bar'), ['hel\\)lo'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_completer.py
+++ b/brkt_cli/shell/test_completer.py
@@ -15,7 +15,7 @@ import unittest
 
 from prompt_toolkit.document import Document
 
-from brkt_cli.shell.test_utils import make_top_cmd, make_app
+from brkt_cli.shell.test_utils import make_app
 
 
 class TestCompleter(unittest.TestCase):

--- a/brkt_cli/shell/test_completer.py
+++ b/brkt_cli/shell/test_completer.py
@@ -1,0 +1,254 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.test_utils import make_top_cmd, make_app
+
+
+class TestCompleter(unittest.TestCase):
+    def test_get_completions_list(self):
+        app = make_app()
+
+        # Test nothing in prompt. Should return commands.
+        doc = Document(u'')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['deep', 'shallow', 'super_shallow'])
+
+        # Test a deep command in prompt. Should return subcommand.
+        doc = Document(u'deep')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['semi_shallow'])
+
+        # Test a deep command and subcommand in prompt. Should return options.
+        doc = Document(u'deep semi_shallow')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_store'])
+
+        # Test a deep command and subcommand and help argument in prompt. Should return no options as help stops
+        # further options.
+        doc = Document(u'deep semi_shallow --help')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, [])
+
+        # Test a deep command and subcommand and regular argument in prompt. Should return one option as the
+        # --optional_store option cannot be specified again.
+        doc = Document(u'deep semi_shallow --optional_store')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help'])
+
+        # Test a command with no arguments. Should return --help.
+        doc = Document(u'super_shallow')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help'])
+
+        # Test a command with no arguments. Should return all.
+        doc = Document(u'shallow')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with no arguments and dev mode enabled. Should return all plus the hidden argument.
+        app.dev_mode = True
+        doc = Document(u'shallow')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_hidden', '--optional_store_int',
+                                   '--optional_true'])
+        app.dev_mode = False
+
+        # Test a command with help argument. Should no arguments as --help stops suggestions
+        doc = Document(u'shallow --help')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, [])
+
+        # Test a command with an argument being written
+        doc = Document(u'shallow --optional_store ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, [])
+
+        # Test a command with an argument that has been entered. Should remove the argument from the list.
+        doc = Document(u'shallow --optional_store foo ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written
+        doc = Document(u'shallow --optional_append ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, [])
+
+        # Test a command with an argument that has been entered. Should NOT remove the argument from the list.
+        doc = Document(u'shallow --optional_append foo ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written. Should leave space for argument value and suggest
+        # default choices.
+        doc = Document(u'shallow --optional_store_choices ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['cold', 'hot'])
+
+        # Test a command with an argument being written. Should not leave space for argument value and should remove
+        # the argument from the list.
+        doc = Document(u'shallow --optional_const ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written. Should not leave space for argument value and should remove
+        # the argument from the list.
+        doc = Document(u'shallow --optional_append_const_a ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written. Should not leave space for argument value and should NOT
+        # remove the argument from the list.
+        doc = Document(u'shallow --optional_count ')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written. Should not leave space for argument value and should remove
+        # the argument from the list.
+        doc = Document(u'shallow --optional_false')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int', '--optional_true'])
+
+        # Test a command with an argument being written. Should not leave space for argument value and should remove
+        # the argument from the list.
+        doc = Document(u'shallow --optional_true')
+        ret = app.completer.get_completions_list(doc)
+        self.assertListEqual(ret, ['--help', '--optional_append', '--optional_append_const_a',
+                                   '--optional_append_const_b', '--optional_const', '--optional_count',
+                                   '--optional_false', '--optional_store', '--optional_store_choices',
+                                   '--optional_store_default', '--optional_store_int'])
+
+    def test_get_current_command(self):
+        app = make_app()
+
+        doc = Document(u'')
+        ret = app.completer.get_current_command(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'deep semi_shallow')
+        ret = app.completer.get_current_command(doc)
+        self.assertEqual(ret.path, 'test.deep.semi_shallow')
+
+        doc = Document(u'super_shallow')
+        ret = app.completer.get_current_command(doc)
+        self.assertEqual(ret.path, 'test.super_shallow')
+
+        doc = Document(u'shallow')
+        ret = app.completer.get_current_command(doc)
+        self.assertEqual(ret.path, 'test.shallow')
+
+        doc = Document(u'shallow --optional_store foo --optional_const')
+        ret = app.completer.get_current_command(doc)
+        self.assertEqual(ret.path, 'test.shallow')
+
+        doc = Document(u'deep fake')
+        ret = app.completer.get_current_command(doc)
+        self.assertEqual(ret.path, 'test.deep')
+
+    def test_get_current_command_location(self):
+        app = make_app()
+
+        doc = Document(u'')
+        ret_start, ret_end = app.completer.get_current_command_location(doc)
+        self.assertEqual(ret_start, 0)
+        self.assertEqual(ret_end, 0)
+
+        doc = Document(u'deep semi_shallow')
+        ret_start, ret_end = app.completer.get_current_command_location(doc)
+        self.assertEqual(ret_start, 0)
+        self.assertEqual(ret_end, 17)
+
+        doc = Document(u'shallow')
+        ret_start, ret_end = app.completer.get_current_command_location(doc)
+        self.assertEqual(ret_start, 0)
+        self.assertEqual(ret_end, 7)
+
+        doc = Document(u'shallow --optional_store foo --optional_const')
+        ret_start, ret_end = app.completer.get_current_command_location(doc)
+        self.assertEqual(ret_start, 0)
+        self.assertEqual(ret_end, 7)
+
+        doc = Document(u'deep fake')
+        ret_start, ret_end = app.completer.get_current_command_location(doc)
+        self.assertEqual(ret_start, 0)
+        self.assertEqual(ret_end, 4)
+
+    def test_get_current_argument(self):
+        app = make_app()
+
+        doc = Document(u'')
+        ret = app.completer.get_current_argument(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'shallow')
+        ret = app.completer.get_current_argument(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'deep semi_shallow')
+        ret = app.completer.get_current_argument(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'deep semi_shallow --optional_store')
+        ret = app.completer.get_current_argument(doc)
+        self.assertEqual(ret.tag, '--optional_store')
+
+        doc = Document(u'deep fake --optional_store')
+        ret = app.completer.get_current_argument(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'shallow --optional_store')
+        ret = app.completer.get_current_argument(doc)
+        self.assertEqual(ret.tag, '--optional_store')
+
+        doc = Document(u'shallow --optional_store foo')
+        ret = app.completer.get_current_argument(doc)
+        self.assertEqual(ret.tag, '--optional_store')
+
+        doc = Document(u'shallow --optional_store foo ')
+        ret = app.completer.get_current_argument(doc)
+        self.assertIsNone(ret)
+
+        doc = Document(u'shallow --optional_store foo --optional_true')
+        ret = app.completer.get_current_argument(doc)
+        self.assertEqual(ret.tag, '--optional_true')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_enum.py
+++ b/brkt_cli/shell/test_enum.py
@@ -11,16 +11,22 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
-class Enum:
-    @classmethod
-    def format_enum(cls, enum):
-        """
-        Formats an enum as a string
-        :param enum: the enum integer
-        :type enum: int
-        :return: the string name of the enum
-        :rtype: unicode
-        """
-        for name, val in filter((lambda (key, value): not key.startswith('__')), cls.__dict__.items()):
-            if val == enum:
-                return name
+import unittest
+
+from brkt_cli.shell.enum import Enum
+
+
+class TestEnum(unittest.TestCase):
+    def test_format_enum(self):
+        class FakeEnum(Enum):
+            Unknown, Foo, Bar = range(3)
+
+        self.assertEqual(FakeEnum.format_enum(FakeEnum.Unknown), 'Unknown')
+        self.assertEqual(FakeEnum.format_enum(FakeEnum.Foo), 'Foo')
+        self.assertEqual(FakeEnum.format_enum(FakeEnum.Bar), 'Bar')
+        self.assertEqual(FakeEnum.format_enum(2), 'Bar')
+        self.assertIsNone(FakeEnum.format_enum(3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_get_set_inner_commands.py
+++ b/brkt_cli/shell/test_get_set_inner_commands.py
@@ -28,6 +28,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {
@@ -101,6 +102,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {
@@ -153,6 +155,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {
@@ -241,6 +244,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {
@@ -293,6 +297,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {
@@ -375,6 +380,7 @@ class TestGetSetInnerCommands(unittest.TestCase):
 
         def on_change_manual_arg(val):
             pass
+
         def on_delete_manual_arg():
             pass
         app.manual_args = {

--- a/brkt_cli/shell/test_get_set_inner_commands.py
+++ b/brkt_cli/shell/test_get_set_inner_commands.py
@@ -1,0 +1,427 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.get_set_inner_commmands import set_inner_command, \
+    complete_set_inner_command, get_inner_command, del_inner_command, complete_get_inner_command, \
+    complete_del_inner_command
+from brkt_cli.shell.inner_commands import InnerCommandError
+from brkt_cli.shell.test_utils import trap_print_output, make_app
+
+
+class TestGetSetInnerCommands(unittest.TestCase):
+    def test_set_inner_command_func(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+
+        set_inner_command.run_action('/set test.shallow.optional_store abc', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_store'], 'abc')
+
+        set_inner_command.run_action('/set test.shallow.optional_store xyz', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_store'], 'xyz')
+
+        set_inner_command.run_action('/set test.shallow.optional_store_int 64', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_store_int'], 64)
+
+        with self.assertRaises(ValueError):
+            set_inner_command.run_action('/set test.shallow.optional_store_int forty nine', app)
+
+        set_inner_command.run_action('/set test.shallow.optional_const true', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_const'], True)
+        set_inner_command.run_action('/set test.shallow.optional_const false', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_const'], False)
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/set test.shallow.optional_const bool', app)
+
+        set_inner_command.run_action('/set test.shallow.optional_append hello, world', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_append'], ['hello', 'world'])
+
+        set_inner_command.run_action('/set test.shallow.optional_append_const_a true', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_append_const_a'], True)
+
+        set_inner_command.run_action('/set test.shallow.optional_count 4', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_count'], 4)
+
+        with self.assertRaises(ValueError):
+            set_inner_command.run_action('/set test.shallow.optional_count nine', app)
+
+        set_inner_command.run_action('/set test.shallow.optional_true true', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_true'], True)
+        set_inner_command.run_action('/set test.shallow.optional_false false', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_false'], False)
+
+        set_inner_command.run_action('/set test.shallow.POSITIONAL_1 stem', app)
+        self.assertEqual(app.set_args['test.shallow']['POSITIONAL_1'], 'stem')
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/set test.fake.fake-arg foobar', app)
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/set test.shallow.fake-arg foobar', app)
+
+        set_inner_command.run_action('/set app.manual_arg floof', app)
+        self.assertEqual(app.set_args['app']['manual_arg'], 'floof')
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/set app.fake foobar', app)
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/set test.shallow.optional_store_hidden phrase', app)
+
+        app.dev_mode = True
+        set_inner_command.run_action('/set test.shallow.optional_store_hidden phrase', app)
+        self.assertEqual(app.set_args['test.shallow']['optional_store_hidden'], 'phrase')
+        app.dev_mode = False
+
+    def test_complete_set_inner_command(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+
+        ret = complete_set_inner_command(0, app, [], Document(u'/set '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg', 'test.deep.semi_shallow.optional_store',
+                                   'test.shallow.POSITIONAL_1', 'test.shallow.POSITIONAL_2',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_append_const_b', 'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_choices',
+                                   'test.shallow.optional_store_default', 'test.shallow.optional_store_int',
+                                   'test.shallow.optional_true'])
+
+        app.dev_mode = True
+        ret = complete_set_inner_command(0, app, [], Document(u'/set '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg', 'test.deep.semi_shallow.optional_store',
+                                   'test.shallow.POSITIONAL_1', 'test.shallow.POSITIONAL_2',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_append_const_b', 'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_choices',
+                                   'test.shallow.optional_store_default', 'test.shallow.optional_store_hidden',
+                                   'test.shallow.optional_store_int', 'test.shallow.optional_true'])
+        app.dev_mode = False
+
+        ret = complete_set_inner_command(1, app, ['test.shallow.optional_store'],
+                                         Document(u'/set test.shallow.optional_store '))
+        ret.sort()
+        self.assertListEqual(ret, [])
+
+        ret = complete_set_inner_command(1, app, ['test.shallow.optional_store_choices'],
+                                         Document(u'/set test.shallow.optional_store_choices '))
+        ret.sort()
+        self.assertListEqual(ret, ['cold', 'hot'])
+
+        ret = complete_set_inner_command(1, app, ['test.shallow.optional_true'],
+                                         Document(u'/set test.shallow.optional_true '))
+        ret.sort()
+        self.assertListEqual(ret, ['false', 'true'])
+
+    def test_get_inner_command_func(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+        app.set_args = {
+            'test.shallow': {
+                'optional_store': 'xyz',
+                'optional_store_int': 64,
+                'optional_const': False,
+                'optional_append': ['hello', 'world'],
+                'optional_append_const_a': True,
+                'optional_count': 4,
+                'optional_true': True,
+                'optional_false': False,
+                'POSITIONAL_1': 'stem',
+                'optional_store_hidden': 'phrase',
+            },
+            'app': {
+                'manual_arg': 'floof',
+            }
+        }
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_store', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_store: xyz')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_store_int', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_store_int: 64')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_const', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_const: False')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_append', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_append: [\'hello\', \'world\']')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_append_const_a', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_append_const_a: True')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_count', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_count: 4')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_true', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_true: True')
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_false', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_false: False')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.POSITIONAL_1', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.POSITIONAL_1: stem')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get app.manual_arg', app)
+            self.assertEqual(out.getvalue().strip(), 'app.manual_arg: floof')
+
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_append_const_b', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_append_const_b: None')
+
+        with self.assertRaises(InnerCommandError):
+            get_inner_command.run_action('/get test.shallow.optional_store_hidden', app)
+
+        app.dev_mode = True
+        with trap_print_output() as (out, err):
+            get_inner_command.run_action('/get test.shallow.optional_store_hidden', app)
+            self.assertEqual(out.getvalue().strip(), 'test.shallow.optional_store_hidden: phrase')
+        app.dev_mode = False
+
+        with self.assertRaises(InnerCommandError):
+            get_inner_command.run_action('/get test.fake.fake-arg', app)
+
+        with self.assertRaises(InnerCommandError):
+            get_inner_command.run_action('/get test.shallow.fake-arg', app)
+
+    def test_complete_get_inner_command(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+        app.set_args = {
+            'test.shallow': {
+                'optional_store': 'xyz',
+                'optional_store_int': 64,
+                'optional_const': False,
+                'optional_append': ['hello', 'world'],
+                'optional_append_const_a': True,
+                'optional_count': 4,
+                'optional_true': True,
+                'optional_false': False,
+                'POSITIONAL_1': 'stem',
+                'optional_store_hidden': 'phrase',
+            },
+            'app': {
+                'manual_arg': 'floof',
+            }
+        }
+
+        ret = complete_get_inner_command(0, app, [], Document(u'/get '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg',
+                                   'test.shallow.POSITIONAL_1',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_int',
+                                   'test.shallow.optional_true'])
+
+        app.dev_mode = True
+        ret = complete_get_inner_command(0, app, [], Document(u'/get '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg',
+                                   'test.shallow.POSITIONAL_1',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_hidden',
+                                   'test.shallow.optional_store_int', 'test.shallow.optional_true'])
+        app.dev_mode = False
+
+    def test_del_inner_command_func(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+        app.set_args = {
+            'test.shallow': {
+                'optional_store': 'xyz',
+                'optional_store_int': 64,
+                'optional_const': False,
+                'optional_append': ['hello', 'world'],
+                'optional_append_const_a': True,
+                'optional_count': 4,
+                'optional_true': True,
+                'optional_false': False,
+                'POSITIONAL_1': 'stem',
+                'optional_store_hidden': 'phrase',
+            },
+            'app': {
+                'manual_arg': 'floof',
+            }
+        }
+
+        del_inner_command.run_action('/del test.shallow.optional_store', app)
+        self.assertFalse('optional_store' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_store_int', app)
+        self.assertFalse('optional_store_int' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_const', app)
+        self.assertFalse('optional_const' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_append', app)
+        self.assertFalse('optional_append' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_append_const_a', app)
+        self.assertFalse('optional_append_const_a' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_count', app)
+        self.assertFalse('optional_count' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_true', app)
+        self.assertFalse('optional_true' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.optional_false', app)
+        self.assertFalse('optional_false' in app.set_args['test.shallow'])
+
+        del_inner_command.run_action('/del test.shallow.POSITIONAL_1', app)
+        self.assertFalse('POSITIONAL_1' in app.set_args['test.shallow'])
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/del test.shallow.optional_store_hidden', app)
+
+        app.dev_mode = True
+        del_inner_command.run_action('/del test.shallow.optional_store_hidden', app)
+        self.assertFalse('optional_store_hidden' in app.set_args['test.shallow'])
+        app.dev_mode = False
+
+        del_inner_command.run_action('/del app.manual_arg', app)
+        self.assertFalse('manual_arg' in app.set_args['app'])
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/del test.shallow.optional_append_const_b', app)
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/del test.fake.fake-arg', app)
+
+        with self.assertRaises(InnerCommandError):
+            set_inner_command.run_action('/del test.shallow.fake-arg', app)
+
+        self.assertDictEqual(app.set_args, {
+            'test.shallow': {},
+            'app': {},
+        })
+
+    def test_complete_del_inner_command(self):
+        app = make_app()
+
+        def on_change_manual_arg(val):
+            pass
+        def on_delete_manual_arg():
+            pass
+        app.manual_args = {
+            'app': {
+                'manual_arg': (on_change_manual_arg, on_delete_manual_arg)
+            }
+        }
+        app.set_args = {
+            'test.shallow': {
+                'optional_store': 'xyz',
+                'optional_store_int': 64,
+                'optional_const': False,
+                'optional_append': ['hello', 'world'],
+                'optional_append_const_a': True,
+                'optional_count': 4,
+                'optional_true': True,
+                'optional_false': False,
+                'POSITIONAL_1': 'stem',
+                'optional_store_hidden': 'phrase',
+            },
+            'app': {
+                'manual_arg': 'floof',
+            }
+        }
+
+        ret = complete_del_inner_command(0, app, [], Document(u'/del '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg',
+                                   'test.shallow.POSITIONAL_1',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_int',
+                                   'test.shallow.optional_true'])
+
+        app.dev_mode = True
+        ret = complete_del_inner_command(0, app, [], Document(u'/del '))
+        ret.sort()
+        self.assertListEqual(ret, ['app.manual_arg',
+                                   'test.shallow.POSITIONAL_1',
+                                   'test.shallow.optional_append', 'test.shallow.optional_append_const_a',
+                                   'test.shallow.optional_const',
+                                   'test.shallow.optional_count', 'test.shallow.optional_false',
+                                   'test.shallow.optional_store', 'test.shallow.optional_store_hidden',
+                                   'test.shallow.optional_store_int', 'test.shallow.optional_true'])
+        app.dev_mode = False
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_inner_commands.py
+++ b/brkt_cli/shell/test_inner_commands.py
@@ -1,0 +1,126 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell import App
+from brkt_cli.shell.inner_commands import exit_inner_command_func, inner_command_completer_static, InnerCommand, \
+    InnerCommandError
+from brkt_cli.shell.test_app import generate_app
+
+
+class TestInnerCommand(unittest.TestCase):
+    def test_run_action(self):
+        app = generate_app()
+        def action(params, app):
+            return params, app
+
+        cmd = InnerCommand('test', 'a test', '/test', action)
+        ret_params, ret_app = cmd.run_action('/test', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), '')
+        with self.assertRaises(IndexError):
+            ret_params.group(1)
+
+        cmd = InnerCommand('test', 'a test', 'test', action)
+        with self.assertRaises(InnerCommandError):
+            cmd.run_action('/test unwanted', app)
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED TEXT', action, param_regex=r'^(.+)$')
+        ret_params, ret_app = cmd.run_action('/test foobar', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), 'foobar')
+        self.assertEqual(ret_params.group(1), 'foobar')
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED TEXT', action, param_regex=r'^(.+)$')
+        with self.assertRaises(InnerCommandError):
+            cmd.run_action('/test', app)
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED TEXT', action, param_regex=r'^(.+)$')
+        ret_params, ret_app = cmd.run_action('/test foo bar', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), 'foo bar')
+        self.assertEqual(ret_params.group(1), 'foo bar')
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED REQUIRED', action, param_regex=r'^([^ ]+) (.+)$')
+        ret_params, ret_app = cmd.run_action('/test foo bar', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), 'foo bar')
+        self.assertEqual(ret_params.group(1), 'foo')
+        self.assertEqual(ret_params.group(2), 'bar')
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED REQUIRED', action, param_regex=r'^([^ ]+) (.+)$')
+        with self.assertRaises(InnerCommandError):
+            cmd.run_action('/test foo', app)
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED [optional]', action, param_regex=r'^([^ ]+)(?: (.+))?$')
+        ret_params, ret_app = cmd.run_action('/test foo bar', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), 'foo bar')
+        self.assertEqual(ret_params.group(1), 'foo')
+        self.assertEqual(ret_params.group(2), 'bar')
+
+        cmd = InnerCommand('test', 'a test', 'test REQUIRED [optional]', action, param_regex=r'^([^ ]+)(?: (.+))?$')
+        ret_params, ret_app = cmd.run_action('/test foo', app)
+        self.assertEqual(ret_app, app)
+        self.assertIsNotNone(ret_params)
+        self.assertEqual(ret_params.group(0), 'foo')
+        self.assertEqual(ret_params.group(1), 'foo')
+        self.assertIsNone(ret_params.group(2))
+
+    def test_inner_command_error(self):
+        self.assertEqual(InnerCommandError('Unknown error').format_error(), 'Error: Unknown error')
+        self.assertEqual(InnerCommandError('').format_error(), 'Error: ')
+        self.assertEqual(InnerCommandError.format(Exception('foo bar').message), 'Error: foo bar')
+
+
+    def test_inner_command_completer_static(self):
+        app = generate_app()
+
+        res_func = inner_command_completer_static()
+        res = res_func(0, app, [], Document())
+        self.assertListEqual(res, [])
+
+        res_func = inner_command_completer_static()
+        res = res_func(100, app, [], Document())
+        self.assertListEqual(res, [])
+
+        res_func = inner_command_completer_static([['foo','bar']])
+        res = res_func(0, app, [], Document())
+        self.assertListEqual(res, ['foo', 'bar'])
+
+        res_func = inner_command_completer_static([['foo', 'bar'], []])
+        res = res_func(1, app, [], Document())
+        self.assertListEqual(res, [])
+
+        res_func = inner_command_completer_static([['foo', 'bar']])
+        res = res_func(1, app, [], Document())
+        self.assertListEqual(res, [])
+
+        res_func = inner_command_completer_static([['foo', 'bar'], ['baz']])
+        res = res_func(1, app, [], Document())
+        self.assertListEqual(res, ['baz'])
+    def test_exit_inner_command_func(self):
+        res = exit_inner_command_func([], generate_app())
+        self.assertEqual(res, App.MachineCommands.Exit)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_inner_commands.py
+++ b/brkt_cli/shell/test_inner_commands.py
@@ -24,8 +24,9 @@ from brkt_cli.shell.test_utils import make_app
 class TestInnerCommand(unittest.TestCase):
     def test_run_action(self):
         app = make_app()
-        def action(params, app):
-            return params, app
+
+        def action(params, the_app):
+            return params, the_app
 
         cmd = InnerCommand('test', 'a test', '/test', action)
         ret_params, ret_app = cmd.run_action('/test', app)
@@ -101,7 +102,7 @@ class TestInnerCommand(unittest.TestCase):
         res = res_func(100, app, [], Document())
         self.assertListEqual(res, [])
 
-        res_func = inner_command_completer_static([['foo','bar']])
+        res_func = inner_command_completer_static([['foo', 'bar']])
         res = res_func(0, app, [], Document())
         self.assertListEqual(res, ['foo', 'bar'])
 

--- a/brkt_cli/shell/test_inner_commands.py
+++ b/brkt_cli/shell/test_inner_commands.py
@@ -18,12 +18,12 @@ from prompt_toolkit.document import Document
 from brkt_cli.shell import App
 from brkt_cli.shell.inner_commands import exit_inner_command_func, inner_command_completer_static, InnerCommand, \
     InnerCommandError
-from brkt_cli.shell.test_app import generate_app
+from brkt_cli.shell.test_utils import make_app
 
 
 class TestInnerCommand(unittest.TestCase):
     def test_run_action(self):
-        app = generate_app()
+        app = make_app()
         def action(params, app):
             return params, app
 
@@ -90,9 +90,8 @@ class TestInnerCommand(unittest.TestCase):
         self.assertEqual(InnerCommandError('').format_error(), 'Error: ')
         self.assertEqual(InnerCommandError.format(Exception('foo bar').message), 'Error: foo bar')
 
-
     def test_inner_command_completer_static(self):
-        app = generate_app()
+        app = make_app()
 
         res_func = inner_command_completer_static()
         res = res_func(0, app, [], Document())
@@ -117,8 +116,9 @@ class TestInnerCommand(unittest.TestCase):
         res_func = inner_command_completer_static([['foo', 'bar'], ['baz']])
         res = res_func(1, app, [], Document())
         self.assertListEqual(res, ['baz'])
+
     def test_exit_inner_command_func(self):
-        res = exit_inner_command_func([], generate_app())
+        res = exit_inner_command_func(None, make_app())
         self.assertEqual(res, App.MachineCommands.Exit)
 
 

--- a/brkt_cli/shell/test_manpage.py
+++ b/brkt_cli/shell/test_manpage.py
@@ -1,0 +1,84 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.manpage import Manpage
+from brkt_cli.shell.test_utils import make_app
+
+
+class TestManpage(unittest.TestCase):
+    def test_get_text(self):
+        app = make_app()
+        manpage = Manpage(app)
+
+        ret = manpage.get_text(Document(u''))
+        self.assertEqual(ret, '')
+
+        ret = manpage.get_text(Document(u'deep'))
+        self.assertTrue(ret.startswith('has subcommands'))
+        self.assertTrue('[-h]' in ret)
+
+        ret = manpage.get_text(Document(u'deep semi_shallow'))
+        self.assertTrue(ret.startswith('has no subcommands and one arguments'))
+        self.assertTrue('[-h]' in ret)
+        self.assertTrue('[--optional_store OPTIONAL_STORE]' in ret)
+
+        ret = manpage.get_text(Document(u'super_shallow'))
+        self.assertTrue(ret.startswith('has no subcommands and no arguments'))
+        self.assertTrue('[-h]' in ret)
+
+        ret = manpage.get_text(Document(u'shallow'))
+        self.assertTrue(ret.startswith('has no subcommands but all arguments'))
+        self.assertTrue('[--optional_true]' in ret)
+        self.assertTrue('[--optional_false]' in ret)
+        self.assertTrue('[--optional_store OPTIONAL_STORE]' in ret)
+        self.assertTrue('[--optional_store_int OPTIONAL_STORE_INT]' in ret)
+        self.assertTrue('[--optional_store_default OPTIONAL_STORE_DEFAULT]' in ret)
+        self.assertTrue('[--optional_store_choices {hot,cold}]' in ret)
+        self.assertTrue('[--optional_const]' in ret)
+        self.assertTrue('[--optional_append OPTIONAL_APPEND]' in ret)
+        self.assertTrue('[--optional_append_const_a]' in ret)
+        self.assertTrue('[--optional_append_const_b]' in ret)
+        self.assertTrue('[--optional_count]' in ret)
+        self.assertTrue('POSITIONAL_1 POSITIONAL_2' in ret)
+
+        ret = manpage.get_text(Document(u'shallow --optional_store'))
+        self.assertEqual(ret, 'Optional store')
+
+        ret = manpage.get_text(Document(u'shallow --optional_store foo'))
+        self.assertEqual(ret, 'Optional store')
+
+        ret = manpage.get_text(Document(u'shallow --optional_store foo '))
+        self.assertTrue(ret.startswith('has no subcommands but all arguments'))
+        self.assertTrue('[--optional_true]' in ret)
+        self.assertTrue('[--optional_false]' in ret)
+        self.assertTrue('[--optional_store OPTIONAL_STORE]' in ret)
+        self.assertTrue('[--optional_store_int OPTIONAL_STORE_INT]' in ret)
+        self.assertTrue('[--optional_store_default OPTIONAL_STORE_DEFAULT]' in ret)
+        self.assertTrue('[--optional_store_choices {hot,cold}]' in ret)
+        self.assertTrue('[--optional_const]' in ret)
+        self.assertTrue('[--optional_append OPTIONAL_APPEND]' in ret)
+        self.assertTrue('[--optional_append_const_a]' in ret)
+        self.assertTrue('[--optional_append_const_b]' in ret)
+        self.assertTrue('[--optional_count]' in ret)
+        self.assertTrue('POSITIONAL_1 POSITIONAL_2' in ret)
+
+        ret = manpage.get_text(Document(u'shallow --optional_store foo --optional_true'))
+        self.assertEqual(ret, 'Optional true')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_raw_commands.py
+++ b/brkt_cli/shell/test_raw_commands.py
@@ -1,0 +1,101 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from brkt_cli.shell import traverse_tree
+from brkt_cli.shell.raw_commands import CommandPromptToolkit
+from brkt_cli.shell.test_utils import make_top_cmd_subparsers, make_top_cmd
+
+
+class TestRawCommands(unittest.TestCase):
+    def test_traverse_tree(self):
+        ret = traverse_tree('test', make_top_cmd_subparsers(), None, '', '', None, '', None)
+        ret_arr = ret.get_all_paths()
+        ret_arr.sort()
+        self.assertListEqual(ret_arr, ['test', 'test.deep', 'test.deep.semi_shallow', 'test.shallow',
+                                       'test.super_shallow'])
+        sc = ret.get_subcommand_from_path('test.super_shallow')
+        self.assertEqual(sc.name, 'super_shallow')
+        self.assertEqual(sc.description, 'has no subcommands and no arguments')
+        args = map(lambda x: x.get_name(), sc.optional_arguments+sc.positionals)
+        args.sort()
+        self.assertListEqual(args, ['help'])
+
+        sc = ret.get_subcommand_from_path('test.shallow')
+        self.assertEqual(sc.name, 'shallow')
+        self.assertEqual(sc.description, 'has no subcommands but all arguments')
+        args = map(lambda x: x.get_name(), sc.optional_arguments+sc.positionals)
+        args.sort()
+        self.assertListEqual(args, ['POSITIONAL_1', 'POSITIONAL_2', 'help', 'optional_append',
+                                    'optional_append_const_a', 'optional_append_const_b', 'optional_const',
+                                    'optional_count', 'optional_false', 'optional_store', 'optional_store_choices',
+                                    'optional_store_default', 'optional_store_hidden', 'optional_store_int',
+                                    'optional_true'])
+
+        sc = ret.get_subcommand_from_path('test.deep')
+        self.assertEqual(sc.name, 'deep')
+        self.assertEqual(sc.description, 'has subcommands')
+        args = map(lambda x: x.get_name(), sc.optional_arguments + sc.positionals)
+        args.sort()
+        self.assertListEqual(args, ['help'])
+
+        sc = ret.get_subcommand_from_path('test.deep.semi_shallow')
+        self.assertEqual(sc.name, 'semi_shallow')
+        self.assertEqual(sc.description, 'has no subcommands and one arguments')
+        args = map(lambda x: x.get_name(), sc.optional_arguments + sc.positionals)
+        args.sort()
+        self.assertListEqual(args, ['help', 'optional_store'])
+
+    def test_list_subcommand_names(self):
+        cmd = make_top_cmd()
+        ret = cmd.list_subcommand_names()
+        ret.sort()
+        self.assertListEqual(ret, ['deep', 'shallow', 'super_shallow'])
+
+        cmd = CommandPromptToolkit('foo', 'has no subcommands', 'foo', 'foo', None)
+        ret = cmd.list_subcommand_names()
+        ret.sort()
+        self.assertListEqual(ret, [])
+
+    def test_get_all_paths(self):
+        cmd = make_top_cmd()
+        ret = cmd.get_all_paths()
+        ret.sort()
+        self.assertListEqual(ret, ['test', 'test.deep', 'test.deep.semi_shallow', 'test.shallow', 'test.super_shallow'])
+
+        cmd = CommandPromptToolkit('foo', 'has no subcommands', 'foo', 'foo', None)
+        ret = cmd.get_all_paths()
+        ret.sort()
+        self.assertListEqual(ret, ['foo'])
+
+    def test_get_argument_from_full_path(self):
+        cmd = make_top_cmd()
+        ret = cmd.get_argument_from_full_path('test.deep.semi_shallow.optional_store')
+        self.assertEqual(ret.tag, '--optional_store')
+
+        ret = cmd.get_argument_from_full_path('test.deep.fake.fake-arg')
+        self.assertIsNone(ret)
+
+        ret = cmd.get_argument_from_full_path('test.deep.semi_shallow.fake-arg')
+        self.assertIsNone(ret)
+
+    def test_has_subcommands(self):
+        cmd = make_top_cmd()
+        self.assertTrue(cmd.has_subcommands())
+        self.assertFalse(cmd.get_subcommand_from_path('test.deep.semi_shallow').has_subcommands())
+        self.assertFalse(CommandPromptToolkit('foo', 'has no subcommands', 'foo', 'foo', None).has_subcommands())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_save_command.py
+++ b/brkt_cli/shell/test_save_command.py
@@ -1,0 +1,36 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.save_command import complete_alias_inner_command
+from brkt_cli.shell.test_utils import make_app
+
+
+class TestSaveCommand(unittest.TestCase):
+    def test_complete_alias_inner_command(self):
+        app = make_app()
+
+        ret = complete_alias_inner_command(0, app, [], Document(u'/alias '))
+        ret.sort()
+        self.assertListEqual(ret, [])
+
+        ret = complete_alias_inner_command(1, app, ['foo'], Document(u'/alias foo '))
+        ret.sort()
+        self.assertListEqual(ret, ['deep', 'shallow', 'super_shallow'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_settings.py
+++ b/brkt_cli/shell/test_settings.py
@@ -1,0 +1,98 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from prompt_toolkit.document import Document
+
+from brkt_cli.shell.inner_commands import InnerCommandError
+from brkt_cli.shell.settings import Setting, bool_parse_value, bool_validate_change, setting_inner_command, \
+    complete_setting_inner_command
+from brkt_cli.shell.test_utils import make_app, trap_print_output
+
+
+class TestSettings(unittest.TestCase):
+    def test_set_value(self):
+        self.test_set_value_changed = False
+        def on_changed(val):
+            self.test_set_value_changed = True
+        setting = Setting('test', True, str_acceptable_values=['true', 'false'], parse_value=bool_parse_value,
+                          validate_change=bool_validate_change, on_changed=on_changed)
+
+        self.assertEqual(setting.value, True)
+
+        setting.value = False
+        self.assertEqual(setting.value, False)
+        self.assertTrue(self.test_set_value_changed)
+
+        with self.assertRaises(InnerCommandError):
+            setting.value = 'foobar'
+
+    def test_set_value_with_str(self):
+        setting = Setting('test', True, str_acceptable_values=['true', 'false'], parse_value=bool_parse_value)
+
+        setting.set_value_with_str('false')
+        self.assertEqual(setting.value, False)
+
+        with self.assertRaises(InnerCommandError):
+            setting.set_value_with_str('foobar')
+
+    def test_setting_inner_command_func(self):
+        app = make_app()
+        app.settings = {
+            'test': Setting('test', True, str_acceptable_values=['true', 'false'], parse_value=bool_parse_value),
+        }
+
+        with trap_print_output() as (out, err):
+            setting_inner_command.run_action('/setting test', app)
+            self.assertTrue('test - True' in out.getvalue().strip())
+
+        with self.assertRaises(InnerCommandError):
+            setting_inner_command.run_action('/setting fake', app)
+
+        setting_inner_command.run_action('/setting test false', app)
+        self.assertEqual(app.settings['test'].value, False)
+
+        with self.assertRaises(InnerCommandError):
+            setting_inner_command.run_action('/setting test fake-val', app)
+
+        with self.assertRaises(InnerCommandError):
+            setting_inner_command.run_action('/setting fake fake-val', app)
+
+    def test_complete_setting_inner_command(self):
+        app = make_app()
+        app.settings = {
+            'test': Setting('test', True, str_acceptable_values=['true', 'false'], parse_value=bool_parse_value),
+            'anything': Setting('anything', 'hello'),
+        }
+
+        ret = complete_setting_inner_command(0, app, [], Document(u'/setting '))
+        ret.sort()
+        self.assertListEqual(ret, ['anything', 'test'])
+
+        ret = complete_setting_inner_command(1, app, ['test'], Document(u'/setting test '))
+        ret.sort()
+        self.assertListEqual(ret, ['false', 'true'])
+
+        ret = complete_setting_inner_command(1, app, ['anything'], Document(u'/setting anything '))
+        ret.sort()
+        self.assertListEqual(ret, [])
+
+        ret = complete_setting_inner_command(1, app, ['fake'], Document(u'/setting fake '))
+        ret.sort()
+        self.assertListEqual(ret, [])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brkt_cli/shell/test_settings.py
+++ b/brkt_cli/shell/test_settings.py
@@ -24,6 +24,7 @@ from brkt_cli.shell.test_utils import make_app, trap_print_output
 class TestSettings(unittest.TestCase):
     def test_set_value(self):
         self.test_set_value_changed = False
+
         def on_changed(val):
             self.test_set_value_changed = True
         setting = Setting('test', True, str_acceptable_values=['true', 'false'], parse_value=bool_parse_value,
@@ -91,8 +92,6 @@ class TestSettings(unittest.TestCase):
         ret = complete_setting_inner_command(1, app, ['fake'], Document(u'/setting fake '))
         ret.sort()
         self.assertListEqual(ret, [])
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/brkt_cli/shell/test_utils.py
+++ b/brkt_cli/shell/test_utils.py
@@ -1,0 +1,155 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+from StringIO import StringIO
+from contextlib import contextmanager
+
+import sys
+
+from brkt_cli.shell import traverse_tree, App, ShellCompleter
+from brkt_cli.shell.inner_commands import InnerCommand
+
+
+@contextmanager
+def trap_print_output():
+    out, err = StringIO(), StringIO()
+    std_out, std_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = out, err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = std_out, std_err
+
+
+def make_top_cmd_subparsers():
+    top_cmd_parser = argparse.ArgumentParser(
+        description='testing command',
+    )
+    subparsers = top_cmd_parser.add_subparsers()  # type: argparse._SubParsersAction
+
+    subparsers.add_parser(
+        'super_shallow',
+        description='has no subcommands and no arguments',
+    )
+    shallow_cmd_parser = subparsers.add_parser(
+        'shallow',
+        description='has no subcommands but all arguments',
+    )
+    deep_cmd_parser = subparsers.add_parser(
+        'deep',
+        description='has subcommands',
+    )
+    deep_cmd_subparser = deep_cmd_parser.add_subparsers()
+    semi_shallow_cmd_parser = deep_cmd_subparser.add_parser(
+        'semi_shallow',
+        description='has no subcommands and one arguments',
+    )
+    semi_shallow_cmd_parser.add_argument(
+        '--optional_store',
+        dest='optional_store',
+        help='Optional store'
+    )
+
+    shallow_cmd_parser.add_argument(
+        'pos1',
+        metavar='POSITIONAL_1',
+        help='First positional')
+    shallow_cmd_parser.add_argument(
+        'pos2',
+        metavar='POSITIONAL_2',
+        help='Second positional')
+    shallow_cmd_parser.add_argument(
+        '--optional_true',
+        dest='optional_true',
+        action='store_true',
+        help='Optional true')
+    shallow_cmd_parser.add_argument(
+        '--optional_false',
+        dest='optional_false',
+        action='store_false',
+        help='Optional false')
+    shallow_cmd_parser.add_argument(
+        '--optional_store',
+        dest='optional_store',
+        help='Optional store')
+    shallow_cmd_parser.add_argument(
+        '--optional_store_int',
+        dest='optional_store_int',
+        type=int,
+        help='Optional store int')
+    shallow_cmd_parser.add_argument(
+        '--optional_store_hidden',
+        dest='optional_store_hidden',
+        help=argparse.SUPPRESS)
+    shallow_cmd_parser.add_argument(
+        '--optional_store_default',
+        dest='optional_store_default',
+        default='foobar',
+        help='Optional store default')
+    shallow_cmd_parser.add_argument(
+        '--optional_store_choices',
+        dest='optional_store_choices',
+        choices=['hot', 'cold'],
+        help='Optional store choices')
+    shallow_cmd_parser.add_argument(
+        '--optional_const',
+        dest='optional_const',
+        action='store_const',
+        const='123abc',
+        help='Optional store const')
+    shallow_cmd_parser.add_argument(
+        '--optional_append',
+        dest='optional_append',
+        action='append',
+        help='Optional append')
+    shallow_cmd_parser.add_argument(
+        '--optional_append_const_a',
+        dest='optional_append_const',
+        action='append_const',
+        const='a',
+        help='Optional append const a')
+    shallow_cmd_parser.add_argument(
+        '--optional_append_const_b',
+        dest='optional_append_const',
+        action='append_const',
+        const='b',
+        help='Optional append const b')
+    shallow_cmd_parser.add_argument(
+        '--optional_count',
+        dest='optional_count',
+        action='count',
+        help='Optional count')
+
+    return subparsers
+
+
+def make_top_cmd():
+    return traverse_tree('test', make_top_cmd_subparsers(), None, '', '', None, '', None)
+
+
+class TestAppClass(App):
+
+    def make_cli_interface(self):
+        pass
+
+
+def make_app():
+    top_cmd = make_top_cmd()
+    app = TestAppClass(ShellCompleter(top_cmd), top_cmd)
+    app.inner_commands = {
+        u'/test': InnerCommand('test', 'tests with no arguments', 'test', None),
+        u'/test_arg': InnerCommand('test_arg', 'tests with an arguments', 'test ARG', None),
+    }
+    app.dummy = True
+    return app

--- a/brkt_cli/shell/test_utils.py
+++ b/brkt_cli/shell/test_utils.py
@@ -147,9 +147,14 @@ class TestAppClass(App):
 def make_app():
     top_cmd = make_top_cmd()
     app = TestAppClass(ShellCompleter(top_cmd), top_cmd)
+
+    def inner_command_run(params, the_app):
+        pass
+
     app.inner_commands = {
-        u'/test': InnerCommand('test', 'tests with no arguments', 'test', None),
-        u'/test_arg': InnerCommand('test_arg', 'tests with an arguments', 'test ARG', None),
+        u'/test': InnerCommand('test', 'tests with no arguments', 'test', inner_command_run),
+        u'/test_arg': InnerCommand('test_arg', 'tests with an arguments', 'test ARG', inner_command_run,
+                                   param_regex=r'^(.+)$'),
     }
     app.dummy = True
     return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-termcolor
-pygments
-prompt_toolkit
+termcolor == 1.1.0
+pygments == 2.2.0
+prompt_toolkit == 1.0.14
 boto == 2.38.0
 boto3 >= 1.4.4
 google-api-python-client >= 1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+termcolor
+pygments
+prompt_toolkit
 boto == 2.38.0
 boto3 >= 1.4.4
 google-api-python-client >= 1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-termcolor == 1.1.0
-pygments == 2.2.0
-prompt_toolkit == 1.0.14
 boto == 2.38.0
 boto3 >= 1.4.4
 google-api-python-client >= 1.5.1
@@ -13,3 +10,6 @@ pyvmomi == 5.5.0; python_version <= '2.7.8'
 pyvmomi == 6.0.0; python_version >= '2.7.9'
 PyYAML >= 3.11
 requests >= 2.7.0
+termcolor == 1.1.0
+pygments == 2.2.0
+prompt_toolkit == 1.0.14


### PR DESCRIPTION
Added a shell to the brkt CLI. This essentially prompts the user for a command and aids in the command and argument completion.

Some features include:
- Auto suggest commands with arguments
- Display command and argument info
- Aliases to commands for shortcuts
- Saving previous commands
- Saving arguments in the shell (like `export` in bash)
- Embedded commands using `$(COMMAND)`
- Emacs/VI keybindings
- All hidden arguments remain hidden unless you pass `--dev` to the shell command