### PR TITLE
Better handling of encryption status for large volumes

### DIFF
--- a/brkt_cli/aws/test_encrypt_ami.py
+++ b/brkt_cli/aws/test_encrypt_ami.py
@@ -77,6 +77,7 @@ class CantContactEncryptionService(encryptor_service.BaseEncryptorService):
         return {
             'state': encryptor_service.ENCRYPT_FAILED,
             'percent_complete': 50,
+            'bytes_written': 1048576,
         }
 
 

--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -124,7 +124,7 @@ class EncryptorService(BaseEncryptorService):
             info['percent_complete'] = 100
         elif bytes_total is not None and bytes_total > 0:
             ratio = float(info['bytes_written']) / info['bytes_total']
-            info['percent_complete'] = int(100 * ratio)
+            info['percent_complete'] = float(100 * ratio)
         return info
 
 
@@ -211,7 +211,8 @@ def wait_for_encryption(enc_svc,
 
         state = status['state']
         percent_complete = status['percent_complete']
-        log.debug('state=%s, percent_complete=%d', state, percent_complete)
+        bytes_written = status['bytes_written']
+        log.debug('state=%s, percent_complete=%.2f', state, percent_complete)
 
         # Make sure that encryption progress hasn't stalled.
         if progress_deadline.is_expired():
@@ -219,8 +220,8 @@ def wait_for_encryption(enc_svc,
                 'Waited for encryption progress for longer than %s seconds' %
                 progress_timeout
             )
-        if percent_complete > last_progress or state != last_state:
-            last_progress = percent_complete
+        if bytes_written > last_progress or state != last_state:
+            last_progress = bytes_written
             last_state = state
             progress_deadline = Deadline(progress_timeout)
 
@@ -234,7 +235,7 @@ def wait_for_encryption(enc_svc,
                 if state == ENCRYPT_DOWNLOADING:
                     state_display = 'Download from cloud storage'
                 log.info(
-                    '%s is %d%% complete', state_display, percent_complete)
+                    '%s is %.2f%% complete', state_display, percent_complete)
             last_log_time = now
 
         if state == ENCRYPT_SUCCESSFUL:

--- a/brkt_cli/test_encryptor_service.py
+++ b/brkt_cli/test_encryptor_service.py
@@ -30,6 +30,7 @@ class DummyEncryptorService(encryptor_service.BaseEncryptorService):
         super(DummyEncryptorService, self).__init__(hostnames, port)
         self.is_up = False
         self.progress = 0
+        self.bytes_written = 0
 
     def fetch(self, name):
         return None
@@ -48,9 +49,11 @@ class DummyEncryptorService(encryptor_service.BaseEncryptorService):
         ret_val = {
             'state': encryptor_service.ENCRYPT_ENCRYPTING,
             'percent_complete': self.progress,
+            'bytes_written': self.bytes_written,
         }
         if self.progress < 100:
             self.progress += 20
+            self.bytes_written += 1048576
         else:
             ret_val['state'] = 'finished'
         return ret_val
@@ -64,6 +67,7 @@ class FailedEncryptionService(encryptor_service.BaseEncryptorService):
         return {
             'state': encryptor_service.ENCRYPT_FAILED,
             'percent_complete': 50,
+            'bytes_written': 1073741824,
         }
 
 
@@ -97,7 +101,8 @@ class TestEncryptionService(unittest.TestCase):
                     'state': encryptor_service.ENCRYPT_FAILED,
                     'failure_code':
                         encryptor_service.FAILURE_CODE_UNSUPPORTED_GUEST,
-                    'percent_complete': 0
+                    'percent_complete': 0,
+                    'bytes_written': 0
                 }
 
         with self.assertRaises(encryptor_service.UnsupportedGuestError):
@@ -114,7 +119,8 @@ class TestEncryptionService(unittest.TestCase):
             def get_status(self):
                 return {
                     'state': encryptor_service.ENCRYPT_ENCRYPTING,
-                    'percent_complete': 0
+                    'percent_complete': 0,
+                    'bytes_written': 0
                 }
 
         with self.assertRaises(encryptor_service.EncryptionError):


### PR DESCRIPTION
With very large root volumes, the encryption progress, which is currently
printed as a integer might take a long time to increment and as a result
the encryption itself might timeout interpreting as a lack of progress.
This change:
 - Prints the encryption progress as a float with 2 significant decimal places
 - Checks the bytes_written for the encryption status instead of the progress percentage