### PR TITLE
Get the console output from the proper attribute

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -557,7 +557,10 @@ class AWSService(BaseAWSService):
     def get_console_output(self, instance_id):
         response = self.ec2client.get_console_output(
             InstanceId=instance_id)
-        return response['Output']
+        if 'Output' in response:
+            return response['Output']
+        else:
+            return None
 
     def get_subnet(self, subnet_id):
         subnet = self.ec2.Subnet(subnet_id)
@@ -1002,11 +1005,11 @@ def _write_console_output(aws_svc, instance_id):
 
     try:
         console_output = aws_svc.get_console_output(instance_id)
-        if console_output.output:
+        if console_output:
             prefix = instance_id + '-'
             with tempfile.NamedTemporaryFile(
                     prefix=prefix, suffix='-console.txt', delete=False) as t:
-                t.write(console_output.output)
+                t.write(console_output)
             return t
     except:
         log.exception('Unable to write console output')

--- a/brkt_cli/aws/model.py
+++ b/brkt_cli/aws/model.py
@@ -51,14 +51,6 @@ class TaggedEC2Object(EC2Object):
         self.tags = []
 
 
-class ConsoleOutput(object):
-    def __init__(self, parent=None):
-        self.parent = parent
-        self.instance_id = None
-        self.timestamp = None
-        self.output = None
-
-
 class Image(TaggedEC2Object):
     """
     Represents an EC2 Image

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -23,7 +23,6 @@ import brkt_cli.aws
 import brkt_cli.util
 from brkt_cli.aws import aws_service, boto3_device, boto3_tag, encrypt_ami
 from brkt_cli.aws.model import (
-    ConsoleOutput,
     Image,
     Instance,
     KeyPair,
@@ -397,9 +396,7 @@ class DummyAWSService(aws_service.BaseAWSService):
         return kp
 
     def get_console_output(self, instance_id):
-        console_output = ConsoleOutput()
-        console_output.output = self.console_output_text
-        return console_output
+        return self.console_output_text
 
     def get_subnet(self, subnet_id):
         return self.subnets[subnet_id]


### PR DESCRIPTION
With the migration to Boto3, read the console output attribute
properly from the response object. Also check if there is a valid
output before returning the same.