### PR TITLE
Pass owner information to images filter option correctly

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -507,14 +507,15 @@ class AWSService(BaseAWSService):
 
     def get_images(self, name=None, owner_alias=None, product_code=None):
         filters = list()
+        owners = []
         if name:
             filters.append({'Name': 'name', 'Values': [name]})
-        if owner_alias:
-            filters.append({'Name': 'owner-alias', 'Values': [owner_alias]})
         if product_code:
             filters.append({'Name': 'product-code', 'Values': [product_code]})
+        if owner_alias:
+            owners.append(owner_alias)
 
-        images = self.ec2.images.filter(Filters=filters)
+        images = self.ec2.images.filter(Owners=owners, Filters=filters)
         for image in images:
             image.load()
         return list(images)


### PR DESCRIPTION
Boto3 no longer supports `self` as a valid owner-alias (see
http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_images).
Instead we need to pass a new list with the owners, which allows `self` as a
valid value