### PR TITLE
Add missing IAM permissions

### DIFF
--- a/reference_templates/brkt-cli-iam-permissions.json
+++ b/reference_templates/brkt-cli-iam-permissions.json
@@ -28,8 +28,10 @@
                 "ec2:DescribeVpcs",
                 "ec2:GetConsoleOutput",
                 "ec2:ModifyImageAttribute",
+                "ec2:ModifyInstanceAttribute",
                 "ec2:RegisterImage",
                 "ec2:RunInstances",
+                "ec2:StartInstances",
                 "ec2:StopInstances",
                 "ec2:TerminateInstances"
             ],


### PR DESCRIPTION
The wrap-guest-image and wrap-instance command require the additional
ModifyInstanceAttribute and StartInstances permissions to complete
successfully