### PR TITLE
Remove timestamp deprecation

### DIFF
--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -348,10 +348,6 @@ def parse_timestamp(ts_string):
     # Parse integer timestamp.
     m = re.match('\d+(\.\d+)?$', ts_string)
     if m:
-        log.warn(
-            'Integer timestamps are deprecated.  Please use a duration '
-            'like 12h.'
-        )
         t = float(ts_string)
         if t < now:
             raise ValidationError(
@@ -362,10 +358,6 @@ def parse_timestamp(ts_string):
     # Parse ISO 8601 timestamp.
     try:
         dt = iso8601.parse_date(ts_string)
-        log.warn(
-            'ISO 8601 timestamps are deprecated.  Please use a duration '
-            'like 12h.'
-        )
     except iso8601.ParseError:
         raise ValidationError(
             'Timestamp "%s" must be a duration '


### PR DESCRIPTION
Remove deprecation warnings that are logged when the user specifies
token expiry as a timestamp (as opposed to a duration).  It's convenient
to specify that a token expires at a given date and time.  When the user
specifies a timestamp, the CLI calculates the time difference and sends
it to the token service as a value in seconds.