### PR TITLE
Fix traceback error during image update

### DIFF
--- a/brkt_cli/encryptor_service.py
+++ b/brkt_cli/encryptor_service.py
@@ -211,7 +211,8 @@ def wait_for_encryption(enc_svc,
 
         state = status['state']
         percent_complete = status['percent_complete']
-        bytes_written = status['bytes_written']
+        # For image updates, there is no bytes_written
+        bytes_written = status.get('bytes_written', 0)
         log.debug('state=%s, percent_complete=%.2f', state, percent_complete)
 
         # Make sure that encryption progress hasn't stalled.


### PR DESCRIPTION
When doing an image update, there is no 'bytes_written' field returned
in the status. Hence check if the field exists. If not, initialize it
to 0.