### PR TITLE
Provide option to override encryptor instance type

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -409,6 +409,7 @@ def run_encrypt(values, config, verbose=False):
         subnet_id=values.subnet_id,
         security_group_ids=values.security_group_ids,
         guest_instance_type=values.guest_instance_type,
+        encryptor_instance_type=values.encryptor_instance_type,
         instance_config=instance_config,
         status_port=values.status_port,
         save_encryptor_logs=values.save_encryptor_logs,

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -112,8 +112,8 @@ def _get_description_from_image(image):
 
 def _run_encryptor_instance(
         aws_svc, encryptor_image_id, snapshot, root_size, guest_image_id,
-        crypto_policy, security_group_ids=None, subnet_id=None, placement=None,
-        instance_config=None,
+        crypto_policy, security_group_ids=None, subnet_id=None,
+        instance_type='c4.xlarge', placement=None, instance_config=None,
         status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
 
     if instance_config is None:
@@ -185,6 +185,7 @@ def _run_encryptor_instance(
             placement=placement,
             block_device_mappings=bdm,
             subnet_id=subnet_id,
+            instance_type=instance_type,
             name=NAME_ENCRYPTOR,
             description=DESCRIPTION_ENCRYPTOR % {'image_id': guest_image_id}
         )
@@ -443,8 +444,8 @@ def _print_bdm(context, resource):
 
 def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            guest_instance_type='m4.large', instance_config=None,
-            save_encryptor_logs=True,
+            guest_instance_type='m4.large', encryptor_instance_type='c4.xlarge',
+            instance_config=None, save_encryptor_logs=True,
             status_port=encryptor_service.ENCRYPTOR_STATUS_PORT,
             terminate_encryptor_on_failure=True, legacy=False,
             encryption_start_timeout=600):
@@ -513,6 +514,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
             crypto_policy=crypto_policy,
             security_group_ids=security_group_ids,
             subnet_id=subnet_id,
+            instance_type=encryptor_instance_type,
             placement=guest_instance.placement,
             instance_config=instance_config,
             status_port=status_port

--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -48,6 +48,15 @@ def setup_encrypt_ami_args(parser, parsed_config):
             'instance'),
         default='m4.large'
     )
+    parser.add_argument(
+        '--encryptor-instance-type',
+        metavar='TYPE',
+        dest='encryptor_instance_type',
+        help=(
+            'The instance type to use when running the Bracket encryptor '
+            'instance'),
+        default='c4.xlarge'
+    )
 
     # Add the --legacy argument, for specifying legacy mode during
     # encryption and update.  This hidden argument is only here for backward

--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -333,6 +333,26 @@ class TestRunEncryption(unittest.TestCase):
             guest_instance_type='t2.micro'
         )
 
+    def test_encryptor_instance_type(self):
+        """ Test that we use the specified instance type to launch the
+        encryptor instance.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        def run_instance_callback(args):
+            if args.image_id == guest_image.id:
+                self.assertEqual('c3.xlarge', args.instance_type)
+
+        aws_svc.run_instance_callback = run_instance_callback
+        encrypt_ami.encrypt(
+            aws_svc=aws_svc,
+            enc_svc_cls=DummyEncryptorService,
+            image_id=guest_image.id,
+            encryptor_ami=encryptor_image.id,
+            crypto_policy=CRYPTO_GCM,
+            guest_instance_type='c3.xlarge'
+        )
+
     def test_terminate_guest(self):
         """ Test that we terminate the guest instance if an exception is
         raised while waiting for it to come up.


### PR DESCRIPTION
The default encryptor instance type is c4.xlarge which can sometimes
be not available due to capacity issues. This argument allows a user
to override and use a different encryptor instance type to
temporarily workaround the problems. In most cases, the default
instance type would suffice (and would be used).