### PR TITLE
Add OVF properties to configure static IP

### DIFF
--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -158,6 +158,7 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
             cdrom=values.cdrom,
+            ip_ovf_properties=False if use_esx else values.ip_ovf_properties,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -359,6 +360,7 @@ def run_update(values, parsed_config, log, use_esx=False):
             network_name=values.network_name,
             nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
+            ip_ovf_properties=False,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -495,6 +497,7 @@ def run_wrap_image(values, parsed_config, log, use_esx=False):
             network_name=values.network_name,
             nic_type=values.nic_type,
             verify=False if use_esx else values.validate,
+            ip_ovf_properties=False,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter: ", e)
@@ -585,6 +588,7 @@ def run_assign_static_ip(values, parsed_config, log):
             nic_type=None,
             verify=values.validate,
             cdrom=None,
+            ip_ovf_properties=False,
         )
     except Exception as e:
         log.exception(e)
@@ -635,6 +639,7 @@ def run_rescue_metavisor(values, parsed_config, log):
             nic_type=None,
             verify=values.validate,
             cdrom=values.cdrom,
+            ip_ovf_properties=False,
         )
     except Exception as e:
         raise ValidationError("Failed to connect to vCenter ", e)

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -108,6 +108,9 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         # detach unencrypted guest root
         vc_swc.power_off(vm)
         vc_swc.detach_disk(vm, unit_number=2)
+        # Add OVF properties related to IP configuration
+        if vc_swc.ip_ovf_properties:
+            vc_swc.add_static_ip_ovf_properties(vm)
         # detach serial port
         if serial_port_file_name:
             vc_swc.delete_serial_port_to_file(vm, serial_port_file_name)

--- a/brkt_cli/esx/encrypt_vmdk_args.py
+++ b/brkt_cli/esx/encrypt_vmdk_args.py
@@ -36,6 +36,7 @@ def setup_encrypt_vmdk_args(parser):
     esx_args.add_static_dns_domain(parser)
     esx_args.add_static_dns_server(parser)
     esx_args.add_no_verify_cert(parser)
+    esx_args.add_ip_properties(parser)
     parser.add_argument(
         '--create-ovf',
         dest='create_ovf',

--- a/brkt_cli/esx/esx_args.py
+++ b/brkt_cli/esx/esx_args.py
@@ -316,7 +316,7 @@ def add_disk_type(parser):
     )
 
 
-def add_nic_type(parser, help=argparse.SUPPRESS):
+def add_nic_type(parser):
     parser.add_argument(
         '--nic-type',
         metavar='NAME',
@@ -324,6 +324,17 @@ def add_nic_type(parser, help=argparse.SUPPRESS):
         choices=["Port", "DistributedVirtualPort", "DistributedVirtualPortGroup"],
         help='Port/DistributedVirtualPort/DistributedVirtualPortGroup',
         default="Port",
+        required=False
+    )
+
+
+def add_ip_properties(parser):
+    parser.add_argument(
+        '--enable-static-ip-ovf-property',
+        dest='ip_ovf_properties',
+        action='store_true',
+        help='Enable OVF properties to configure static IP on Bracketized VMs',
+        default=False,
         required=False
     )
 


### PR DESCRIPTION
This allows customers to allow addition of OVF properties
to configure static IP in the template VM or the encrypted OVF.
Primarily design for use to encrypt Ops Manager in PCF, but
is a generic implementation and can be used for any customer
which wants to use static IP.