### PR TITLE
Validate instance type for wrap operations

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -188,7 +188,8 @@ def run_wrap_image(values, config):
             metavisor_ami,
             key_name=values.key_name,
             subnet_id=values.subnet_id,
-            security_group_ids=values.security_group_ids
+            security_group_ids=values.security_group_ids,
+            instance_type=values.instance_type
         )
 
         brkt_cli.validate_ntp_servers(values.ntp_servers)
@@ -800,7 +801,8 @@ def _validate_encryptor_ami(aws_svc, ami_id):
 
 
 def _validate(aws_svc, encryptor_ami_id, encrypted_ami_name=None,
-              key_name=None, subnet_id=None, security_group_ids=None):
+              key_name=None, subnet_id=None, security_group_ids=None,
+              instance_type=None):
     """ Validate command-line options
 
     :param aws_svc: the BaseAWSService implementation
@@ -808,6 +810,12 @@ def _validate(aws_svc, encryptor_ami_id, encrypted_ami_name=None,
     """
     if encrypted_ami_name:
         aws_service.validate_image_name(encrypted_ami_name)
+
+    if instance_type and (
+        instance_type == 't2.nano' or instance_type == 't1.micro'):
+            raise ValidationError(
+                'Unsupported instance type %s' % instance_type
+            )
 
     try:
         if key_name:

--- a/brkt_cli/aws/test_aws_service.py
+++ b/brkt_cli/aws/test_aws_service.py
@@ -132,6 +132,7 @@ class DummyAWSService(aws_service.BaseAWSService):
         instance.state['Name'] = 'pending'
         instance.state['Code'] = 0
         instance.placement = placement or {'AvailabilityZone': 'us-west-2a'}
+        instance.type = instance_type
 
         # Create volumes based on block device data from the image.
         image = self.get_image(image_id)

--- a/brkt_cli/aws/test_wrap_guest_image.py
+++ b/brkt_cli/aws/test_wrap_guest_image.py
@@ -161,6 +161,19 @@ class TestRunEncryption(unittest.TestCase):
             instance_type='t2.micro'
         )
 
+    def test_invalid_instance_type(self):
+        """ Test that we use the specified instance type to launch the wrapped
+        instance.
+        """
+        aws_svc, encryptor_image, guest_image = build_aws_service()
+
+        with self.assertRaises(brkt_cli.validation.ValidationError):
+            brkt_cli.aws._validate(
+                aws_svc,
+                encryptor_image.id,
+                instance_type='t2.nano'
+            )
+
     def test_iam_role(self):
         """ Test that the IAM role is passed to the calls to
         AWSService.run_instance().

--- a/brkt_cli/aws/wrap_image.py
+++ b/brkt_cli/aws/wrap_image.py
@@ -177,6 +177,11 @@ def launch_wrapped_image(aws_svc, image_id, metavisor_ami,
 def wrap_instance(aws_svc, instance_id, metavisor_ami, instance_config=None):
     instance = aws_svc.get_instance(instance_id)
 
+    if instance.type == 't2.nano' or instance.type == 't1.micro':
+        raise ValidationError(
+            'Unsupported instance type %s' % instance.type
+        )
+
     # If the guest already has /dev/sdf mounted, don't try to put the guest
     # root there.
     if boto3_device.get_device(instance.block_device_mappings, '/dev/sdf'):

--- a/brkt_cli/gcp/__init__.py
+++ b/brkt_cli/gcp/__init__.py
@@ -140,6 +140,8 @@ def run_launch(values, config):
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
 
+    validate_instance_type(values.instance_type)
+
     # Use the token in the image unless a token or tags were specified on
     # the command line.
     lt = None
@@ -190,6 +192,8 @@ def run_wrap_image(values, config):
 
     if values.ssd_scratch_disks > 8:
         raise ValidationError("Maximum of 8 SSD scratch disks are supported")
+
+    validate_instance_type(values.instance_type)
 
     brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
@@ -476,3 +480,8 @@ def check_args(values, gcp_svc, cli_config):
 def validate_tags(tags):
     for tag in tags:
         gcp_service.validate_image_name(tag)
+
+
+def validate_instance_type(instance_type):
+    if instance_type == 'f1-micro':
+        raise ValidationError('Unsupported instance type %s' % instance_type)


### PR DESCRIPTION
Metavisor requires instances with atleast 1 vCPU and 1GB RAM. This
change validates that unsupported instances type (t1.micro and
t2.nano in AWS and f1-micro in GCP) are not allowed with the wrap
commands