### PR TITLE
Configure volumes for wrapped instance to be deleted on termination

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -697,6 +697,13 @@ class AWSService(BaseAWSService):
                 InstanceId=instance_id,
                 UserData={'Value': value}
             )
+        elif attribute == 'blockDeviceMappings':
+            log.info('Setting blockDeviceMapping for %s to %s',
+                     instance_id, value)
+            modify_instance_attribute(
+                InstanceId=instance_id,
+                BlockDeviceMappings=value
+            )
         else:
             log.info('Setting %s for %s to %s', attribute, instance_id, value)
             modify_instance_attribute(


### PR DESCRIPTION
Detaching and re-attaching volumes cause them to lose their
DeleteOnTermination property, which needs to be reset on the
running instance.