### PR TITLE
Improvements to tagging, AWS logging, and cleanup

### DIFF
--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -177,20 +177,17 @@ def _run_encryptor_instance(
         compressed_user_data = gzip_user_data(user_data)
 
         bdm = [guest_unencrypted_root, guest_encrypted_root]
+        log.info('Launching encryptor instance.')
         instance = run_instance(
             encryptor_image_id,
             security_group_ids=security_group_ids,
             user_data=compressed_user_data,
             placement=placement,
             block_device_mappings=bdm,
-            subnet_id=subnet_id
-        )
-        aws_svc.create_tags(
-            instance.id,
+            subnet_id=subnet_id,
             name=NAME_ENCRYPTOR,
             description=DESCRIPTION_ENCRYPTOR % {'image_id': guest_image_id}
         )
-        log.info('Launching encryptor instance %s', instance.id)
         instance = wait_for_instance(aws_svc, instance.id)
 
         # Tag volumes.
@@ -491,6 +488,8 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
                  "instead of /dev/sda1", guest_image.root_device_name)
         legacy = True
     """
+
+    log.info('Snapshotting the guest root disk.')
 
     try:
         guest_instance = run_guest_instance(

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -122,7 +122,9 @@ class DummyAWSService(aws_service.BaseAWSService):
                      subnet_id=None,
                      user_data=None,
                      ebs_optimized=True,
-                     instance_profile_name=None):
+                     instance_profile_name=None,
+                     name=None,
+                     description=None):
         instance = Instance()
         instance.id = 'i-' + new_id()
         instance.image_id = image_id
@@ -160,6 +162,8 @@ class DummyAWSService(aws_service.BaseAWSService):
             args.instance = instance
             args.instance_profile_name = instance_profile_name
             self.run_instance_callback(args)
+
+        self.create_tags(instance.id, name=name, description=description)
 
         return instance
 

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -84,9 +84,7 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
             instance_type=guest_instance_type,
             ebs_optimized=False,
             subnet_id=subnet_id,
-            user_data=json.dumps(instance_config.brkt_config))
-        aws_svc.create_tags(
-            encrypted_guest.id,
+            user_data=json.dumps(instance_config.brkt_config),
             name=NAME_GUEST_CREATOR,
             description=DESCRIPTION_GUEST_CREATOR % {'image_id': encrypted_ami}
         )
@@ -121,11 +119,9 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
             ebs_optimized=False,
             subnet_id=subnet_id,
             placement=encrypted_guest.placement,
-            security_group_ids=security_group_ids)
-        aws_svc.create_tags(
-            updater.id,
+            security_group_ids=security_group_ids,
             name=NAME_METAVISOR_UPDATER,
-            description=DESCRIPTION_METAVISOR_UPDATER,
+            description=DESCRIPTION_METAVISOR_UPDATER
         )
 
         log.info(

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -185,10 +185,7 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
             block_device_mappings=bdm,
             ebs_optimized=ebs_optimized,
             subnet_id=subnet_id,
-            instance_profile_name=iam
-        )
-        aws_svc.create_tags(
-            instance.id,
+            instance_profile_name=iam,
             name=instance_name
         )
 


### PR DESCRIPTION
Create tags automatically when we run an instance, create a volume, or
create an image.

Log all operations that alter the state of the AWS account.  We now log
inside AWSService, to make sure that we don't miss any callsites.
Remove extra logging from callsites.  Remove the resource type from log
messages to make them more concise.  The resource type can be inferred
from the AWS ID prefix.

Add calls to clean_up() inside AWSService methods.  This ensures that
the created resource is cleaned up if a subsequent operation (e.g.
tagging) fails or is interrupted.

Update unit tests that were affected by the new behavior.