### PR TITLE
Update AWS code to use boto3

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -16,26 +16,26 @@ import abc
 import logging
 import re
 import ssl
-import time
-
 import string
 import tempfile
+import time
 from datetime import datetime
 
-import boto
-import boto.sts
-import boto.vpc
-import boto.iam
-from boto.exception import EC2ResponseError, BotoServerError
+import boto3
+from botocore.exceptions import ClientError
 
 from brkt_cli import util, encryptor_service
+from brkt_cli.aws import boto3_device, boto3_tag
 from brkt_cli.aws.aws_constants import (
     NAME_ENCRYPTOR_SECURITY_GROUP,
     DESCRIPTION_ENCRYPTOR_SECURITY_GROUP, NAME_GUEST_CREATOR,
     DESCRIPTION_GUEST_CREATOR, NAME_LOG_SNAPSHOT, DESCRIPTION_LOG_SNAPSHOT,
     NAME_ORIGINAL_VOLUME, NAME_ORIGINAL_SNAPSHOT,
     DESCRIPTION_ORIGINAL_SNAPSHOT)
-from brkt_cli.util import Deadline, BracketError, sleep, make_nonce
+from brkt_cli.aws.model import RegionInfo
+from brkt_cli.util import (
+    Deadline, BracketError, sleep, make_nonce, pretty_print_json
+)
 from brkt_cli.validation import ValidationError
 
 log = logging.getLogger(__name__)
@@ -137,7 +137,6 @@ class BaseAWSService(object):
     def delete_volume(self, volume_id):
         """ Delete the given volume.
         :return: True if the volume was deleted
-        :raise: EC2ResponseError if an error occurred
         """
         pass
 
@@ -146,7 +145,7 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def get_images(self, filters=None, owners=None):
+    def get_images(self, name=None, owner_alias=None, product_code=None):
         pass
 
     @abc.abstractmethod
@@ -162,7 +161,7 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
-    def add_security_group_rule(self, sg_id, **kwargs):
+    def authorize_security_group_ingress(self, sg_id, port):
         pass
 
     @abc.abstractmethod
@@ -199,10 +198,6 @@ class BaseAWSService(object):
 
     @abc.abstractmethod
     def get_default_vpc(self):
-        pass
-
-    @abc.abstractmethod
-    def get_instance_attribute(self, instance_id, attribute, dry_run=False):
         pass
 
     @abc.abstractmethod
@@ -224,14 +219,19 @@ class BotoRetryExceptionChecker(util.RetryExceptionChecker):
         if isinstance(exception, ssl.SSLError):
             # We've seen this in the field.
             return True
-        if not isinstance(exception, BotoServerError):
+
+        if not isinstance(exception, ClientError):
             return False
-        if exception.status == 503:
+
+        error_code, _ = get_code_and_message(exception)
+        if error_code == '503':
             # This can happen when the AWS request limit has been exceeded.
             return True
+
         if self.error_code_regexp:
-            m = re.match(self.error_code_regexp, exception.error_code)
+            m = re.match(self.error_code_regexp, error_code)
             return bool(m)
+
         return False
 
 
@@ -246,19 +246,6 @@ def retry_boto(function, error_code_regexp=None, timeout=10.0,
         timeout=timeout,
         initial_sleep_seconds=initial_sleep_seconds
     )
-
-
-def _get_first_element(list, error_status):
-    """ Return the first element in the list.  If the list is empty, raise
-    an EC2ResponseError with the given error status.  This is a workaround
-    for the case where the AWS API erroneously returns an empty list instead
-    of an error.
-    """
-    if list:
-        return list[0]
-    else:
-        raise EC2ResponseError(
-            error_status, 'AWS API returned an empty response')
 
 
 class AWSService(BaseAWSService):
@@ -278,15 +265,24 @@ class AWSService(BaseAWSService):
         # These will be initialized by connect().
         self.key_name = None
         self.region = None
-        self.conn = None
+
+        self.ec2 = None
+        # Hardcode us-east-1 for the purpose of getting the list of regions.
+        self.ec2client = boto3.client('ec2', region_name='us-east-1')
 
     def get_regions(self):
-        return boto.vpc.regions()
+        """ Return the available regions as a list of RegionInfo. """
+        regions = []
+        for r in self.ec2client.describe_regions()['Regions']:
+            ri = RegionInfo(name=r['RegionName'], endpoint=r['Endpoint'])
+            regions.append(ri)
+        return regions
 
     def connect(self, region, key_name=None):
         self.region = region
         self.key_name = key_name
-        self.conn = boto.vpc.connect_to_region(region)
+        self.ec2 = boto3.resource('ec2', region_name=region)
+        self.ec2client = boto3.client('ec2', region_name=region)
 
     def retry(self, function, error_code_regexp=None, timeout=None):
         """ Call the retry_boto function with this object's timeout and
@@ -305,248 +301,338 @@ class AWSService(BaseAWSService):
                      security_group_ids=None,
                      instance_type='c4.xlarge',
                      placement=None,
-                     block_device_map=None,
+                     block_device_mappings=None,
                      subnet_id=None,
                      user_data=None,
                      ebs_optimized=True,
                      instance_profile_name=None):
-        if security_group_ids is None:
-            security_group_ids = []
-        log.debug(
-            'run_instance: %s, security groups=%s, subnet=%s, '
-            'type=%s',
-            image_id, security_group_ids, subnet_id, instance_type
-        )
-
         try:
-            run_instances = self.retry(self.conn.run_instances)
-            reservation = run_instances(
-                image_id=image_id,
-                placement=placement,
-                key_name=self.key_name,
-                instance_type=instance_type,
-                block_device_map=block_device_map,
-                security_group_ids=security_group_ids,
-                subnet_id=subnet_id,
-                ebs_optimized=ebs_optimized,
-                user_data=user_data,
-                instance_profile_name=instance_profile_name
-            )
-            instance = reservation.instances[0]
-            log.debug('Launched instance %s', instance.id)
-            return instance
-        except EC2ResponseError:
+            kwargs = {
+                'ImageId': image_id,
+                'MaxCount': 1,
+                'MinCount': 1
+            }
+            if security_group_ids:
+                kwargs['SecurityGroupIds'] = security_group_ids
+            if instance_type:
+                kwargs['InstanceType'] = instance_type
+            if placement:
+                kwargs['Placement'] = placement
+            if block_device_mappings:
+                kwargs['BlockDeviceMappings'] = block_device_mappings
+            if subnet_id:
+                kwargs['SubnetId'] = subnet_id
+            if user_data:
+                kwargs['UserData'] = user_data
+            if ebs_optimized is not None:
+                kwargs['EbsOptimized'] = ebs_optimized
+            if instance_profile_name:
+                kwargs['IamInstanceProfile'] = instance_profile_name
+
+            if log.isEnabledFor(logging.DEBUG):
+                # User-data is long and can have binary content.
+                kwargs_for_log = dict(kwargs)
+                if user_data:
+                    kwargs_for_log['UserData'] = '(%d bytes)' % len(user_data)
+                j = pretty_print_json(kwargs_for_log)
+                log.debug('Running instance: %s', j)
+
+            run_instances = self.retry(
+                self.ec2client.run_instances, )
+            response = run_instances(**kwargs)
+            instance_id = response['Instances'][0]['InstanceId']
+            log.debug('Launched instance %s', instance_id)
+            return self.get_instance(instance_id)
+        except ClientError:
             log.debug('Failed to launch instance for %s', image_id)
             raise
 
     def get_instance(self, instance_id):
-        get_only_instances = self.retry(
-            self.conn.get_only_instances, r'InvalidInstanceID\.NotFound')
-        instances = get_only_instances([instance_id])
-        return _get_first_element(instances, 'InvalidInstanceID.NotFound')
+        instance = self.ec2.Instance(instance_id)
+        load = self.retry(
+            instance.load, r'InvalidInstanceID\.NotFound')
+        load()
+        return instance
 
     def create_tags(self, resource_id, name=None, description=None):
-        tags = dict(self.default_tags)
+        d = dict(self.default_tags)
         if name:
-            tags['Name'] = name
+            d['Name'] = name
         if description:
-            tags['Description'] = description
-        log.debug('Tagging %s with %s', resource_id, tags)
-        create_tags = self.retry(self.conn.create_tags, r'.*\.NotFound')
-        create_tags([resource_id], tags)
+            d['Description'] = description
+        log.debug(
+            'Tagging %s with %s', resource_id, pretty_print_json(d))
+        create_tags = self.retry(self.ec2client.create_tags, r'.*\.NotFound')
+        create_tags(
+            Resources=[resource_id],
+            Tags=boto3_tag.dict_to_tags(d)
+        )
 
     def stop_instance(self, instance_id):
         log.debug('Stopping instance %s', instance_id)
-        stop_instances = self.retry(self.conn.stop_instances)
-        instances = stop_instances([instance_id])
-        return instances[0]
+        stop_instances = self.retry(self.ec2client.stop_instances)
+        stop_instances(InstanceIds=[instance_id])
 
     def terminate_instance(self, instance_id):
         log.debug('Terminating instance %s', instance_id)
-        terminate_instances = self.retry(self.conn.terminate_instances)
-        terminate_instances([instance_id])
+        terminate_instances = self.retry(self.ec2client.terminate_instances)
+        terminate_instances(InstanceIds=[instance_id])
 
     def get_volume(self, volume_id):
-        get_all_volumes = self.retry(
-            self.conn.get_all_volumes, r'InvalidVolume\.NotFound')
-        volumes = get_all_volumes(volume_ids=[volume_id])
-        return _get_first_element(volumes, 'InvalidVolume.NotFound')
+        volume = self.ec2.Volume(volume_id)
+        load = self.retry(
+            volume.load, r'InvalidVolume\.NotFound')
+        load()
+        return volume
 
     def get_volumes(self, tag_key=None, tag_value=None):
-        filters = {}
+        filters = list()
         if tag_key and tag_value:
-            filters['tag:%s' % tag_key] = tag_value
+            filters = [{'Name': 'tag:%s' % tag_key, 'Values': [tag_value]}]
 
-        get_all_volumes = self.retry(self.conn.get_all_volumes)
-        return get_all_volumes(filters=filters)
+        f = self.retry(
+            self.ec2.volumes.filter, r'InvalidVolume\.NotFound')
+        volumes = f(Filters=filters)
+
+        for volume in volumes:
+            load = self.retry(volume.load, r'InvalidVolume\.NotFound')
+            load()
+        return list(volumes)
 
     def iam_role_exists(self, role):
-        conn = boto.iam.connect_to_region(self.region)
         try:
-            conn.get_instance_profile(role)
-        except BotoServerError as e:
-            if e.error_code != 'NoSuchEntity':
+            self.ec2client.get_instance_profile(InstanceProfileName=role)
+        except ClientError as e:
+            code, _ = get_code_and_message(e)
+            if code != 'NoSuchEntity':
                 raise
             return False
         return True
 
     def get_snapshots(self, *snapshot_ids):
-        get_all_snapshots = self.retry(
-            self.conn.get_all_snapshots, r'InvalidSnapshot\.NotFound')
-        return get_all_snapshots(snapshot_ids)
+        f = self.retry(
+            self.ec2.snapshots.filter, r'InvalidSnapshot\.NotFound')
+        snapshots = f(SnapshotIds=snapshot_ids)
+        for snapshot in snapshots:
+            load = self.retry(snapshot.load, r'InvalidSnapshot\.NotFound')
+            load()
+        return list(snapshots)
 
     def get_snapshot(self, snapshot_id):
-        snapshots = self.get_snapshots(snapshot_id)
-        return _get_first_element(snapshots, 'InvalidSnapshot.NotFound')
+        snapshot = self.ec2.Snapshot(snapshot_id)
+        load = self.retry(snapshot.load, r'InvalidSnapshot\.NotFound')
+        load()
+        return snapshot
 
     def create_snapshot(self, volume_id, name=None, description=None):
         log.debug('Creating snapshot of %s', volume_id)
-        create_snapshot = self.retry(self.conn.create_snapshot)
-        snapshot = create_snapshot(volume_id, description)
-        self.create_tags(snapshot.id, name=name)
-        return snapshot
+        create_snapshot = self.retry(self.ec2client.create_snapshot)
+        kwargs = {
+            'VolumeId': volume_id
+        }
+        if description:
+            kwargs['Description'] = description
+        response = create_snapshot(**kwargs)
+        snapshot_id = response['SnapshotId']
+        self.create_tags(snapshot_id, name=name)
+        return self.get_snapshot(snapshot_id)
 
     def create_volume(self,
                       size,
                       zone,
-                      snapshot=None,
+                      snapshot_id=None,
                       volume_type=None,
                       encrypted=None):
-        create_volume = self.retry(self.conn.create_volume)
-        return create_volume(
-            size,
-            zone,
-            snapshot=snapshot,
-            volume_type=volume_type,
-            encrypted=encrypted)
+        create_volume = self.retry(self.ec2client.create_volume)
+
+        kwargs = {
+            'AvailabilityZone': zone,
+            'Size': size
+        }
+        if snapshot_id:
+            kwargs['SnapshotId'] = snapshot_id
+        if volume_type:
+            kwargs['VolumeType'] = volume_type
+        if encrypted:
+            kwargs['Encrypted'] = encrypted
+
+        log.debug('Creating volume: %s', pretty_print_json(kwargs))
+        response = create_volume(**kwargs)
+        volume_id = response['VolumeId']
+        return self.get_volume(volume_id)
 
     def delete_volume(self, volume_id):
         log.debug('Deleting volume %s', volume_id)
         try:
             delete_volume = self.retry(
-                self.conn.delete_volume, r'VolumeInUse')
-            delete_volume(volume_id)
-        except EC2ResponseError as e:
-            if e.error_code != 'InvalidVolume.NotFound':
+                self.ec2client.delete_volume, r'VolumeInUse')
+            delete_volume(VolumeId=volume_id)
+        except ClientError as e:
+            code, _ = get_code_and_message(e)
+            if code != 'InvalidVolume.NotFound':
                 raise
+
         return True
 
-    def get_images(self, filters=None, owners=None):
-        get_all_images = self.retry(self.conn.get_all_images)
-        return get_all_images(filters=filters, owners=owners)
+    def get_images(self, name=None, owner_alias=None, product_code=None):
+        filters = list()
+        if name:
+            filters.append({'Name': 'name', 'Values': [name]})
+        if owner_alias:
+            filters.append({'Name': 'owner-alias', 'Values': [owner_alias]})
+        if product_code:
+            filters.append({'Name': 'product-code', 'Values': [product_code]})
+
+        images = self.ec2.images.filter(Filters=filters)
+        for image in images:
+            image.load()
+        return list(images)
 
     def get_image(self, image_id, retry=False):
-        get_image = self.conn.get_image
+        image = self.ec2.Image(image_id)
+        load = image.load
         if retry:
-            get_image = self.retry(
-                self.conn.get_image, r'InvalidAMIID\.NotFound')
+            load = self.retry(
+                image.load, r'InvalidAMIID\.NotFound')
 
-        return get_image(image_id)
+        load()
+        return image
 
     def delete_snapshot(self, snapshot_id):
-        delete_snapshot = self.retry(self.conn.delete_snapshot)
-        return delete_snapshot(snapshot_id)
+        delete_snapshot = self.retry(self.ec2client.delete_snapshot)
+        return delete_snapshot(SnapshotId=snapshot_id)
 
     def create_security_group(self, name, description, vpc_id=None):
-        log.debug(
-            'Creating security group: name=%s, description=%s',
-            name, description
-        )
+        kwargs = {
+            'Description': description,
+            'GroupName': name
+        }
         if vpc_id:
-            log.debug('Using %s', vpc_id)
+            kwargs['VpcId'] = vpc_id
 
-        create_security_group = self.retry(self.conn.create_security_group)
-        return create_security_group(
-            name, description, vpc_id=vpc_id
-        )
+        create_security_group = self.retry(
+            self.ec2client.create_security_group)
+        log.debug('Creating security group: %s', pretty_print_json(kwargs))
+        response = create_security_group(**kwargs)
+        return self.get_security_group(response['GroupId'])
 
     def get_security_group(self, sg_id, retry=True):
-        get_all_security_groups = self.conn.get_all_security_groups
+        sg = self.ec2.SecurityGroup(sg_id)
+        load = sg.load
         if retry:
-            get_all_security_groups = self.retry(
-                self.conn.get_all_security_groups, r'InvalidGroup\.NotFound')
+            load = self.retry(
+                sg.load, r'InvalidGroup\.NotFound')
 
-        groups = get_all_security_groups(group_ids=[sg_id])
-        return _get_first_element(groups, 'InvalidGroup.NotFound')
+        load()
+        return sg
 
-    def add_security_group_rule(self, sg_id, **kwargs):
-        kwargs['group_id'] = sg_id
-        authorize_security_group = self.retry(
-            self.conn.authorize_security_group)
-        ok = authorize_security_group(**kwargs)
-        if not ok:
-            raise Exception('Unknown error while adding security group rule')
+    def authorize_security_group_ingress(self, sg_id, port):
+        log.debug('Authorizing ingress to %s on port %d', sg_id, port)
+        authorize = self.retry(
+            self.ec2client.authorize_security_group_ingress)
+        authorize(
+            GroupId=sg_id,
+            FromPort=port,
+            ToPort=port,
+            CidrIp='0.0.0.0/0',
+            IpProtocol='tcp'
+        )
 
     def delete_security_group(self, sg_id):
+        log.debug('Deleting %s', sg_id)
         delete_security_group = self.retry(
-            self.conn.delete_security_group,
+            self.ec2client.delete_security_group,
             r'InvalidGroup\.InUse|DependencyViolation'
         )
-        ok = delete_security_group(group_id=sg_id)
-        if not ok:
-            raise Exception('Unknown error while deleting security group')
+        delete_security_group(GroupId=sg_id)
 
     def get_key_pair(self, keyname):
-        get_all_key_pairs = self.retry(self.conn.get_all_key_pairs)
-        key_pairs = get_all_key_pairs(keynames=[keyname])
-        return _get_first_element(key_pairs, 'InvalidKeyPair.NotFound')
+        key_pair = self.ec2.KeyPair(keyname)
+        load = self.retry(key_pair.load)
+        load()
+        return key_pair
 
     def get_console_output(self, instance_id):
-        return self.conn.get_console_output(instance_id)
+        response = self.ec2client.get_console_output(
+            InstanceId=instance_id)
+        return response['Output']
 
     def get_subnet(self, subnet_id):
-        subnets = self.conn.get_all_subnets(subnet_ids=[subnet_id])
-        return _get_first_element(subnets, 'InvalidSubnetID.NotFound')
+        subnet = self.ec2.Subnet(subnet_id)
+        load = self.retry(subnet.load)
+        load()
+        return subnet
 
     def create_image(self,
                      instance_id,
                      name,
                      description=None,
                      no_reboot=True,
-                     block_device_mapping=None):
+                     block_device_mappings=None):
         timeout = float(60 * 60)  # One hour.
         create_image = self.retry(
-            self.conn.create_image, r'InvalidParameterValue', timeout=timeout)
-        return create_image(
-            instance_id,
-            name,
-            description=description,
-            no_reboot=no_reboot,
-            block_device_mapping=block_device_mapping
+            self.ec2client.create_image,
+            r'InvalidParameterValue',
+            timeout=timeout
         )
+        kwargs = {
+            'InstanceId': instance_id,
+            'Name': name
+        }
+        if description:
+            kwargs['Description'] = description
+        if no_reboot is not None:
+            kwargs['NoReboot'] = no_reboot
+        if block_device_mappings:
+            kwargs['BlockDeviceMappings'] = block_device_mappings
+
+        response = create_image(**kwargs)
+        return self.get_image(response['ImageId'])
 
     def detach_volume(self, vol_id, instance_id, force=True):
-        detach_volume = self.retry(self.conn.detach_volume)
-        return detach_volume(
-            vol_id, instance_id=instance_id, force=force)
 
-    def attach_volume(self, vol_id, instance_id, device):
-        attach_volume = self.retry(self.conn.attach_volume, r'VolumeInUse')
-        return attach_volume(vol_id, instance_id, device)
+        detach_volume = self.retry(self.ec2client.detach_volume)
+        kwargs = {
+            'VolumeId': vol_id
+        }
+        if instance_id:
+            kwargs['InstanceId'] = instance_id
+        if force is not None:
+            kwargs['Force'] = force
+        log.debug('Detaching volume: %s', kwargs)
+        response = detach_volume(**kwargs)
+        return self.get_volume(response['VolumeId'])
+
+    def attach_volume(self, vol_id, instance_id, device_name):
+        log.debug(
+            'Attaching %s to %s at %s', vol_id, instance_id, device_name)
+        attach_volume = self.retry(
+            self.ec2client.attach_volume, r'VolumeInUse')
+        response = attach_volume(
+            VolumeId=vol_id,
+            InstanceId=instance_id,
+            Device=device_name
+        )
+        return self.get_volume(response['VolumeId'])
 
     def get_default_vpc(self):
-        get_all_vpcs = self.retry(self.conn.get_all_vpcs)
-        vpcs = get_all_vpcs(filters={'is-default': 'true'})
-        if len(vpcs) > 0:
+        filter = self.retry(self.ec2.vpcs.filter)
+        vpcs = filter(IsDefault=True)
+        if vpcs:
+            vpcs[0].load()
             return vpcs[0]
-        return None
 
-    def get_instance_attribute(self, instance_id, attribute, dry_run=False):
-        get_instance_attribute = self.retry(self.conn.get_instance_attribute)
-        return get_instance_attribute(
-            instance_id,
-            attribute,
-            dry_run=dry_run
-        )
+        return None
 
     def modify_instance_attribute(self, instance_id, attribute,
                                   value, dry_run=False):
-        modify_instance_attribute = self.retry(self.conn.modify_instance_attribute)
-        return modify_instance_attribute(
-            instance_id,
-            attribute,
-            value,
-            dry_run=dry_run
+        log.debug('Setting %s for %s to %s', attribute, instance_id, value)
+        modify_instance_attribute = self.retry(
+            self.ec2client.modify_instance_attribute)
+        modify_instance_attribute(
+            InstanceId=instance_id,
+            Attribute=attribute,
+            Value=value
         )
 
 
@@ -621,7 +707,8 @@ def wait_for_volume(aws_svc, volume_id, timeout=600.0, state='available'):
     sleep_time = 0.5
     while not deadline.is_expired():
         volume = aws_svc.get_volume(volume_id)
-        if volume.status == state:
+        log.debug('Volume %s state=%s', volume.id, volume.state)
+        if volume.state == state:
             return volume
         util.sleep(sleep_time)
         sleep_time *= 2
@@ -656,15 +743,15 @@ def wait_for_instance(
     deadline = Deadline(timeout)
     while not deadline.is_expired():
         instance = aws_svc.get_instance(instance_id)
-        log.debug('Instance %s state=%s', instance.id, instance.state)
-        if instance.state == state:
+        log.debug('Instance %s state=%s', instance.id, instance.state['Name'])
+        if instance.state['Name'] == state:
             return instance
-        if instance.state == 'error':
+        if instance.state['Name'] == 'error':
             raise InstanceError(
                 'Instance %s is in an error state.  Cannot proceed.' %
                 instance_id
             )
-        if state != 'terminated' and instance.state == 'terminated':
+        if state != 'terminated' and instance.state['Name'] == 'terminated':
             raise InstanceError(
                 'Instance %s was unexpectedly terminated.' % instance_id
             )
@@ -689,24 +776,19 @@ def stop_and_wait(aws_svc, instance_id):
 
 def wait_for_image(aws_svc, image_id):
     log.debug('Waiting for %s to become available.', image_id)
+    image = None
+
     for i in range(180):
         sleep(5)
-        try:
-            image = aws_svc.get_image(image_id)
-        except EC2ResponseError, e:
-            if e.error_code == 'InvalidAMIID.NotFound':
-                log.debug('AWS threw a NotFound, ignoring')
-                continue
-            else:
-                log.warn('Unknown AWS error: %s', e)
+        image = aws_svc.get_image(image_id)
         log.debug('%s: %s', image.id, image.state)
         if image.state == 'available':
-            break
+            return image
         if image.state == 'failed':
             raise BracketError('Image state became failed')
-    else:
-        raise BracketError(
-            'Image failed to become available (%s)' % image.state)
+
+    raise BracketError(
+        'Image failed to become available (%s)' % image.state)
 
 
 def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
@@ -716,11 +798,7 @@ def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
     sg = aws_svc.create_security_group(sg_name, sg_desc, vpc_id=vpc_id)
     log.info('Created temporary security group with id %s', sg.id)
     try:
-        aws_svc.add_security_group_rule(
-            sg.id, ip_protocol='tcp',
-            from_port=status_port,
-            to_port=status_port,
-            cidr_ip='0.0.0.0/0')
+        aws_svc.authorize_security_group_ingress(sg.id, status_port)
     except Exception as e:
         log.error('Failed adding security group rule to %s: %s', sg.id, e)
         try:
@@ -776,7 +854,7 @@ def clean_up(aws_svc, instance_ids=None, volume_ids=None,
             log.info('Terminating instance %s', instance_id)
             aws_svc.terminate_instance(instance_id)
             terminated_instance_ids.add(instance_id)
-        except EC2ResponseError as e:
+        except ClientError as e:
             log.warn('Unable to terminate instance %s: %s', instance_id, e)
         except:
             log.exception('Unable to terminate instance %s', instance_id)
@@ -785,7 +863,7 @@ def clean_up(aws_svc, instance_ids=None, volume_ids=None,
         try:
             log.info('Deleting snapshot %s', snapshot_id)
             aws_svc.delete_snapshot(snapshot_id)
-        except EC2ResponseError as e:
+        except ClientError as e:
             log.warn('Unable to delete snapshot %s: %s', snapshot_id, e)
         except:
             log.exception('Unable to delete snapshot %s', snapshot_id)
@@ -796,7 +874,7 @@ def clean_up(aws_svc, instance_ids=None, volume_ids=None,
         log.info('Waiting for instance %s to terminate.', id)
         try:
             wait_for_instance(aws_svc, id, state='terminated')
-        except (EC2ResponseError, InstanceError) as e:
+        except (ClientError, InstanceError) as e:
             log.warn(
                 'An error occurred while waiting for instance to '
                 'terminate: %s', e)
@@ -811,7 +889,7 @@ def clean_up(aws_svc, instance_ids=None, volume_ids=None,
         try:
             log.info('Deleting volume %s', volume_id)
             aws_svc.delete_volume(volume_id)
-        except EC2ResponseError as e:
+        except ClientError as e:
             log.warn('Unable to delete volume %s: %s', volume_id, e)
         except:
             log.exception('Unable to delete volume %s', volume_id)
@@ -820,7 +898,7 @@ def clean_up(aws_svc, instance_ids=None, volume_ids=None,
         try:
             log.info('Deleting security group %s', sg_id)
             aws_svc.delete_security_group(sg_id)
-        except EC2ResponseError as e:
+        except ClientError as e:
             log.warn('Unable to delete security group %s: %s', sg_id, e)
         except:
             log.exception('Unable to delete security group %s', sg_id)
@@ -857,10 +935,8 @@ def snapshot_log_volume(aws_svc, instance_id):
 
     # Snapshot root volume.
     instance = aws_svc.get_instance(instance_id)
-    bdm = instance.block_device_mapping
-
-    log_vol = bdm["/dev/sda1"]
-    vol = aws_svc.get_volume(log_vol.volume_id)
+    device = boto3_device.get_device(instance.block_device_mappings, '/dev/sda1')
+    vol = aws_svc.get_volume(boto3_device.get_volume_id(device))
     image = aws_svc.get_image(instance.image_id)
     snapshot = aws_svc.create_snapshot(
         vol.id,
@@ -901,9 +977,10 @@ def wait_for_volume_attached(aws_svc, instance_id, device):
 
     for _ in xrange(20):
         instance = aws_svc.get_instance(instance_id)
-        bdm = instance.block_device_mapping
-        log.debug('Found devices: %s', bdm.keys())
-        if device in bdm:
+        device_names = boto3_device.get_device_names(
+            instance.block_device_mappings)
+        log.debug('Found devices: %s', device_names)
+        if device in device_names:
             found = True
             break
         else:
@@ -944,14 +1021,14 @@ def wait_for_snapshots(aws_svc, *snapshot_ids):
 
     while True:
         snapshots = aws_svc.get_snapshots(*snapshot_ids)
-        log.debug('%s', {s.id: s.status for s in snapshots})
+        log.debug('%s', {s.id: s.state for s in snapshots})
 
         done = True
         error_ids = []
         for snapshot in snapshots:
-            if snapshot.status == 'error':
+            if snapshot.state == 'error':
                 error_ids.append(snapshot.id)
-            if snapshot.status != 'completed':
+            if snapshot.state != 'completed':
                 done = False
 
         if error_ids:
@@ -993,16 +1070,21 @@ def snapshot_root_volume(aws_svc, instance, image_id):
 
     # Snapshot root volume.
     instance = aws_svc.get_instance(instance.id)
-    root_dev = instance.root_device_name
-    bdm = instance.block_device_mapping
+    root_device_name = instance.root_device_name
+    device_names = boto3_device.get_device_names(
+        instance.block_device_mappings)
 
-    if root_dev not in bdm:
+    if root_device_name not in device_names:
         # try stripping partition id
-        root_dev = string.rstrip(root_dev, string.digits)
-    root_vol = bdm[root_dev]
-    vol = aws_svc.get_volume(root_vol.volume_id)
+        root_device_name = string.rstrip(root_device_name, string.digits)
+
+    root_device = boto3_device.get_device(
+        instance.block_device_mappings, root_device_name)
+
+    volume_id = boto3_device.get_volume_id(root_device)
+    vol = aws_svc.get_volume(volume_id)
     aws_svc.create_tags(
-        root_vol.volume_id,
+        volume_id,
         name=NAME_ORIGINAL_VOLUME % {'image_id': image_id}
     )
 
@@ -1020,26 +1102,34 @@ def snapshot_root_volume(aws_svc, instance, image_id):
         wait_for_snapshots(aws_svc, snapshot.id)
 
         # Now try to detach the root volume.
-        log.info('Detaching root volume %s from %s',
-                 root_vol.volume_id, instance.id)
+        log.info('Detaching root volume from guest.')
         aws_svc.detach_volume(
-            root_vol.volume_id,
+            volume_id,
             instance_id=instance.id,
             force=True
         )
-        wait_for_volume(aws_svc, root_vol.volume_id)
+        wait_for_volume(aws_svc, volume_id)
         # And now delete it
-        log.info('Deleting root volume %s', root_vol.volume_id)
-        aws_svc.delete_volume(root_vol.volume_id)
+        log.info('Deleting root volume %s', volume_id)
+        aws_svc.delete_volume(volume_id)
     except:
         clean_up(aws_svc, snapshot_ids=[snapshot.id])
         raise
 
     iops = None
-    if vol.type == 'io1':
+    if vol.volume_type == 'io1':
         iops = vol.iops
 
     ret_values = (
-        snapshot.id, root_dev, vol.size, vol.type, iops)
+        snapshot.id, root_device_name, vol.size, vol.volume_type, iops)
     log.debug('Returning %s', str(ret_values))
     return ret_values
+
+
+def get_code_and_message(client_error):
+    """ Return the AWS error code and message from the given
+    boto3 ClientError. """
+    return (
+        client_error.response['Error']['Code'],
+        client_error.response['Error']['Message']
+    )

--- a/brkt_cli/aws/boto3_device.py
+++ b/brkt_cli/aws/boto3_device.py
@@ -1,0 +1,96 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+def get_device(block_device_mappings, device_name):
+    """ Return the block device with the given name.
+    """
+    for bdm in block_device_mappings:
+        if bdm['DeviceName'] == device_name:
+            # Return a copy of the dictionary, so that the caller doesn't
+            # inadvertently modify the source data.
+            return dict(bdm)
+    return None
+
+
+def get_device_names(block_device_mappings):
+    """ Return all of the device names for the given block device
+    mappings. """
+    return [d['DeviceName'] for d in block_device_mappings]
+
+
+def make_device(device_name=None, virtual_name=None, encrypted=None,
+                delete_on_termination=None, iops=None, snapshot_id=None,
+                volume_size=None, volume_type=None, no_device=None,
+                volume_id=None):
+    """ Return a dictionary that represents a boto3 block device. """
+    d = dict()
+    ebs = dict()
+
+    if device_name:
+        d['DeviceName'] = device_name
+    if virtual_name:
+        d['VirtualName'] = virtual_name
+    if no_device:
+        d['NoDevice'] = no_device
+
+    if encrypted is not None:
+        ebs['Encrypted'] = encrypted
+    if delete_on_termination is not None:
+        ebs['DeleteOnTermination'] = delete_on_termination
+    if iops:
+        ebs['Iops'] = iops
+    if snapshot_id:
+        ebs['SnapshotId'] = snapshot_id
+    if volume_size:
+        ebs['VolumeSize'] = volume_size
+    if volume_type:
+        ebs['VolumeType'] = volume_type
+    if volume_id:
+        ebs['VolumeId'] = volume_id
+
+    d['Ebs'] = ebs
+    return d
+
+
+def get_volume_id(device):
+    ebs = device.get('Ebs')
+    if ebs:
+        return ebs.get('VolumeId')
+    return None
+
+
+def get_snapshot_id(device):
+    ebs = device.get('Ebs')
+    if ebs:
+        return ebs.get('SnapshotId')
+    return None
+
+
+def make_device_for_image(source_device):
+    """ Return a copy of the given device that only contains the fields
+    required for creating an image.  This removes other fields that cause
+    the call to create_image() to fail.
+    """
+    return make_device(
+        device_name=source_device.get('DeviceName'),
+        virtual_name=source_device.get('VirtualName'),
+        encrypted=source_device.get('Encrypted'),
+        delete_on_termination=source_device.get('DeleteOnTermination'),
+        iops=source_device.get('Iops'),
+        snapshot_id=source_device.get('SnapshotId'),
+        volume_size=source_device.get('VolumeSize'),
+        volume_type=source_device.get('VolumeType'),
+        no_device=source_device.get('NoDevice')
+    )

--- a/brkt_cli/aws/boto3_tag.py
+++ b/brkt_cli/aws/boto3_tag.py
@@ -1,0 +1,43 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+
+def tags_to_dict(tags_json):
+    d = {}
+    if tags_json:
+        for tag in tags_json:
+            d[tag['Key']] = tag['Value']
+    return d
+
+
+def dict_to_tags(d):
+    tags = list()
+    for key, value in d.iteritems():
+        tags.append({'Key': key, 'Value': value})
+    return tags
+
+
+def get_value(tags_json, key, default=None):
+    return tags_to_dict(tags_json).get(key, default)
+
+
+def set_value(tags_json, key, value):
+    # Tag already exists.
+    for t in tags_json:
+        if t['Key'] == key:
+            t['Value'] = value
+            return
+
+    # Set the tag for the first time.
+    tags_json.append({'Key': key, 'Value': value})

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -14,7 +14,6 @@
 import os
 import unittest
 
-from boto.exception import EC2ResponseError
 from brkt_cli import encryptor_service
 
 from brkt_cli import util
@@ -117,9 +116,8 @@ class TestRunUpdate(unittest.TestCase):
                 if self.call_count < 3:
                     # Simulate eventual consistency error while creating
                     # security group.
-                    e = EC2ResponseError(None, None)
-                    e.error_code = 'InvalidGroup.NotFound'
-                    raise e
+                    raise test_aws_service.new_client_error(
+                        'InvalidGroup.NotFound')
 
         aws_svc.run_instance_callback = run_instance_callback
         update_ami(


### PR DESCRIPTION
Update AWS code to use boto3.  The bulk of the change is in AWSService,
but higher-level code was also affected for two reasons:

1) A bunch of field names changed
2) Embedded data structures are now dictionaries instead of objects

(2) makes application code a bit icky.  I did my best to code
around this by adding utility functions to a couple of new modules:
boto3_device and boto3_tag.

I was able to encrypt and update Ubuntu, RHEL, CentOS, and Amazon Linux
images with this change.

We still have a little bit of boto2 code in share-logs.  Mark graciously
offered to update and test the share-logs code.