### PR TITLE
Save the console log when encryption doesn't start

### DIFF
--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -148,7 +148,7 @@ def wait_for_encryptor_up(enc_svc, deadline):
             )
             return
         sleep(5)
-    raise BracketError(
+    raise EncryptionError(
         'Unable to contact encryptor instance at %s, port %d.' %
         (', '.join(enc_svc.hostnames), enc_svc.port)
     )


### PR DESCRIPTION
If we hit a timeout waiting for encryption to start, save the encryptor
console log in the same way that we do when encryption fails.  This
helps the user diagnose communication issues between the CLI and
encryptor, or between encryptor and Yeti.

Add an encryption_start_timeout argument to the encrypt() function.
This allows encryption to time out immediately in unit tests.