### PR TITLE
Preserve license info when wrapping an image

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -179,6 +179,8 @@ def run_wrap_image(values, config):
 
     metavisor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
                                                     values.metavisor_version)
+    log.debug('Using Metavisor %s', metavisor_ami)
+
     if values.validate:
         values.encrypted_ami_name = None
         _validate(aws_svc, values, metavisor_ami)

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -99,6 +99,10 @@ class BaseAWSService(object):
         pass
 
     @abc.abstractmethod
+    def start_instance(self, instance_id):
+        pass
+
+    @abc.abstractmethod
     def terminate_instance(self, instance_id):
         pass
 
@@ -130,7 +134,7 @@ class BaseAWSService(object):
     def create_volume(self,
                       size,
                       zone,
-                      snapshot=None,
+                      snapshot_id=None,
                       volume_type=None,
                       encrypted=False):
         pass
@@ -386,6 +390,11 @@ class AWSService(BaseAWSService):
         log.info('Stopping %s', instance_id)
         stop_instances = self.retry(self.ec2client.stop_instances)
         stop_instances(InstanceIds=[instance_id])
+
+    def start_instance(self, instance_id):
+        log.info('Starting %s', instance_id)
+        self.ec2client.start_instances(InstanceIds=[instance_id])
+        return self.get_instance(instance_id)
 
     def terminate_instance(self, instance_id):
         log.info('Terminating %s', instance_id)
@@ -673,14 +682,25 @@ class AWSService(BaseAWSService):
 
     def modify_instance_attribute(self, instance_id, attribute,
                                   value, dry_run=False):
-        log.info('Setting %s for %s to %s', attribute, instance_id, value)
         modify_instance_attribute = self.retry(
             self.ec2client.modify_instance_attribute)
-        modify_instance_attribute(
-            InstanceId=instance_id,
-            Attribute=attribute,
-            Value=value
-        )
+
+        if attribute == 'userData':
+            log.info(
+                'Setting userData for %s, content length is %d bytes.',
+                len(value)
+            )
+            modify_instance_attribute(
+                InstanceId=instance_id,
+                UserData={'Value': value}
+            )
+        else:
+            log.info('Setting %s for %s to %s', attribute, instance_id, value)
+            modify_instance_attribute(
+                InstanceId=instance_id,
+                Attribute=attribute,
+                Value=value
+            )
 
 
 def validate_image_name(name):
@@ -746,9 +766,8 @@ def wait_for_volume(aws_svc, volume_id, timeout=600.0, state='available'):
     :return the Volume object
     :raise VolumeError if the timeout is exceeded
     """
-    log.debug(
-        'Waiting for %s, timeout=%.02f, state=%s',
-        volume_id, timeout, state)
+    log.info('Waiting for %s to be in the %s state', volume_id, state)
+    log.debug('timeout=%.02f', timeout)
 
     deadline = Deadline(timeout)
     sleep_time = 0.5

--- a/brkt_cli/aws/model.py
+++ b/brkt_cli/aws/model.py
@@ -234,23 +234,11 @@ class Instance(TaggedEC2Object):
         self.sriov_net_support = None
         self._previous_state = None
         self.state = dict()
-        self._placement = InstancePlacement()
+        self.placement = dict()
         self.ena_support = False
 
     def __repr__(self):
         return 'Instance:%s' % self.id
-
-    @property
-    def placement(self):
-        return self._placement.zone
-
-    @property
-    def placement_group(self):
-        return self._placement.group_name
-
-    @property
-    def placement_tenancy(self):
-        return self._placement.tenancy
 
 
 class KeyPair(object):

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -63,7 +63,7 @@ class TestRunEncryption(unittest.TestCase):
         self.assertIsNotNone(instance)
 
     def test_wrapped_instance_name(self):
-        """ Test that the wrapped instance is launched with the Metavisor AMI.
+        """ Test that the wrapped instance is launched with the guest AMI.
         """
         aws_svc, encryptor_image, guest_image = build_aws_service()
 
@@ -75,7 +75,7 @@ class TestRunEncryption(unittest.TestCase):
             wrapped_instance_name=name,
         )
         instance = aws_svc.get_instance(instance.id)
-        self.assertEqual(encryptor_image.id, instance.image_id)
+        self.assertEqual(guest_image.id, instance.image_id)
 
     def test_subnet_with_security_groups(self):
         """ Test that the subnet and security groups are passed to the


### PR DESCRIPTION
Rewrite the wrap-guest-image logic so that we modify the guest instance
instead of launching a new one.  This preserves RHEL licensing
information that's embedded in the instance and allows the user to run
yum update.

The new process is:

1) Launch the guest.
2) Stop the guest.
3) Create a Metavisor root volume based on the Metavisor AMI.
4) Move the guest root to /dev/sdf.
5) Attach the Metavisor volume at the original guest root location.
6) Start the guest.

The whole process takes about a minute.

Random related fixes:
* Add AWSService.start_instance().
* Add support for modifying user-data of an instance.  This has to be
special-cased because user-data isn't a simple string value.
* Add initialization of volume size and instance placement to
DummyAWSService, so that launch_wrapped_image() gets the values it's
expecting.
* Update unit tests to check that we launch the guest instead of
launching Metavisor.