### PR TITLE
Fix IAM role settings with boto3

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -161,10 +161,17 @@ def run_wrap_image(values, config):
 
     aws_svc.connect(values.region, key_name=values.key_name)
 
+    # Keywords check
+    guest_ami_id = values.ami
+    if values.ami == 'ubuntu':
+        guest_ami_id = get_ubuntu_ami_id(values.stock_image_version, values.region)
+    elif values.ami == 'centos':
+        guest_ami_id = get_centos_ami_id(values.stock_image_version, aws_svc)
+
     if values.validate:
-        guest_image = _validate_guest_ami(aws_svc, values.ami)
+        guest_image = _validate_guest_ami(aws_svc, guest_ami_id)
     else:
-        guest_image = aws_svc.get_image(values.ami)
+        guest_image = _validate_ami(aws_svc, guest_ami_id)
 
     if values.iam:
         if not aws_svc.iam_role_exists(values.iam):

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -327,7 +327,7 @@ class AWSService(BaseAWSService):
             if ebs_optimized is not None:
                 kwargs['EbsOptimized'] = ebs_optimized
             if instance_profile_name:
-                kwargs['IamInstanceProfile'] = instance_profile_name
+                kwargs['IamInstanceProfile'] = {'Name': instance_profile_name}
             if self.key_name:
                 kwargs['KeyName'] = self.key_name
 
@@ -403,7 +403,9 @@ class AWSService(BaseAWSService):
 
     def iam_role_exists(self, role):
         try:
-            self.ec2client.get_instance_profile(InstanceProfileName=role)
+            iam = boto3.resource('iam')
+            iamRole = iam.Role(role)
+            iamRole.load()
         except ClientError as e:
             code, _ = get_code_and_message(e)
             if code != 'NoSuchEntity':

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -102,6 +102,7 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
         guest_image.block_device_mappings,
         guest_image.root_device_name
     )
+    instance = None
     temp_sg = None
     temp_snapshot_id = None
     completed = False

--- a/brkt_cli/aws/wrap_image_args.py
+++ b/brkt_cli/aws/wrap_image_args.py
@@ -22,6 +22,12 @@ def setup_wrap_image_args(parser, parsed_config):
         help='The guest AMI that will be launched as a wrapped Bracket instance'
     )
     parser.add_argument(
+        '--stock-image-version',
+        metavar='STOCK_IMAGE_VERSION',
+        help='The version number when specifying "ubuntu" or "centos" instead of'
+             ' an AMI ID. The default versions are Ubuntu 16.04 and CentOS 7.'
+    )
+    parser.add_argument(
         '--wrapped-instance-name',
         metavar='NAME',
         dest='wrapped_instance_name',


### PR DESCRIPTION
After the migration to boto3, the validation method for the IAM role
as well as the instance launch method with the IAM role were failing.
Those were fixed to match the required boto3 syntax.

Also included @billybobjoeaglt change to specify a guest OS instead
of AMI ID for the wrap command.