### PR TITLE
Improve image validation

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -616,6 +616,18 @@ def _validate_guest_ami(aws_svc, ami_id):
     :raise: ValidationError if the AMI id is invalid
     """
     image = _validate_ami(aws_svc, ami_id)
+
+    if image.virtualization_type != 'hvm':
+        raise ValidationError(
+            'Unsupported virtualization type: %s.  Must be hvm.' %
+            image.virtualization_type
+        )
+    if image.architecture != 'x86_64':
+        raise ValidationError(
+            'Unsupported architecture: %s.  Must be x86_64.' %
+            image.architecture
+        )
+
     tags = boto3_tag.tags_to_dict(image.tags)
     if tags and TAG_ENCRYPTOR in tags:
         raise ValidationError('%s is already an encrypted image' % ami_id)

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -459,19 +459,9 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
     guest_instance = None
     temp_sg_id = None
     guest_image = aws_svc.get_image(image_id)
-    mv_image = aws_svc.get_image(encryptor_ami)
+    aws_svc.get_image(encryptor_ami)
     encrypted_image = None
 
-    # Normal operation is both encryptor and guest match
-    # on virtualization type, but we'll support a PV encryptor
-    # and a HVM guest (legacy)
-    log.debug('Guest type: %s Encryptor type: %s',
-        guest_image.virtualization_type, mv_image.virtualization_type)
-    if guest_image.virtualization_type != 'hvm':
-        raise BracketError(
-            'Unsupported virtualization type: %s' %
-            guest_image.virtualization_type
-        )
     legacy = False
     root_device_name = guest_image.root_device_name
     root_dev = boto3_device.get_device(


### PR DESCRIPTION
Move HVM check from encrypt_ami.encrypt() to _validate_guest_ami(), so
that we check the virtualization type for all AWS commands that operate
on a guest image.  Validate that the architecture is set to "x86_64", in
case we encounter a 32-bit HVM image.