### PR TITLE
Use getattr() to query the ena_support field

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -1139,3 +1139,15 @@ def get_code_and_message(client_error):
         client_error.response['Error']['Code'],
         client_error.response['Error']['Message']
     )
+
+
+def has_ena_support(instance):
+    """ Return True if the given instance has ENA support enabled.  We have
+    to do this because the AWS API does not always return the enaSupport
+    field.
+
+    :param instance an ec2.Instance object
+    """
+    if not hasattr(instance, 'ena_support'):
+        return False
+    return bool(instance.ena_support)

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -521,12 +521,14 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
         )
 
         # Enable ENA if Metavisor supports it.
+        encryptor_ena_support = aws_service.has_ena_support(encryptor_instance)
+        guest_ena_support = aws_service.has_ena_support(guest_instance)
         log.debug(
             'ENA support: encryptor=%s, guest=%s',
-            encryptor_instance.ena_support,
-            guest_instance.ena_support
+            encryptor_ena_support,
+            guest_ena_support
         )
-        if encryptor_instance.ena_support and not guest_instance.ena_support:
+        if encryptor_ena_support and not guest_ena_support:
             aws_svc.modify_instance_attribute(
                 guest_instance.id,
                 'enaSupport',

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -26,7 +26,7 @@ import logging
 import os
 
 from brkt_cli import encryptor_service
-from brkt_cli.aws import boto3_device
+from brkt_cli.aws import boto3_device, aws_service
 from brkt_cli.aws.aws_constants import (
     NAME_GUEST_CREATOR, DESCRIPTION_GUEST_CREATOR, NAME_METAVISOR_UPDATER,
     DESCRIPTION_METAVISOR_UPDATER,
@@ -139,12 +139,14 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
             aws_svc, encrypted_guest.id, state="stopped")
 
         # Enable ENA if Metavisor supports it.
+        updater_ena_support = aws_service.has_ena_support(updater)
+        guest_ena_support = aws_service.has_ena_support(encrypted_guest)
         log.debug(
             'ENA support: updater=%s, guest=%s',
-            updater.ena_support,
-            encrypted_guest.ena_support
+            updater_ena_support,
+            guest_ena_support
         )
-        if updater.ena_support and not encrypted_guest.ena_support:
+        if updater_ena_support and not guest_ena_support:
             aws_svc.modify_instance_attribute(
                 encrypted_guest.id,
                 'enaSupport',


### PR DESCRIPTION
Turns out that the AWS API doesn't always return the enaSupport field.
When this happens, the ec2.Instance object doesn't have an ena_support
field.

Add an aws_service.has_ena_support() function, which checks if the field
is there before attempting to access it.