### PR TITLE
Use the version of Metavisor returned by the Bracket service

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -11,6 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+import httplib
 import json
 import logging
 import re
@@ -343,8 +344,16 @@ def run_encrypt(values, config, verbose=False):
         guest_image = _validate_guest_ami(aws_svc, guest_ami_id)
     else:
         guest_image = _validate_ami(aws_svc, guest_ami_id)
-    encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
-                                                    values.metavisor_version)
+
+    brkt_env = brkt_cli.brkt_env_from_values(values, config)
+    encryptor_ami = values.encryptor_ami
+    if not encryptor_ami:
+        mv_version = values.metavisor_version
+        if not mv_version:
+            yeti = instance_config_args.yeti_service_from_brkt_env(brkt_env)
+            mv_version = yeti.get_metavisor_version()
+        encryptor_ami = _get_encryptor_ami(values.region, mv_version)
+
     aws_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
     command_line_tags = brkt_cli.parse_tags(values.aws_tags)
     aws_tags.update(command_line_tags)
@@ -382,7 +391,6 @@ def run_encrypt(values, config, verbose=False):
                 crypto_policy, mv_image.name
             )
 
-    brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(
         values,
@@ -850,22 +858,44 @@ def _get_encryptor_ami(region_name, version):
     :raise ValidationError if the region is not supported
     :raise BracketError if the list of AMIs cannot be read
     """
-    bucket = ENCRYPTOR_AMIS_AWS_BUCKET
-    amis_url = mv_version.get_amis_url(version, bucket)
+    all_buckets = (
+        mv_version.AWS_PROD_BUCKET,
+        mv_version.AWS_STAGE_BUCKET,
+        mv_version.AWS_BUILD_BUCKET
+    )
 
-    log.debug('Getting encryptor AMI list from %s', amis_url)
-    r = urllib2.urlopen(amis_url)
-    if r.getcode() not in (200, 201):
-        raise BracketError(
-            'Getting %s gave response: %s' % (amis_url, r.text))
-    resp_json = json.loads(r.read())
-    ami = resp_json.get(region_name)
+    for bucket in all_buckets:
+        try:
+            amis_url = mv_version.get_amis_url(version, bucket)
+        except mv_version.MetavisorVersionNotFoundError:
+            log.debug('Could not find %s in %s', version, bucket)
+            continue
 
-    if not ami:
+        log.debug('Getting encryptor AMI list from %s', amis_url)
+        try:
+            r = urllib2.urlopen(amis_url)
+        except urllib2.HTTPError as e:
+            if e.code == httplib.NOT_FOUND:
+                log.debug('Version not found.')
+                continue
+            if e.code == httplib.FORBIDDEN:
+                log.debug('Forbidden.')
+                continue
+            raise
+
+        if r.getcode() not in (httplib.OK, httplib.CREATED):
+            raise BracketError(
+                'Getting %s gave response: %s' % (amis_url, r.text))
+        resp_json = json.loads(r.read())
+        ami = resp_json.get(region_name)
+        if ami:
+            return ami
+
         regions = resp_json.keys()
         raise ValidationError(
             'Encryptor AMI is only available in %s' % ', '.join(regions))
-    return ami
+
+    raise ValidationError('Unable to find Metavisor version %s' % version)
 
 
 def _get_updated_image_name(image_name, session_id):

--- a/brkt_cli/yeti.py
+++ b/brkt_cli/yeti.py
@@ -164,6 +164,19 @@ class YetiService(object):
             email=d['email']
         )
 
+    def get_metavisor_version(self):
+        """ Return the version of Metavisor that will be used for new
+        instances.
+
+        :raise YetiError if Yeti returns an HTTP error status.
+        """
+        d = get_json(
+            self.root_url + '/api/v1/upgrade/latest_metavisor',
+            token=self.token,
+            root_cert_path=self.root_cert_path
+        )
+        return d['long_form']
+
     def _create_token(self, token_type, tags=None, expiry=None):
         """ Return a JWT that is created by Yeti.
 


### PR DESCRIPTION
Get the Metavisor version from the Bracket service instead of using the
latest Metavisor release.  With a Customer Managed MCP that has not been
upgraded, the latest Metavisor may attempt to call service endpoints
that are not available.