### PR TITLE
Temporary fix when rename VM does not work.

### DIFF
--- a/brkt_cli/esx/esx_service.py
+++ b/brkt_cli/esx/esx_service.py
@@ -234,6 +234,9 @@ class BaseVCenterService(object):
     def rename_vm(self, vm, new_name):
         pass
 
+    def change_vm_name(self, vm, new_name):
+        self.rename_vm()
+
     @abc.abstractmethod
     def add_disk(self, vm, disk_size=12*1024*1024,
                  filename=None, unit_number=0):
@@ -667,6 +670,13 @@ class VCenterService(BaseVCenterService):
                                     self.datacenter_name)
         task = f.MoveDatastoreFile_Task(vm_disk_name, datacenter,
                                         dest_disk_name, datacenter)
+        self.__wait_for_task(task)
+
+    def change_vm_name(self, vm, new_name):
+        # merely change the name without changing any of the underlying disks
+        self.validate_connection()
+        spec = vim.vm.ConfigSpec(name=new_name)
+        task = vm.ReconfigVM_Task(spec=spec)
         self.__wait_for_task(task)
 
     def add_serial_port_to_file(self, vm, filename):

--- a/brkt_cli/esx/update_vmdk.py
+++ b/brkt_cli/esx/update_vmdk.py
@@ -97,7 +97,16 @@ def update_ovf_image_mv_vm(vc_swc, enc_svc_cls, guest_vm, mv_vm,
                                        vc_swc.session_id
                 log.info("Renaming the old template to %s",
                          old_template_vm_name)
-                vc_swc.rename_vm(template_vm, old_template_vm_name)
+                try:
+                    vc_swc.rename_vm(template_vm, old_template_vm_name)
+                except Exception as e:
+                    if "vim.fault.FileFault" not in str(e):
+                        raise
+                    log.info("Rename VM not supported. "
+                             "Deleting the old template %s.", template_vm.name)
+                    if not vc_swc.find_vm(template_vm_name):
+                        vc_swc.change_vm_name(template_vm, template_vm_name)
+                    vc_swc.destroy_vm(template_vm)
             # clone the vm to create template
             log.info("Creating the template VM")
             template_vm = vc_swc.clone_vm(guest_vm, vm_name=template_vm_name,


### PR DESCRIPTION
In case rename VM does not work, e.g. for VSAN, use the not-error-free
solution where the old template vm gets deleted, and then the new one
gets created. Thus, this can cause issues if creation of new template
fails because old one gets deleted. Committing this temporary workaround
till can find a more complete fix without rename.