### PR TITLE
Add --encryptor-instance-type to aws encrypt

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -154,7 +154,8 @@ be in the same VPC.
 $ brkt aws encrypt --help
 usage: brkt aws encrypt [-h] [--stock-image-version STOCK_IMAGE_VERSION]
                         [--encrypted-ami-name NAME]
-                        [--guest-instance-type TYPE] [--no-validate]
+                        [--guest-instance-type TYPE]
+                        [--encryptor-instance-type TYPE] [--no-validate]
                         --region NAME [--security-group ID] [--subnet ID]
                         [--aws-tag KEY=VALUE] [--metavisor-version NAME]
                         [--ntp-server DNS_NAME]
@@ -183,7 +184,10 @@ optional arguments:
                         Specify the name of the generated encrypted AMI
   --guest-instance-type TYPE
                         The instance type to use when running the unencrypted
-                        guest instance (default: m3.medium)
+                        guest instance (default: m4.large)
+  --encryptor-instance-type TYPE
+                        The instance type to use when performing the
+                        encypt operation. (default: c4.xlarge)
   --metavisor-version NAME
                         Metavisor version [e.g 1.2.12 ] (default: latest)
   --no-validate         Don't validate AMIs, subnet, and security groups

--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -417,6 +417,7 @@ def run_encrypt(values, config, verbose=False):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
+        encryptor_instance_type=values.encryptor_instance_type,
         instance_config=instance_config,
         status_port=values.status_port,
         save_encryptor_logs=values.save_encryptor_logs,

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -112,8 +112,8 @@ def _get_description_from_image(image):
 
 def _run_encryptor_instance(
         aws_svc, encryptor_image_id, snapshot, root_size, guest_image_id,
-        crypto_policy, security_group_ids=None, subnet_id=None, placement=None,
-        instance_config=None,
+        crypto_policy, instance_type, security_group_ids=None, subnet_id=None,
+        placement=None, instance_config=None,
         status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
 
     if instance_config is None:
@@ -186,7 +186,8 @@ def _run_encryptor_instance(
             block_device_mappings=bdm,
             subnet_id=subnet_id,
             name=NAME_ENCRYPTOR,
-            description=DESCRIPTION_ENCRYPTOR % {'image_id': guest_image_id}
+            description=DESCRIPTION_ENCRYPTOR % {'image_id': guest_image_id},
+            instance_type=instance_type,
         )
         instance = wait_for_instance(aws_svc, instance.id)
 
@@ -447,7 +448,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             save_encryptor_logs=True,
             status_port=encryptor_service.ENCRYPTOR_STATUS_PORT,
             terminate_encryptor_on_failure=True, legacy=False,
-            encryption_start_timeout=600):
+            encryption_start_timeout=600, encryptor_instance_type='c4.xlarge'):
     log.info(
         'Starting session %s to encrypt %s',
         aws_svc.session_id,
@@ -515,7 +516,8 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             subnet_id=subnet_id,
             placement=guest_instance.placement,
             instance_config=instance_config,
-            status_port=status_port
+            status_port=status_port,
+            instance_type=encryptor_instance_type,
         )
 
         # Enable ENA if Metavisor supports it.

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -49,6 +49,15 @@ def setup_encrypt_ami_args(parser, parsed_config):
         default='m4.large'
     )
 
+    parser.add_argument(
+        '--encryptor-instance-type',
+        metavar='TYPE',
+        dest='encryptor_instance_type',
+        help=(
+            'The instance type to use when running the encryptor instance'),
+        default='c4.xlarge'
+    )
+
     # Add the --legacy argument, for specifying legacy mode during
     # encryption and update.  This hidden argument is only here for backward
     # compatibility.  We'll remove it once we're sure that legacy mode is


### PR DESCRIPTION
We were defaulting to c4.xlarge, a terrific choice, but this instance
requires a VPC. For people with old AWS accounts and EC2 classic this
preculuded them from doing encryption outside of a specific VPC.

The update subcommand already has an --updater-instance-type option.