### PR TITLE
Add aws wrap-instance command

### DIFF
--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -168,7 +168,7 @@ class DummyAWSService(aws_service.BaseAWSService):
 
         return instance
 
-    def get_instance(self, instance_id):
+    def get_instance(self, instance_id, retry=True):
         instance = self.instances[instance_id]
         if self.get_instance_callback:
             self.get_instance_callback(instance)

--- a/brkt_cli/aws/wrap_instance_args.py
+++ b/brkt_cli/aws/wrap_instance_args.py
@@ -1,0 +1,43 @@
+# Copyright 2017 Bracket Computing, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# https://github.com/brkt/brkt-cli/blob/master/LICENSE
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+
+from brkt_cli.aws import aws_args
+
+
+def setup_wrap_instance_args(parser, parsed_config):
+    parser.add_argument(
+        'instance_id',
+        metavar='ID',
+        help='The ID of the instance that will be wrapped with Metavisor'
+    )
+    parser.add_argument(
+        '--wrapped-instance-name',
+        metavar='NAME',
+        dest='wrapped_instance_name',
+        help='Specify the name of the wrapped Bracket instance',
+        required=False
+    )
+    aws_args.add_no_validate(parser)
+    aws_args.add_region(parser, parsed_config)
+    aws_args.add_metavisor_version(parser)
+
+    # Optional AMI ID that's used to launch the encryptor instance.  This
+    # argument is hidden because it's only used for development.
+    aws_args.add_encryptor_ami(parser)
+
+    # Optional arguments for changing the behavior of our retry logic.  We
+    # use these options internally, to avoid intermittent AWS service failures
+    # when running concurrent encryption processes in integration tests.
+    aws_args.add_retry_timeout(parser)
+    aws_args.add_retry_initial_sleep_seconds(parser)


### PR DESCRIPTION
Add a wrap-instance command for wrapping an AWS instance with Metavisor.
  This logic is effectively the same thing as wrapping an image, except
that we don't launch an instance at the beginning of the process.

Move the bulk of the orchestration code from launch_wrapped_image() into
a new wrap_instance() function.  Add a new wrap-instance command that
calls wrap_instance() directly.