### PR TITLE
Add config key for security group

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -457,6 +457,11 @@ class AWSSubcommand(Subcommand):
             'aws.subnet',
             'The AWS subnet metavisors will be launched into'
         )
+        config.register_option(
+            'aws.security-group',
+            'The AWS security group to use when launching Metavisor during '
+            'encryption, update, and wrap-image'
+        )
 
     def register(self, subparsers, parsed_config):
         self.config = parsed_config

--- a/brkt_cli/aws/aws_args.py
+++ b/brkt_cli/aws/aws_args.py
@@ -34,12 +34,16 @@ def add_no_validate(parser):
     )
 
 
-def add_security_group(parser):
+def add_security_group(parser, parsed_config):
+    sg = parsed_config.get_option('aws.security-group')
+    default = [sg] if sg else None
+
     parser.add_argument(
         '--security-group',
         metavar='ID',
         dest='security_group_ids',
         action='append',
+        default=default,
         help=(
             'Use this security group when running the encryptor instance. '
             'May be specified multiple times.'

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -62,7 +62,7 @@ def setup_encrypt_ami_args(parser, parsed_config):
 
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    aws_args.add_security_group(parser)
+    aws_args.add_security_group(parser, parsed_config)
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
     aws_args.add_metavisor_version(parser)

--- a/brkt_cli/aws/update_encrypted_ami_args.py
+++ b/brkt_cli/aws/update_encrypted_ami_args.py
@@ -45,7 +45,7 @@ def setup_update_encrypted_ami(parser, parsed_config):
     )
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    aws_args.add_security_group(parser)
+    aws_args.add_security_group(parser, parsed_config)
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_key(parser)
     aws_args.add_aws_tag(parser)

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -37,7 +37,7 @@ def setup_wrap_image_args(parser, parsed_config):
     )
     aws_args.add_no_validate(parser)
     aws_args.add_region(parser, parsed_config)
-    aws_args.add_security_group(parser)
+    aws_args.add_security_group(parser, parsed_config)
     aws_args.add_subnet(parser, parsed_config)
     aws_args.add_aws_tag(parser)
     aws_args.add_metavisor_version(parser)


### PR DESCRIPTION
Add an aws.security-group config key, for specifying the default
security group when launching a Metavisor instance during encryption,
update, and wrap-guest-image.