### PR TITLE
Don't attempt to tag when no tags were specified

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -370,6 +370,10 @@ class AWSService(BaseAWSService):
             d['Name'] = name
         if description:
             d['Description'] = description
+        if not d:
+            log.debug('Not tagging %s.  No tags were specified.', resource_id)
+            return
+
         log.debug(
             'Tagging %s with %s', resource_id, pretty_print_json(d))
         create_tags = self.retry(self.ec2client.create_tags, r'.*\.NotFound')


### PR DESCRIPTION
When create_tags() is called with an empty tag set, don't call the
CreateTags API.  AWS returns a bad request error in this case.