### PR TITLE
Turn on ENA support if Metavisor supports it

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -629,7 +629,7 @@ class AWSService(BaseAWSService):
 
     def modify_instance_attribute(self, instance_id, attribute,
                                   value, dry_run=False):
-        log.debug('Setting %s for %s to %s', attribute, instance_id, value)
+        log.info('Setting %s for %s to %s', attribute, instance_id, value)
         modify_instance_attribute = self.retry(
             self.ec2client.modify_instance_attribute)
         modify_instance_attribute(

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -505,6 +505,19 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             status_port=status_port
         )
 
+        # Enable ENA if Metavisor supports it.
+        log.debug(
+            'ENA support: encryptor=%s, guest=%s',
+            encryptor_instance.ena_support,
+            guest_instance.ena_support
+        )
+        if encryptor_instance.ena_support and not guest_instance.ena_support:
+            aws_svc.modify_instance_attribute(
+                guest_instance.id,
+                'enaSupport',
+                'True'
+            )
+
         log.debug('Getting image %s', image_id)
         image = aws_svc.get_image(image_id)
         if image is None:

--- a/brkt_cli/aws/model.py
+++ b/brkt_cli/aws/model.py
@@ -243,6 +243,7 @@ class Instance(TaggedEC2Object):
         self._previous_state = None
         self.state = dict()
         self._placement = InstancePlacement()
+        self.ena_support = False
 
     def __repr__(self):
         return 'Instance:%s' % self.id

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -416,6 +416,10 @@ class DummyAWSService(aws_service.BaseAWSService):
     def modify_instance_attribute(self, instance_id, attribute, value, dry_run=False):
         if attribute == 'sriovNetSupport':
             return dict()
+        elif attribute == 'enaSupport':
+            self.instances[instance_id].ena_support = bool(value)
+            return dict()
+
         return None
 
     def retry(self, function, error_code_regexp=None, timeout=None):

--- a/brkt_cli/aws/test_update_ami.py
+++ b/brkt_cli/aws/test_update_ami.py
@@ -174,3 +174,35 @@ class TestRunUpdate(unittest.TestCase):
             os.remove(e.console_output_file.name)
 
         self.assertTrue(self.updater_stopped)
+
+    def test_ena_support(self):
+        """ Test that we enable ENA support on the guest instance when ENA
+        support is enabled on the Metavisor instance."""
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        encrypted_ami_id = encrypt_ami.encrypt(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM
+        )
+
+        self.encrypted_instance = None
+
+        def run_instance_callback(args):
+            if args.image_id == encryptor_image.id:
+                args.instance.ena_support = True
+            elif args.image_id == encrypted_ami_id:
+                args.instance.ena_support = False
+                self.encrypted_instance = args.instance
+
+        aws_svc.run_instance_callback = run_instance_callback
+
+        update_ami(
+            aws_svc, encrypted_ami_id, encryptor_image.id,
+            'Test updated AMI',
+            enc_svc_class=DummyEncryptorService
+        )
+
+        self.assertTrue(self.encrypted_instance.ena_support)


### PR DESCRIPTION
Enable ENA support on the guest instance if it's enabled on the
Metavisor instance.  Shuffle around some of the code in update_ami, to
allow us to do this earlier in the process.  If things go wrong, we'll
know sooner rather than later.  Log the "setting attribute" message at
info level for greater transparency.