### PR TITLE
YETI-3635: Add support for single-disk encryption on GCP

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -49,11 +49,7 @@ from brkt_cli.instance_config_args import (
     setup_instance_config_args
 )
 from brkt_cli.subcommand import Subcommand
-from brkt_cli.util import (
-    BracketError,
-    CRYPTO_GCM,
-    CRYPTO_XTS
-)
+from brkt_cli.util import BracketError
 from brkt_cli.validation import ValidationError
 
 log = logging.getLogger(__name__)
@@ -362,27 +358,7 @@ def run_encrypt(values, config, verbose=False):
         )
         brkt_cli.validate_ntp_servers(values.ntp_servers)
 
-    mv_image = aws_svc.get_image(encryptor_ami)
-    if values.crypto is None:
-        if mv_image.name.startswith('metavisor'):
-            crypto_policy = CRYPTO_XTS
-        elif mv_image.name.startswith('brkt-avatar'):
-            crypto_policy = CRYPTO_GCM
-        else:
-            log.warn(
-                "Unable to determine encryptor type for image %s. "
-                "Default boot volume crypto policy to %s",
-                mv_image.name, CRYPTO_XTS
-            )
-            crypto_policy = CRYPTO_XTS
-    else:
-        crypto_policy = values.crypto
-        if crypto_policy == CRYPTO_XTS and not mv_image.name.startswith('metavisor'):
-            raise ValidationError(
-                'Unsupported crypto policy %s for encryptor %s' %
-                crypto_policy, mv_image.name
-            )
-
+    crypto_policy = values.crypto
     brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
     instance_config = instance_config_from_values(

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -118,7 +118,6 @@ def _run_encryptor_instance(
 
     if instance_config is None:
         instance_config = InstanceConfig()
-    instance_config.brkt_config['crypto_policy_type'] = crypto_policy
 
     # Use 'sd' names even though AWS maps these to 'xvd'
     # The AWS GUI only exposes 'sd' names, and won't allow

--- a/brkt_cli/esx/__init__.py
+++ b/brkt_cli/esx/__init__.py
@@ -35,7 +35,6 @@ from brkt_cli.instance_config_args import (
     instance_config_from_values,
     setup_instance_config_args
 )
-from brkt_cli.util import CRYPTO_XTS
 
 from brkt_cli.esx import (
     encrypt_vmdk,
@@ -196,10 +195,8 @@ def run_encrypt(values, parsed_config, log, use_esx=False):
             brkt_env=brkt_env,
             launch_token=lt
         )
+
         crypto_policy = values.crypto
-        if crypto_policy is None:
-            crypto_policy = CRYPTO_XTS
-        instance_config.brkt_config['crypto_policy_type'] = crypto_policy
         user_data_str = vc_swc.create_userdata_str(instance_config,
             update=False, ssh_key_file=values.ssh_public_key_file)
         if (values.encryptor_vmdk is not None):

--- a/brkt_cli/esx/encrypt_vmdk.py
+++ b/brkt_cli/esx/encrypt_vmdk.py
@@ -60,8 +60,6 @@ def create_ovf_image_from_mv_vm(vc_swc, enc_svc_cls, vm, guest_vmdk,
         # Add datastore path to the guest vmdk
         # Attach guest vmdk
         vc_swc.add_disk(vm, filename=new_guest_vmdk_name, unit_number=2)
-        if crypto_policy is None:
-            crypto_policy = CRYPTO_XTS
         # Attach empty disk
         size = vc_swc.get_disk_size(vm, 2)
         if crypto_policy == CRYPTO_XTS:

--- a/brkt_cli/gcp/encrypt_gcp_image.py
+++ b/brkt_cli/gcp/encrypt_gcp_image.py
@@ -4,178 +4,152 @@ import httplib
 import logging
 import socket
 
+from googleapiclient import errors
+
 from brkt_cli.encryptor_service import (
-    ENCRYPTOR_STATUS_PORT,
     wait_for_encryption,
     wait_for_encryptor_up
 )
 from brkt_cli.gcp.gcp_service import gcp_metadata_from_userdata
-from brkt_cli.util import Deadline, retry, append_suffix
-from googleapiclient import errors
-from brkt_cli.util import CRYPTO_XTS
+from brkt_cli.util import (
+    CRYPTO_GCM,
+    Deadline,
+    METAVISOR_DISK_SIZE,
+    append_suffix,
+    retry
+)
 
 
 log = logging.getLogger(__name__)
 
 
-def setup_encryption(gcp_svc,
-                     image_id,
-                     encrypted_image_disk,
-                     instance_name,
-                     zone,
-                     image_project,
-                     crypto_policy):
+def setup_encryption(gcp_svc, values, encrypted_image_disk, instance_name):
     try:
-        # create disk from guest image
-        gcp_svc.disk_from_image(zone, image_id, instance_name, image_project)
+        # Create disk from guest image.
+        gcp_svc.disk_from_image(values.zone, values.image, instance_name,
+                                values.image_project)
         log.info('Waiting for guest root disk to become ready')
-        gcp_svc.wait_for_detach(zone, instance_name)
+        gcp_svc.wait_for_detach(values.zone, instance_name)
+        guest_disk_size = gcp_svc.get_disk_size(values.zone, instance_name)
 
-        guest_size = gcp_svc.get_disk_size(zone, instance_name)
-        # create blank disk. the encrypted image will be
-        # dd'd to this disk. Blank disk should be 2x the size
-        # of the unencrypted guest root (GCM)
-        log.info('Creating disk for encrypted image')
-        if crypto_policy == CRYPTO_XTS:
-            gcp_svc.create_disk(zone, encrypted_image_disk, guest_size + 1)
+        # Create a blank disk. The size of which depends on the crypto
+        # policy and whether we do single-disk encryption or not.
+        encrypted_disk_size = guest_disk_size
+        if values.crypto == CRYPTO_GCM:
+            encrypted_disk_size *= 2
+        if values.single_disk:
+            encrypted_disk_size += METAVISOR_DISK_SIZE
         else:
-            gcp_svc.create_disk(zone, encrypted_image_disk, guest_size * 2 + 1)
+            encrypted_disk_size += 1
+        log.info('Creating a %sGB disk for the encrypted image',
+                 encrypted_disk_size)
+        gcp_svc.create_disk(values.zone, encrypted_image_disk,
+                            encrypted_disk_size)
+
         #
         # Amazing but true - just attach a big drive to get more IOPS
         # to be shared by all volumes attached to this VM. We don't
         # use the dummy-iops drive but get to use it's IOPS for other
         # drives.
         #
-        log.info('Creating dummy IOPS disk')
+        dummy_disk_size = 500
+        log.info('Creating a %sGB dummy disk for better IOPS', dummy_disk_size)
         dummy_name = append_suffix(encrypted_image_disk, "-dummy-iops", 64)
-        gcp_svc.create_disk(zone, dummy_name, 500)
+        gcp_svc.create_disk(values.zone, dummy_name, dummy_disk_size)
     except:
         log.info('Encryption setup failed')
         raise
 
 
-def do_encryption(gcp_svc,
-                  enc_svc_cls,
-                  zone,
-                  encryptor,
-                  encryptor_image,
-                  instance_name,
-                  instance_config,
-                  encrypted_image_disk,
-                  crypto_policy,
-                  network,
-                  subnetwork,
-                  status_port=ENCRYPTOR_STATUS_PORT,
-                  gcp_tags=None):
-    instance_config.brkt_config['crypto_policy_type'] = crypto_policy
-    metadata = gcp_metadata_from_userdata(instance_config.make_userdata())
+def do_encryption(gcp_svc, enc_svc_cls, values, encryptor, instance_name,
+                  instance_config, encrypted_image_disk):
     log.info('Launching encryptor instance')
     dummy_name = append_suffix(encrypted_image_disk, "-dummy-iops", 64)
-    gcp_svc.run_instance(zone=zone,
-                         name=encryptor,
-                         image=encryptor_image,
-                         network=network,
-                         subnet=subnetwork,
-                         disks=[gcp_svc.get_disk(zone, instance_name),
-                                gcp_svc.get_disk(zone, encrypted_image_disk),
-                                gcp_svc.get_disk(zone, dummy_name)],
-                         delete_boot=False,
-                         metadata=metadata,
-                         tags=gcp_tags)
+    disks = [gcp_svc.get_disk(values.zone, instance_name),
+             gcp_svc.get_disk(values.zone, encrypted_image_disk),
+             gcp_svc.get_disk(values.zone, dummy_name)]
+    metadata = gcp_metadata_from_userdata(instance_config.make_userdata())
+    gcp_svc.run_instance(zone=values.zone, name=encryptor,
+                         image=values.encryptor_image, network=values.network,
+                         subnet=values.subnetwork, disks=disks,
+                         delete_boot=False, metadata=metadata,
+                         tags=values.gcp_tags)
 
     try:
         host_ips = []
-        ip = gcp_svc.get_instance_ip(encryptor, zone)
+        ip = gcp_svc.get_instance_ip(encryptor, values.zone)
         if ip:
             host_ips.append(ip)
-        pvt_ip = gcp_svc.get_private_ip(encryptor, zone)
+        pvt_ip = gcp_svc.get_private_ip(encryptor, values.zone)
         if pvt_ip:
             host_ips.append(pvt_ip)
-        enc_svc = enc_svc_cls(host_ips, port=status_port)
+        enc_svc = enc_svc_cls(host_ips, port=values.status_port)
         wait_for_encryptor_up(enc_svc, Deadline(600))
-        log.info(
-            'Waiting for encryption service on %s (%s:%s)',
-            encryptor, ip, enc_svc.port
-        )
+        log.info('Waiting for encryption service on %s (%s:%s)',
+                 encryptor, ip, enc_svc.port)
         wait_for_encryption(enc_svc)
     except:
-        f = gcp_svc.write_serial_console_file(zone, encryptor)
+        f = gcp_svc.write_serial_console_file(values.zone, encryptor)
         if f:
             log.info('Encryption failed. Writing console to %s' % f)
         raise
-    retry(function=gcp_svc.delete_instance,
-            on=[httplib.BadStatusLine, socket.error, errors.HttpError])(zone, encryptor)
+    retry(function=gcp_svc.delete_instance, on=[httplib.BadStatusLine,
+          socket.error, errors.HttpError])(values.zone, encryptor)
 
 
-def create_image(gcp_svc, zone, encrypted_image_disk, encrypted_image_name, encryptor):
+def create_image(gcp_svc, values, encrypted_image_disk, encrypted_image_name,
+                 encryptor):
     try:
-        # snapshot encrypted guest disk
-        log.info("Creating snapshot of encrypted image disk")
-        gcp_svc.create_snapshot(zone, encrypted_image_disk, encrypted_image_name)
-        # create image from encryptor root
-        gcp_svc.wait_for_detach(zone, encryptor)
+        if not values.single_disk:
+            # Snapshot the encrypted guest disk
+            log.info("Creating snapshot of encrypted image disk")
+            gcp_svc.create_snapshot(values.zone, encrypted_image_disk,
+                                    encrypted_image_name)
+            root_disk = encryptor
+        else:
+            root_disk = encrypted_image_disk
 
-        # create image from mv root disk and snapshot
-        # encrypted guest root disk
-        log.info("Creating metavisor image")
-        gcp_svc.create_gcp_image_from_disk(zone, encrypted_image_name, encryptor)
+        # Create image from the given root disk
+        gcp_svc.wait_for_detach(values.zone, root_disk)
+
+        log.info("Creating bracketized guest image")
+        gcp_svc.create_gcp_image_from_disk(values.zone, encrypted_image_name,
+                                           root_disk)
         gcp_svc.wait_image(encrypted_image_name)
-        gcp_svc.wait_snapshot(encrypted_image_name)
+        if not values.single_disk:
+            gcp_svc.wait_snapshot(encrypted_image_name)
         log.info("Image %s successfully created!", encrypted_image_name)
     except:
         log.info('Image creation failed.')
         raise
 
 
-def encrypt(gcp_svc, enc_svc_cls, image_id, encryptor_image,
-            encrypted_image_name, zone, instance_config, crypto_policy,
-            image_project=None, keep_encryptor=False, image_file=None,
-            image_bucket=None, network=None, subnetwork=None,
-            status_port=ENCRYPTOR_STATUS_PORT, cleanup=True, gcp_tags=None):
+def encrypt(gcp_svc, enc_svc_cls, values, encrypted_image_name,
+            instance_config):
     try:
-        # create metavisor image from file in GCS bucket
-        log.info('Retrieving encryptor image from GCS bucket')
-        if not encryptor_image:
-            try:
-                encryptor_image = gcp_svc.get_latest_encryptor_image(zone,
-                    image_bucket, image_file=image_file)
-            except errors.HttpError as e:
-                encryptor_image = None
-                log.exception('GCP API call to create image from file failed')
-                return
-        else:
-            # Keep user provided encryptor image
-            keep_encryptor = True
-
-        # For GCP there is no way to identify the encryptor type
-        # Default to XTS
-        if crypto_policy is None:
-            crypto_policy = CRYPTO_XTS
-
         instance_name = 'brkt-guest-' + gcp_svc.get_session_id()
         encryptor = instance_name + '-encryptor'
         encrypted_image_disk = 'encrypted-image-' + gcp_svc.get_session_id()
 
         # create guest root disk and blank disk to dd to
-        setup_encryption(gcp_svc, image_id, encrypted_image_disk,
-                         instance_name, zone, image_project, crypto_policy)
+        setup_encryption(gcp_svc, values, encrypted_image_disk, instance_name)
 
         # run encryptor instance with avatar_creator as root,
         # customer image and blank disk
-        do_encryption(gcp_svc, enc_svc_cls, zone, encryptor, encryptor_image,
-                      instance_name, instance_config, encrypted_image_disk,
-                      crypto_policy, network, subnetwork, status_port=status_port,
-                      gcp_tags=gcp_tags)
+        do_encryption(gcp_svc, enc_svc_cls, values, encryptor, instance_name,
+                      instance_config, encrypted_image_disk)
 
         # create image
-        create_image(gcp_svc, zone, encrypted_image_disk, encrypted_image_name, encryptor)
+        create_image(gcp_svc, values, encrypted_image_disk,
+                     encrypted_image_name, encryptor)
 
         return encrypted_image_name
     except errors.HttpError as e:
         log.exception('GCP API request failed: {}'.format(e.message))
     finally:
-        if not cleanup:
+        if not values.cleanup:
             log.info("Not cleaning up")
-            return
+            return None
         log.info("Cleaning up")
-        gcp_svc.cleanup(zone, encryptor_image, keep_encryptor)
+        gcp_svc.cleanup(values.zone, values.encryptor_image,
+                        values.keep_encryptor)

--- a/brkt_cli/gcp/update_gcp_image.py
+++ b/brkt_cli/gcp/update_gcp_image.py
@@ -40,7 +40,7 @@ def update_gcp_image(gcp_svc, enc_svc_cls, values, encrypted_image_name,
         # Create disk from encrypted guest snapshot.
         encrypted_image_disk = instance_name + '-root'
         gcp_svc.disk_from_image(values.zone, values.image,
-                                encrypted_image_disk)
+                                encrypted_image_disk, values.image_project)
         gcp_svc.wait_for_disk(values.zone, encrypted_image_disk)
 
         log.info("Launching encrypted updater")

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -31,6 +31,7 @@ from brkt_cli.instance_config import (
     INSTANCE_UPDATER_MODE
 )
 from brkt_cli.util import (
+    CRYPTO_XTS,
     get_domain_from_brkt_env
 )
 from brkt_cli.validation import ValidationError
@@ -108,6 +109,17 @@ def setup_instance_config_args(parser, parsed_config,
             required=False
         )
 
+    if mode == INSTANCE_CREATOR_MODE:
+        parser.add_argument('--single-disk', dest='single_disk',
+                            action='store_true', default=None, required=False,
+                            help=('Specify that single-disk encryption is to '
+                                  'be used.'))
+
+        parser.add_argument('--no-single-disk', dest='single_disk',
+                            action='store_false', default=None, required=False,
+                            help=('Specify that single-disk encryption is not '
+                                  'to be used.'))
+
     # Optional CA cert file for Brkt MCP. When an on-prem MCP is used
     # (and thus, the MCP endpoints are provided in the --brkt-env arg), the
     # CA cert for the MCP root CA must be 'baked into' the encrypted AMI
@@ -167,6 +179,45 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
             values.status_port or
             encryptor_service.ENCRYPTOR_STATUS_PORT
         )
+
+    if mode == INSTANCE_CREATOR_MODE:
+        if values.crypto is None:
+            values.crypto = CRYPTO_XTS
+        brkt_config['crypto_policy_type'] = values.crypto
+
+        if values.single_disk is None:
+            # Neither single-disk flag has been given. Let's pick a
+            # reasonable default. This is a little ugly, but it's
+            # temporary.
+            encryptor = ((values.subparser_name == 'gcp' and
+                          values.encryptor_image) or
+                         (values.subparser_name == 'aws' and
+                          values.encryptor_ami) or
+                         (values.subparser_name == 'vmware' and
+                          values.image_name))
+            if encryptor:
+                # If an encryptor image has been specified, then we
+                # assume that this is an unreleased image, which
+                # supports single-disk encryption. In a sense, we're
+                # defaulting on behalf of forward progress.
+                values.single_disk = True
+            else:
+                # If no encryptor image has been specified, then we
+                # typically grab the latest from some bucket.  We
+                # don't know enough about the image at this time to
+                # assume that single-disk encryption is supported.
+                # Maybe later...
+                values.single_disk = False
+            why = "default"
+        else:
+            why = "command-line"
+        # Staggered introduction of single-disk encryption...
+        if values.subparser_name in ['gcp']:
+            log.info("Single-disk encryption: %s (%s)", values.single_disk,
+                     why)
+            brkt_config['single_disk'] = values.single_disk
+        elif values.single_disk:
+            log.info("Single-disk encryption not supported.")
 
     add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -349,7 +349,10 @@ def instance_config_args_to_values(cli_args, mode=INSTANCE_CREATOR_MODE):
         ' images')
     setup_instance_config_args(parser, config, mode)
     argv = cli_args.split()
-    return parser.parse_args(argv)
+    values = parser.parse_args(argv)
+    values.subparser_name = 'unittest'
+    values.crypto = None
+    return values
 
 
 def add_brkt_env_to_brkt_config(brkt_env, brkt_config):

--- a/brkt_cli/test_encryptor_service.py
+++ b/brkt_cli/test_encryptor_service.py
@@ -31,6 +31,9 @@ class DummyEncryptorService(encryptor_service.BaseEncryptorService):
         self.is_up = False
         self.progress = 0
 
+    def fetch(self, name):
+        return None
+
     def is_encryptor_up(self):
         """ The first call returns False.  Subsequent calls return True.
         """

--- a/brkt_cli/util.py
+++ b/brkt_cli/util.py
@@ -31,6 +31,8 @@ MAX_BACKOFF_SECS = 10
 CRYPTO_GCM = 'gcm'
 CRYPTO_XTS = 'xts'
 
+# Size of the metavisor disk (in GBs)
+METAVISOR_DISK_SIZE = 6
 
 log = logging.getLogger(__name__)
 

--- a/test_gce.py
+++ b/test_gce.py
@@ -233,6 +233,24 @@ class DummyGCPService(gcp_service.BaseGCPService):
         return 'fingerprint'
 
 
+class DummyValues():
+    def __init__(self, image=IGNORE_IMAGE):
+        self.bucket = None
+        self.cleanup = True
+        self.crypto = CRYPTO_GCM
+        self.encryptor_image = 'encryptor-image'
+        self.gcp_tags = None
+        self.image = image
+        self.image_file = None
+        self.image_project = None
+        self.keep_encryptor = False
+        self.network = None
+        self.single_disk = False
+        self.status_port = 80
+        self.subnetwork = None
+        self.zone = 'us-central1-a'
+
+
 class TestEncryptedImageName(unittest.TestCase):
 
     def test_get_image_name(self):
@@ -283,11 +301,8 @@ class TestRunEncryption(unittest.TestCase):
         encrypted_image = encrypt_gcp_image.encrypt(
             gcp_svc=gcp_svc,
             enc_svc_cls=DummyEncryptorService,
-            image_id=IGNORE_IMAGE,
-            encryptor_image='encryptor-image',
+            values=DummyValues(),
             encrypted_image_name='ubuntu-encrypted',
-            zone='us-central1-a',
-            crypto_policy=CRYPTO_GCM,
             instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertIsNotNone(encrypted_image)
@@ -299,11 +314,8 @@ class TestRunEncryption(unittest.TestCase):
         encrypt_gcp_image.encrypt(
             gcp_svc=gcp_svc,
             enc_svc_cls=DummyEncryptorService,
-            image_id=IGNORE_IMAGE,
-            encryptor_image='encryptor-image',
+            values=DummyValues(),
             encrypted_image_name='ubuntu-encrypted',
-            zone='us-central1-a',
-            crypto_policy=CRYPTO_GCM,
             instance_config=InstanceConfig({'identity_token': TOKEN})
         )
         self.assertEqual(len(gcp_svc.disks), 0)
@@ -315,10 +327,8 @@ class TestRunEncryption(unittest.TestCase):
              encrypt_gcp_image.encrypt(
                 gcp_svc=gcp_svc,
                 enc_svc_cls=test.FailedEncryptionService,
-                image_id='test-ubuntu',
-                encryptor_image='encryptor-image',
+                values=DummyValues(image='test-ubuntu'),
                 encrypted_image_name='ubuntu-encrypted',
-                zone='us-central1-a',
                 instance_config=InstanceConfig({'identity_token': TOKEN})
             )
         self.assertEqual(len(gcp_svc.disks), 0)
@@ -375,10 +385,8 @@ class TestRunUpdate(unittest.TestCase):
              update_gcp_image.update_gcp_image(
                 gcp_svc=gcp_svc,
                 enc_svc_cls=FailedEncryptionService,
-                image_id=IGNORE_IMAGE,
-                encryptor_image='encryptor-image',
+                values=DummyValues(),
                 encrypted_image_name='ubuntu-encrypted',
-                zone='us-central1-a',
                 instance_config=InstanceConfig({'identity_token': TOKEN})
             )
         self.assertEqual(len(gcp_svc.disks), 0)
@@ -389,10 +397,8 @@ class TestRunUpdate(unittest.TestCase):
         encrypted_image = update_gcp_image.update_gcp_image(
             gcp_svc=gcp_svc,
             enc_svc_cls=DummyEncryptorService,
-            image_id=IGNORE_IMAGE,
-            encryptor_image='encryptor-image',
+            values=DummyValues(),
             encrypted_image_name='centos-encrypted',
-            zone='us-central1-a',
             instance_config=InstanceConfig({'identity_token': TOKEN})
         )
 


### PR DESCRIPTION
Single-disk encryption is a way of encrypting whereby the encrypted image has the same number of disks as the unencrypted/stock image. While currently we assume there's only a root disk, the mechanism extends to images with multiple disks.

The immediate upshot is that bracketized images can be launched from the GCP or Azure console and that we therefore don't need to use the launch command in the CLI. There are less immediate advantages as well on AWS and ESX, which is why single-disk encryption is not specific to any CSP, but rather the new way to encrypt across all platforms.

Globally:
 o  Introduce METAVISOR_DISK_SIZE. It holds the size of the
    metavisor disk.
 o  Add options --single-disk and --no-single-disk
    Provide a reasonable default when neither is specified.
    Add 'single-disk' to the bracket configuration for GCP.
 o  Add encryptor_did_single_disk()

For GCP:
 o  Support encrypting legacy and single-disk on GCP.
 o  Support updating legacy and single-disk on GCP

For AWS and ESX:
 o  Remove single_disk from the bracket configuration. They'll
    support single-disk encryption in a follow-up commit to
    minimize risk.

While here:
 o  Remove redundant handling of crypto_policy_type

Jira: YETI-3635