### PR TITLE
Add option for specifying the public API root cert

### DIFF
--- a/brkt_cli/argutil.py
+++ b/brkt_cli/argutil.py
@@ -11,6 +11,10 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import argparse
+
+from brkt_cli import crypto
+from brkt_cli.validation import ValidationError
 
 
 def add_out(parser):
@@ -59,4 +63,30 @@ def add_root_url(parser, cli_config):
         metavar='URL',
         default=default_url,
         help='Bracket service root URL'
+    )
+
+
+def _validate_cert_path(path):
+    try:
+        crypto.validate_cert_path(path)
+    except ValidationError as e:
+        raise argparse.ArgumentTypeError(e.message)
+    return path
+
+
+def add_public_api_ca_cert(parser, cli_config=None):
+    default_path = None
+    if cli_config:
+        _, env = cli_config.get_current_env()
+        default_path = env.public_api_ca_cert_path
+
+    parser.add_argument(
+        '--public-api-ca-cert',
+        metavar='PATH',
+        default=default_path,
+        type=_validate_cert_path,
+        help=(
+            'Root X.509 CA certificate for a Customer Managed MCP in PEM '
+            'format.'
+        )
     )

--- a/brkt_cli/config/test_config.py
+++ b/brkt_cli/config/test_config.py
@@ -37,7 +37,7 @@ class SetValues(object):
 class SetEnvValues(object):
     def __init__(self, env_name, api_server=None, key_server=None,
                  network_server=None, public_api_server=None,
-                 service_domain=None):
+                 service_domain=None, public_api_ca_cert=None):
         self.config_subcommand = 'set-env'
         self.env_name = env_name
         self.api_server = api_server
@@ -45,6 +45,7 @@ class SetEnvValues(object):
         self.network_server = network_server
         self.public_api_server = public_api_server
         self.service_domain = service_domain
+        self.public_api_ca_cert = public_api_ca_cert
 
 
 class UnsetEnvValues(object):
@@ -260,6 +261,18 @@ class ConfigCommandTestCase(unittest.TestCase):
             self.assertEqual(tc['host'], host_attr)
             port_attr = getattr(env, tc['attr'] + '_port')
             self.assertEqual(tc['port'], port_attr)
+
+    def test_public_api_ca_cert(self):
+        """Verify that you can set the public API root certificate of
+        an environment.
+        """
+        values = SetEnvValues(
+            env_name='test',
+            public_api_ca_cert='/tmp/root.crt'
+        )
+        self.cmd._set_env(values)
+        env = self.cfg.get_env('test')
+        self.assertEqual('/tmp/root.crt', env.public_api_ca_cert_path)
 
     def test_list_envs_default(self):
         """Verify that the hosted environment is marked as the

--- a/brkt_cli/crypto/__init__.py
+++ b/brkt_cli/crypto/__init__.py
@@ -170,7 +170,6 @@ def _run_cmd(args, input_content=None):
 def validate_cert(cert_data):
     """ Validate that the given string is a valid x509 certificate.
 
-    :return True if the cert is valid
     :raise ValidationError if the string has an unexpected format
     """
     # Try validating with the cryptography library, if it's installed.
@@ -196,3 +195,20 @@ def validate_cert(cert_data):
 
     if code != 0:
         raise ValidationError('Error validating CA cert: ' + output)
+
+
+def validate_cert_path(path):
+    """ Validate that the file at the given path is a valid x509 certificate.
+
+    :return the cert content
+    :raise ValidationError if the file can't be read or the content
+    has an unexpected format
+    """
+    try:
+        with open(path, 'r') as f:
+            content = f.read()
+    except IOError as e:
+        raise ValidationError(e)
+
+    validate_cert(content)
+    return content

--- a/brkt_cli/crypto/test_crypto.py
+++ b/brkt_cli/crypto/test_crypto.py
@@ -213,6 +213,28 @@ class TestReadPrivateKey(unittest.TestCase):
         with self.assertRaises(ValidationError):
             brkt_cli.crypto.validate_cert('foobar')
 
+    def test_validate_cert_path(self):
+        # File does not exist.
+        with self.assertRaises(ValidationError):
+            path = tempfile.gettempdir() + '/nothing_here.pem'
+            brkt_cli.crypto.validate_cert_path(path)
+
+        if brkt_cli.crypto.cryptography_library_available:
+            # File is not a cert.
+            cert_file = tempfile.NamedTemporaryFile()
+            cert_file.write('bogus')
+            cert_file.flush()
+
+            with self.assertRaises(ValidationError):
+                brkt_cli.crypto.validate_cert_path(cert_file.name)
+            cert_file.close()
+
+            # File is a valid cert.
+            cert_file = tempfile.NamedTemporaryFile()
+            cert_file.write(TEST_CERT)
+            cert_file.flush()
+            brkt_cli.crypto.validate_cert_path(cert_file.name)
+
 
 class TestPublicKey(unittest.TestCase):
 

--- a/brkt_cli/make_token.py
+++ b/brkt_cli/make_token.py
@@ -15,12 +15,15 @@
 import json
 import logging
 import uuid
+
 from dateutil.parser import parse
 
 import brkt_cli
 import brkt_cli.crypto
+import brkt_cli.instance_config_args
+import brkt_cli.yeti
 from brkt_cli import (
-    brkt_jwt, ValidationError, util, argutil, instance_config_args
+    brkt_jwt, ValidationError, util, argutil
 )
 from brkt_cli.subcommand import Subcommand
 from brkt_cli.util import parse_timestamp
@@ -70,12 +73,10 @@ class MakeTokenSubcommand(Subcommand):
                 raise ValidationError(msg % '--nbf')
 
             # New workflow: get a launch token from Yeti.
-            if values.root_url:
-                yeti = instance_config_args.get_yeti_service(values.root_url)
-            else:
-                brkt_env = self.config.get_current_env()[1]
-                yeti = instance_config_args.yeti_service_from_brkt_env(
-                    brkt_env)
+            yeti = brkt_cli.instance_config_args.get_yeti_service(
+                values.root_url,
+                root_cert_path=values.public_api_ca_cert
+            )
 
             tags = brkt_jwt.brkt_tags_from_name_value_list(values.brkt_tags)
             expiry = None
@@ -153,6 +154,7 @@ def _setup_args(subparsers, parsed_config):
             )
         )
 
+    argutil.add_public_api_ca_cert(parser, parsed_config)
     argutil.add_brkt_tag(parser)
     argutil.add_root_url(parser, parsed_config)
 

--- a/test.py
+++ b/test.py
@@ -79,6 +79,7 @@ class DummyValues(object):
         self.status_port = None
         self.brkt_env = None
         self.service_domain = None
+        self.public_api_ca_cert = None
 
 
 class TestCommandLineOptions(unittest.TestCase):


### PR DESCRIPTION
Add a --public-api-root-cert option to all commands that talk to the
Bracket service.  This option is used for specifying the path to the
self-signed root cert when brkt-cli talks to a Customer Managed MCP.

Also add a config environment key for this option.

Add crypto.validate_cert_path() for validating a cert that's stored on
disk.  Call this function when validating the --public-api-root-cert and
--ca-cert values.