### PR TITLE
Default crypto policy to XTS

### DIFF
--- a/brkt_cli/aws/encrypt_ami_args.py
+++ b/brkt_cli/aws/encrypt_ami_args.py
@@ -105,5 +105,5 @@ def setup_encrypt_ami_args(parser, parsed_config):
         metavar='NAME',
         choices=[CRYPTO_GCM, CRYPTO_XTS],
         help=argparse.SUPPRESS,
-        default=None
+        default=CRYPTO_XTS
     )

--- a/brkt_cli/esx/esx_args.py
+++ b/brkt_cli/esx/esx_args.py
@@ -422,7 +422,7 @@ def add_crypto_policy(parser, help=argparse.SUPPRESS):
         metavar='NAME',
         choices=[CRYPTO_GCM, CRYPTO_XTS],
         help=help,
-        default=None
+        default=CRYPTO_XTS
     )
 
 

--- a/brkt_cli/gcp/encrypt_gcp_image_args.py
+++ b/brkt_cli/gcp/encrypt_gcp_image_args.py
@@ -66,5 +66,5 @@ def setup_encrypt_gcp_image_args(parser, parsed_config):
         metavar='NAME',
         choices=[CRYPTO_GCM, CRYPTO_XTS],
         help=argparse.SUPPRESS,
-        default=None
+        default=CRYPTO_XTS
     )


### PR DESCRIPTION
While single-disk encryption is enabled for GCP, for the other CSPs
the crypto_policy is being defaulted to GCM instead of XTS resulting
in the guest root volume being 2x the size.