### PR TITLE
Validate access to image

### DIFF
--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -539,6 +539,11 @@ class AWSService(BaseAWSService):
                 image.load, r'InvalidAMIID\.NotFound')
 
         load()
+        try:
+            image.name
+        except AttributeError:
+            return None
+
         return image
 
     def delete_snapshot(self, snapshot_id):


### PR DESCRIPTION
Boto3 returns an image object, if the image exists, even if the user
does not access to the image. This change ensure that the user also
has access to the image before proceeding. This ensures that there are
no unexpected errors downstream.