### PR TITLE
Disable credentials for S3 bucket pagination

### DIFF
--- a/brkt_cli/mv_version.py
+++ b/brkt_cli/mv_version.py
@@ -62,8 +62,7 @@ def get_s3_versions(bucket):
 
     s3 = boto3.resource('s3')
     s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
-    client = boto3.client('s3')
-    paginator = client.get_paginator('list_objects')
+    paginator = s3.meta.client.get_paginator('list_objects')
     page_iterator = paginator.paginate(Bucket=bucket,
                                        Delimiter='/',
                                        Prefix=version_prefix)


### PR DESCRIPTION
When paginating thru' the S3 bucket objects to identify locate
the required metavisor version, disable credentials request
as these buckets are public. AWS credentials should not be
required when trying to download images especially for ESX.