### PR TITLE
Disable legacy mode

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -337,7 +337,8 @@ def run_encrypt(values, config, verbose=False):
         status_port=values.status_port,
         save_encryptor_logs=values.save_encryptor_logs,
         terminate_encryptor_on_failure=(
-            values.terminate_encryptor_on_failure)
+            values.terminate_encryptor_on_failure),
+        legacy=values.legacy
     )
     # Print the AMI ID to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -48,6 +48,18 @@ def setup_encrypt_ami_args(parser, parsed_config):
             'instance'),
         default='m4.large'
     )
+
+    # Add the --legacy argument, for specifying legacy mode during
+    # encryption and update.  This hidden argument is only here for backward
+    # compatibility.  We'll remove it once we're sure that legacy mode is
+    # no longer required.
+    parser.add_argument(
+        '--legacy',
+        action='store_true',
+        default=False,
+        help=argparse.SUPPRESS
+    )
+
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
     aws_args.add_security_group(parser)


### PR DESCRIPTION
Disable the legacy code path in encrypt-ami.  This code was put in to
deal with inconsistencies in block device mappings, and problems with
unmounting the root volume from the guest.  I believe that this
workaround is no longer necessary with the latest HVM images.  I tested
the non-legacy code path with Ubuntu 12.04-16.04, CentOS 6 and 7, Amazon
Linux, RHEL 6.9-7.3, and Cloud Foundry BOSH images.  None of them
required the workaround.

This commit disables legacy mode by hard-coding the legacy variable to
False.  We can remove the legacy code altogether once we're convinced
that we didn't break backward compatibility.