### PR TITLE
Include the ModifyInstanceAttribute IAM policy

### DIFF
--- a/reference_templates/brkt-cli-iam-permissions.json
+++ b/reference_templates/brkt-cli-iam-permissions.json
@@ -27,6 +27,7 @@
                 "ec2:DescribeVolumes",
                 "ec2:DescribeVpcs",
                 "ec2:GetConsoleOutput",
+                "ec2:ModifyImageAttribute",
                 "ec2:RegisterImage",
                 "ec2:RunInstances",
                 "ec2:StopInstances",


### PR DESCRIPTION
The ModifyInstanceAttribute policy is required for enabling ENA
and sriovNet support on the encrypted images during the encryption
process