### PR TITLE
YETI-3635:  Support single-disk encryption for AWS

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -36,7 +36,10 @@ from brkt_cli.aws import (
     wrap_instance_args
 )
 from brkt_cli.aws.aws_constants import (
-    TAG_ENCRYPTOR, TAG_ENCRYPTOR_SESSION_ID, TAG_ENCRYPTOR_AMI
+    NAME_ENCRYPTED_IMAGE_SUFFIX,
+    TAG_ENCRYPTOR,
+    TAG_ENCRYPTOR_AMI,
+    TAG_ENCRYPTOR_SESSION_ID
 )
 from brkt_cli.aws.update_ami import update_ami
 from brkt_cli.instance_config import (
@@ -49,12 +52,16 @@ from brkt_cli.instance_config_args import (
     setup_instance_config_args
 )
 from brkt_cli.subcommand import Subcommand
-from brkt_cli.util import BracketError
 from brkt_cli.validation import ValidationError
+from brkt_cli.util import (
+    BracketError,
+    append_suffix,
+    make_nonce
+)
 
 log = logging.getLogger(__name__)
 
-
+AMI_NAME_MAX_LENGTH = 128
 ENCRYPTOR_AMIS_AWS_BUCKET = 'solo-brkt-prod-net'
 
 
@@ -148,10 +155,8 @@ def run_wrap_image(values, config):
     nonce = util.make_nonce()
 
     aws_svc = aws_service.AWSService(
-        nonce,
-        retry_timeout=values.retry_timeout,
-        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
-    )
+        nonce, retry_timeout=values.retry_timeout,
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds)
     log.debug(
         'Retry timeout=%.02f, initial sleep seconds=%.02f',
         aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
@@ -161,7 +166,8 @@ def run_wrap_image(values, config):
     # Keywords check
     guest_ami_id = values.ami
     if values.ami == 'ubuntu':
-        guest_ami_id = get_ubuntu_ami_id(values.stock_image_version, values.region)
+        guest_ami_id = get_ubuntu_ami_id(values.stock_image_version,
+                                         values.region)
     elif values.ami == 'centos':
         guest_ami_id = get_centos_ami_id(values.stock_image_version, aws_svc)
 
@@ -174,8 +180,11 @@ def run_wrap_image(values, config):
         if not aws_svc.iam_role_exists(values.iam):
             raise ValidationError('IAM role %s does not exist' % values.iam)
 
-    metavisor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
-                                                    values.metavisor_version)
+    if values.encryptor_ami:
+        metavisor_ami = values.encryptor_ami
+    else:
+        metavisor_ami = _get_encryptor_ami(values.region,
+                                           values.metavisor_version)
     log.debug('Using Metavisor %s', metavisor_ami)
 
     if values.validate:
@@ -240,8 +249,11 @@ def run_wrap_instance(values, config):
                 'No instance with id %s' % values.instance_id)
         raise
 
-    metavisor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
-                                                    values.metavisor_version)
+    if values.encryptor_ami:
+        metavisor_ami = values.encryptor_ami
+    else:
+        metavisor_ami = _get_encryptor_ami(values.region,
+                                           values.metavisor_version)
     log.debug('Using Metavisor %s', metavisor_ami)
 
     if values.validate:
@@ -268,22 +280,28 @@ def run_wrap_instance(values, config):
     return 0
 
 
-# Get the AMI ID if the CLI is passed "ubuntu" instead of an AMI. This function grabs the official, non-AWS Marketplace
-# version of the AMI from an API endpoint
+# Get the AMI ID if the CLI is passed "ubuntu" instead of an AMI.
+# This function grabs the official, non-AWS Marketplace version of
+# the AMI from an API endpoint
 def get_ubuntu_ami_id(stock_image_version, region):
     if not stock_image_version:
         stock_image_version = '16.04'
-    resp = urllib2.urlopen("https://cloud-images.ubuntu.com/locator/ec2/releasesTable")
+    url = "https://cloud-images.ubuntu.com/locator/ec2/releasesTable"
+    resp = urllib2.urlopen(url)
     resp_str = resp.read()
     resp.close()
-    # This API endpoint returns faulty JSON with a trailing comma. This regex removes this trailing comma
+    # This API endpoint returns faulty JSON with a trailing comma.
+    # This regex removes this trailing comma
     resp_str = re.sub(",[ \t\r\n]+}", "}", resp_str)
     resp_str = re.sub(",[ \t\r\n]+\]", "]", resp_str)
     ami_data = json.loads(resp_str)['aaData']
     ubuntu_ami = ''
     for ami in ami_data:
-        if ami[0] == region and ami[2].startswith(stock_image_version) and ami[4] == 'hvm:ebs-ssd':
-            # The API endpoint returns an HTML tag with the AMI ID in it. This regex just gets the AMI ID
+        if ami[0] == region and \
+           ami[2].startswith(stock_image_version) and \
+           ami[4] == 'hvm:ebs-ssd':
+            # The API endpoint returns an HTML tag with the AMI ID in it.
+            # This regex just gets the AMI ID
             match_obj = re.match('^<.+>(ami-.+)</.+>$', ami[6])
             ubuntu_ami = match_obj.group(1)
     if not ubuntu_ami:
@@ -292,8 +310,10 @@ def get_ubuntu_ami_id(stock_image_version, region):
     return ubuntu_ami
 
 
-# Get the AMI ID if the CLI is passed "centos" instead of an AMI. This function grabs the official, AWS Marketplace
-# version of the AMI. You need to have previously subscribed to the AMI in order for this to work
+# Get the AMI ID if the CLI is passed "centos" instead of an AMI.
+# This function grabs the official, AWS Marketplace version of the
+# AMI. You need to have previously subscribed to the AMI in order
+# for this to work
 def get_centos_ami_id(stock_image_version, aws_svc):
     if not stock_image_version:
         stock_image_version = '7'
@@ -317,11 +337,9 @@ def run_encrypt(values, config, verbose=False):
     aws_svc = aws_service.AWSService(
         session_id,
         retry_timeout=values.retry_timeout,
-        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
-    )
-    log.debug(
-        'Retry timeout=%.02f, initial sleep seconds=%.02f',
-        aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds)
+    log.debug('Retry timeout=%.02f, initial sleep seconds=%.02f',
+              aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
     aws_svc.connect(values.region, key_name=values.key_name)
 
@@ -330,73 +348,60 @@ def run_encrypt(values, config, verbose=False):
         _validate_region(aws_svc, values.region)
 
     # Keywords check
-    guest_ami_id = values.ami
     if values.ami == 'ubuntu':
-        guest_ami_id = get_ubuntu_ami_id(values.stock_image_version, values.region)
+        values.ami = get_ubuntu_ami_id(values.stock_image_version,
+                                       values.region)
     elif values.ami == 'centos':
-        guest_ami_id = get_centos_ami_id(values.stock_image_version, aws_svc)
+        values.ami = get_centos_ami_id(values.stock_image_version, aws_svc)
 
     if values.validate:
-        guest_image = _validate_guest_ami(aws_svc, guest_ami_id)
+        guest_image = _validate_guest_ami(aws_svc, values.ami)
     else:
-        guest_image = _validate_ami(aws_svc, guest_ami_id)
-    encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
-                                                    values.metavisor_version)
-    aws_tags = encrypt_ami.get_default_tags(session_id, encryptor_ami)
+        guest_image = _validate_ami(aws_svc, values.ami)
+
+    if not values.encrypted_ami_name:
+        suffix = NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': make_nonce()}
+        values.encrypted_ami_name = \
+            append_suffix(guest_image.name, suffix,
+                          max_length=AMI_NAME_MAX_LENGTH)
+
+    if not values.encryptor_ami:
+        values.encryptor_ami = _get_encryptor_ami(values.region,
+                                                  values.metavisor_version)
+
+    aws_tags = encrypt_ami.get_default_tags(session_id,
+                                            values.encryptor_ami)
     command_line_tags = brkt_cli.parse_tags(values.aws_tags)
     aws_tags.update(command_line_tags)
     aws_svc.default_tags = aws_tags
 
     if values.validate:
-        _validate(
-            aws_svc,
-            encryptor_ami,
-            encrypted_ami_name=values.encrypted_ami_name,
-            key_name=values.key_name,
-            subnet_id=values.subnet_id,
-            security_group_ids=values.security_group_ids
-        )
+        _validate(aws_svc, values.encryptor_ami,
+                  encrypted_ami_name=values.encrypted_ami_name,
+                  key_name=values.key_name, subnet_id=values.subnet_id,
+                  security_group_ids=values.security_group_ids)
         brkt_cli.validate_ntp_servers(values.ntp_servers)
 
-    crypto_policy = values.crypto
     brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
-    instance_config = instance_config_from_values(
-        values,
-        mode=INSTANCE_CREATOR_MODE,
-        brkt_env=brkt_env,
-        launch_token=lt
-    )
+    instance_config = instance_config_from_values(values,
+                                                  mode=INSTANCE_CREATOR_MODE,
+                                                  brkt_env=brkt_env,
+                                                  launch_token=lt)
 
     if verbose:
-        with tempfile.NamedTemporaryFile(
-            prefix='user-data-',
-            delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(prefix='user-data-',
+                                         delete=False) as f:
             log.debug('Writing instance user data to %s', f.name)
             f.write(instance_config.make_userdata())
 
     encrypted_image_id = encrypt_ami.encrypt(
-        aws_svc=aws_svc,
-        enc_svc_cls=encryptor_service.EncryptorService,
-        image_id=guest_image.id,
-        encryptor_ami=encryptor_ami,
-        encrypted_ami_name=values.encrypted_ami_name,
-        crypto_policy=crypto_policy,
-        subnet_id=values.subnet_id,
-        security_group_ids=values.security_group_ids,
-        guest_instance_type=values.guest_instance_type,
-        encryptor_instance_type=values.encryptor_instance_type,
-        instance_config=instance_config,
-        status_port=values.status_port,
-        save_encryptor_logs=values.save_encryptor_logs,
-        terminate_encryptor_on_failure=(
-            values.terminate_encryptor_on_failure),
-        legacy=values.legacy
-    )
+        aws_svc=aws_svc, enc_svc_cls=encryptor_service.EncryptorService,
+        values=values, instance_config=instance_config)
+
     # Print the AMI ID to stdout, in case the caller wants to process
     # the output.  Log messages go to stderr.
-    print(encrypted_image_id)
+    print encrypted_image_id
     return 0
 
 
@@ -407,11 +412,9 @@ def run_update(values, config, verbose=False):
     aws_svc = aws_service.AWSService(
         nonce,
         retry_timeout=values.retry_timeout,
-        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds
-    )
-    log.debug(
-        'Retry timeout=%.02f, initial sleep seconds=%.02f',
-        aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
+        retry_initial_sleep_seconds=values.retry_initial_sleep_seconds)
+    log.debug('Retry timeout=%.02f, initial sleep seconds=%.02f',
+              aws_svc.retry_timeout, aws_svc.retry_initial_sleep_seconds)
 
     if values.validate:
         # Validate the region before connecting.
@@ -419,60 +422,54 @@ def run_update(values, config, verbose=False):
 
     aws_svc.connect(values.region, key_name=values.key_name)
     encrypted_image = _validate_ami(aws_svc, values.ami)
-    encryptor_ami = values.encryptor_ami or _get_encryptor_ami(values.region,
-                                                    values.metavisor_version)
-    aws_tags = encrypt_ami.get_default_tags(nonce, encryptor_ami)
+
+    if not values.encryptor_ami:
+        values.encryptor_ami = _get_encryptor_ami(values.region,
+                                                  values.metavisor_version)
+
+    aws_tags = encrypt_ami.get_default_tags(nonce, values.encryptor_ami)
     command_line_tags = brkt_cli.parse_tags(values.aws_tags)
     aws_tags.update(command_line_tags)
     aws_svc.default_tags = aws_tags
 
     if values.validate:
-        _validate_guest_encrypted_ami(
-            aws_svc, encrypted_image.id, encryptor_ami)
+        _validate_guest_encrypted_ami(aws_svc, values.ami,
+                                      values.encryptor_ami)
+        _validate(aws_svc, values.encryptor_ami,
+                  encrypted_ami_name=values.encrypted_ami_name,
+                  key_name=values.key_name, subnet_id=values.subnet_id,
+                  security_group_ids=values.security_group_ids)
         brkt_cli.validate_ntp_servers(values.ntp_servers)
-        _validate(
-            aws_svc,
-            encryptor_ami,
-            encrypted_ami_name=values.encrypted_ami_name,
-            key_name=values.key_name,
-            subnet_id=values.subnet_id,
-            security_group_ids=values.security_group_ids
-        )
-
-        _validate_guest_encrypted_ami(
-            aws_svc, encrypted_image.id, encryptor_ami)
     else:
         log.info('Skipping AMI validation.')
 
-    mv_image = aws_svc.get_image(encryptor_ami)
+    mv_image = aws_svc.get_image(values.encryptor_ami)
     if (encrypted_image.virtualization_type != mv_image.virtualization_type):
         log.error(
             'Virtualization type mismatch.  %s is %s, but encryptor %s is '
             '%s.',
-            encrypted_image.id,
+            values.ami,
             encrypted_image.virtualization_type,
-            mv_image.id,
+            values.encryptor_ami,
             mv_image.virtualization_type
         )
         return 1
 
-    encrypted_ami_name = values.encrypted_ami_name
-    if encrypted_ami_name:
+    if values.encrypted_ami_name:
         # Check for name collision.
-        if aws_svc.get_images(name=encrypted_ami_name, owner_alias='self'):
-            raise ValidationError(
-                'You already own image named %s' % encrypted_ami_name)
+        if aws_svc.get_images(name=values.encrypted_ami_name,
+                              owner_alias='self'):
+            raise ValidationError('You already own image named %s' %
+                                  values.encrypted_ami_name)
     else:
-        encrypted_ami_name = _get_updated_image_name(
+        values.encrypted_ami_name = _get_updated_image_name(
             encrypted_image.name, nonce)
-        log.debug('Image name: %s', encrypted_ami_name)
-        aws_service.validate_image_name(encrypted_ami_name)
+        log.debug('Image name: %s', values.encrypted_ami_name)
+        aws_service.validate_image_name(values.encrypted_ami_name)
 
     # Initial validation done
-    log.info(
-        'Updating %s with new metavisor %s',
-        encrypted_image.id, encryptor_ami
-    )
+    log.info('Updating %s with new metavisor %s', values.ami,
+             values.encryptor_ami)
 
     brkt_env = brkt_cli.brkt_env_from_values(values, config)
     lt = instance_config_args.get_launch_token(values, config)
@@ -490,15 +487,8 @@ def run_update(values, config, verbose=False):
             log.debug('Writing instance user data to %s', f.name)
             f.write(instance_config.make_userdata())
 
-    updated_ami_id = update_ami(
-        aws_svc, encrypted_image.id, encryptor_ami, encrypted_ami_name,
-        subnet_id=values.subnet_id,
-        security_group_ids=values.security_group_ids,
-        guest_instance_type=values.guest_instance_type,
-        updater_instance_type=values.updater_instance_type,
-        instance_config=instance_config,
-        status_port=values.status_port,
-    )
+    updated_ami_id = update_ami(aws_svc, encryptor_service.EncryptorService,
+                                values, instance_config=instance_config)
     print(updated_ami_id)
     return 0
 
@@ -787,11 +777,10 @@ def _validate(aws_svc, encryptor_ami_id, encrypted_ami_name=None,
     if encrypted_ami_name:
         aws_service.validate_image_name(encrypted_ami_name)
 
-    if instance_type and (
-        instance_type == 't2.nano' or instance_type == 't1.micro'):
-            raise ValidationError(
-                'Unsupported instance type %s' % instance_type
-            )
+    if instance_type and (instance_type == 't2.nano' or
+                          instance_type == 't1.micro'):
+            raise ValidationError('Unsupported instance type %s' %
+                                  instance_type)
 
     try:
         if key_name:

--- a/brkt_cli/aws/aws_service.py
+++ b/brkt_cli/aws/aws_service.py
@@ -24,7 +24,7 @@ from datetime import datetime
 import boto3
 from botocore.exceptions import ClientError
 
-from brkt_cli import util, encryptor_service
+from brkt_cli import util
 from brkt_cli.aws import boto3_device, boto3_tag
 from brkt_cli.aws.aws_constants import (
     NAME_ENCRYPTOR_SECURITY_GROUP,
@@ -208,7 +208,7 @@ class BaseAWSService(object):
 
     @abc.abstractmethod
     def modify_instance_attribute(self, instance_id, attribute,
-        value, dry_run=False):
+                                  value, dry_run=False):
         pass
 
     @abc.abstractmethod
@@ -427,8 +427,8 @@ class AWSService(BaseAWSService):
     def iam_role_exists(self, role):
         try:
             iam = boto3.resource('iam')
-            iamRole = iam.Role(role)
-            iamRole.load()
+            iam_role = iam.Role(role)
+            iam_role.load()
         except ClientError as e:
             code, _ = get_code_and_message(e)
             if code != 'NoSuchEntity':
@@ -859,7 +859,7 @@ def wait_for_image(aws_svc, image_id):
     log.debug('Waiting for %s to become available.', image_id)
     image = None
 
-    for i in range(180):
+    for i in range(240):
         sleep(5)
         image = aws_svc.get_image(image_id)
         log.debug('%s: %s', image.id, image.state)
@@ -872,8 +872,7 @@ def wait_for_image(aws_svc, image_id):
         'Image failed to become available (%s)' % image.state)
 
 
-def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=\
-                                    encryptor_service.ENCRYPTOR_STATUS_PORT):
+def create_encryptor_security_group(aws_svc, vpc_id=None, status_port=80):
     sg_name = NAME_ENCRYPTOR_SECURITY_GROUP % {'nonce': make_nonce()}
     sg_desc = DESCRIPTION_ENCRYPTOR_SECURITY_GROUP
     sg = aws_svc.create_security_group(sg_name, sg_desc, vpc_id=vpc_id)
@@ -999,7 +998,8 @@ def snapshot_log_volume(aws_svc, instance_id):
 
     # Snapshot root volume.
     instance = aws_svc.get_instance(instance_id)
-    device = boto3_device.get_device(instance.block_device_mappings, '/dev/sda1')
+    device = boto3_device.get_device(instance.block_device_mappings,
+                                     '/dev/sda1')
     vol = aws_svc.get_volume(boto3_device.get_volume_id(device))
     image = aws_svc.get_image(instance.image_id)
     snapshot = aws_svc.create_snapshot(

--- a/brkt_cli/aws/encrypt_ami.py
+++ b/brkt_cli/aws/encrypt_ami.py
@@ -44,32 +44,43 @@ from botocore.exceptions import ClientError
 from brkt_cli import encryptor_service, util
 from brkt_cli.aws import aws_service, boto3_device
 from brkt_cli.aws.aws_constants import (
-    NAME_ENCRYPTOR, DESCRIPTION_ENCRYPTOR,
-    NAME_ENCRYPTED_ROOT_SNAPSHOT, NAME_METAVISOR_ROOT_SNAPSHOT,
-    DESCRIPTION_SNAPSHOT, NAME_ENCRYPTED_ROOT_VOLUME,
-    NAME_METAVISOR_ROOT_VOLUME, NAME_ENCRYPTED_IMAGE_SUFFIX,
-    SUFFIX_ENCRYPTED_IMAGE, DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE,
-    TAG_ENCRYPTOR, TAG_ENCRYPTOR_SESSION_ID, TAG_ENCRYPTOR_AMI
+    DEFAULT_DESCRIPTION_ENCRYPTED_IMAGE,
+    DESCRIPTION_ENCRYPTOR,
+    DESCRIPTION_SNAPSHOT,
+    NAME_ENCRYPTED_ROOT_SNAPSHOT,
+    NAME_ENCRYPTED_ROOT_VOLUME,
+    NAME_ENCRYPTOR,
+    NAME_METAVISOR_ROOT_SNAPSHOT,
+    NAME_METAVISOR_ROOT_VOLUME,
+    SUFFIX_ENCRYPTED_IMAGE,
+    TAG_ENCRYPTOR,
+    TAG_ENCRYPTOR_AMI,
+    TAG_ENCRYPTOR_SESSION_ID
 )
 from brkt_cli.aws.aws_service import (
-    wait_for_instance, stop_and_wait,
-    wait_for_image, create_encryptor_security_group, run_guest_instance,
-    clean_up, log_exception_console, snapshot_log_volume,
-    wait_for_volume_attached, wait_for_snapshots,
-    snapshot_root_volume, enable_sriov_net_support)
+    clean_up,
+    create_encryptor_security_group,
+    enable_sriov_net_support,
+    log_exception_console,
+    run_guest_instance,
+    snapshot_log_volume,
+    snapshot_root_volume,
+    stop_and_wait,
+    wait_for_image,
+    wait_for_instance,
+    wait_for_snapshots,
+    wait_for_volume_attached
+)
 from brkt_cli.instance_config import InstanceConfig
-from brkt_cli.user_data import gzip_user_data
 from brkt_cli.util import (
     BracketError,
+    CRYPTO_GCM,
     Deadline,
-    make_nonce,
+    METAVISOR_DISK_SIZE,
     append_suffix,
-    CRYPTO_XTS
 )
 
 log = logging.getLogger(__name__)
-
-AMI_NAME_MAX_LENGTH = 128
 
 
 def get_default_tags(session_id, encryptor_ami):
@@ -79,23 +90,6 @@ def get_default_tags(session_id, encryptor_ami):
         TAG_ENCRYPTOR_AMI: encryptor_ami
     }
     return default_tags
-
-
-def get_encrypted_suffix():
-    """ Return a suffix that will be appended to the encrypted image name.
-    The suffix is in the format "(encrypted 787ace7a)".  The nonce portion of
-    the suffix is necessary because Amazon requires image names to be unique.
-    """
-    return NAME_ENCRYPTED_IMAGE_SUFFIX % {'nonce': make_nonce()}
-
-
-def _get_name_from_image(image):
-    name = append_suffix(
-        image.name,
-        get_encrypted_suffix(),
-        max_length=AMI_NAME_MAX_LENGTH
-    )
-    return name
 
 
 def _get_description_from_image(image):
@@ -110,11 +104,9 @@ def _get_description_from_image(image):
     return description
 
 
-def _run_encryptor_instance(
-        aws_svc, encryptor_image_id, snapshot, root_size, guest_image_id,
-        crypto_policy, security_group_ids=None, subnet_id=None,
-        instance_type='c4.xlarge', placement=None, instance_config=None,
-        status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
+def _run_encryptor_instance(aws_svc, values, snapshot, root_size,
+                            placement=None, instance_config=None,
+                            vol_type='gp2'):
 
     if instance_config is None:
         instance_config = InstanceConfig()
@@ -124,29 +116,24 @@ def _run_encryptor_instance(
     # the user to attach to an existing 'sd' name in use, but
     # would allow conflicts if we used 'xvd' names here.
 
-    # Use gp2 for fast burst I/O copying root drive
     guest_unencrypted_root = boto3_device.make_device(
-        device_name='/dev/sdf',
-        volume_type='gp2',
-        snapshot_id=snapshot,
-        delete_on_termination=True
-    )
+        device_name='/dev/sdf', volume_type=vol_type,
+        snapshot_id=snapshot, delete_on_termination=True)
 
-    # Use gp2 for fast burst I/O copying root drive
     log.info('Launching encryptor instance with snapshot %s', snapshot)
-    # They are creating an encrypted AMI instead of updating it
-    # Use gp2 for fast burst I/O copying root drive
 
-    guest_encrypted_root_size = 2 * root_size + 1
-    if crypto_policy == CRYPTO_XTS:
-        guest_encrypted_root_size = root_size + 1
+    guest_encrypted_root_size = root_size
+    if values.crypto == CRYPTO_GCM:
+        guest_encrypted_root_size *= 2
+    if values.single_disk:
+        guest_encrypted_root_size += METAVISOR_DISK_SIZE
+    else:
+        guest_encrypted_root_size += 1
 
     guest_encrypted_root = boto3_device.make_device(
-        device_name='/dev/sdg',
-        volume_type='gp2',
+        device_name='/dev/sdg', volume_type=vol_type,
         volume_size=guest_encrypted_root_size,
-        delete_on_termination=True
-    )
+        delete_on_termination=True)
 
     # If security groups were not specified, create a temporary security
     # group that allows us to poll the metavisor for encryption progress.
@@ -156,14 +143,14 @@ def _run_encryptor_instance(
     try:
         run_instance = aws_svc.run_instance
 
-        if not security_group_ids:
+        if not values.security_group_ids:
             vpc_id = None
-            if subnet_id:
-                subnet = aws_svc.get_subnet(subnet_id)
+            if values.subnet_id:
+                subnet = aws_svc.get_subnet(values.subnet_id)
                 vpc_id = subnet.vpc_id
             temp_sg_id = create_encryptor_security_group(
-                aws_svc, vpc_id=vpc_id, status_port=status_port).id
-            security_group_ids = [temp_sg_id]
+                aws_svc, vpc_id=vpc_id, status_port=values.status_port).id
+            values.security_group_ids = [temp_sg_id]
 
             # Wrap with a retry, to handle eventual consistency issues with
             # the newly-created group.
@@ -172,21 +159,18 @@ def _run_encryptor_instance(
                 error_code_regexp='InvalidGroup\.NotFound'
             )
 
-        user_data = instance_config.make_userdata()
-        compressed_user_data = gzip_user_data(user_data)
-
         bdm = [guest_unencrypted_root, guest_encrypted_root]
         log.info('Launching encryptor instance.')
         instance = run_instance(
-            encryptor_image_id,
-            security_group_ids=security_group_ids,
-            user_data=compressed_user_data,
+            values.encryptor_ami,
+            security_group_ids=values.security_group_ids,
+            user_data=instance_config.make_userdata(),
             placement=placement,
             block_device_mappings=bdm,
-            subnet_id=subnet_id,
-            instance_type=instance_type,
+            subnet_id=values.subnet_id,
+            instance_type=values.encryptor_instance_type,
             name=NAME_ENCRYPTOR,
-            description=DESCRIPTION_ENCRYPTOR % {'image_id': guest_image_id}
+            description=DESCRIPTION_ENCRYPTOR % {'image_id': values.ami}
         )
         instance = wait_for_instance(aws_svc, instance.id)
 
@@ -196,12 +180,11 @@ def _run_encryptor_instance(
         encrypted_root_device = boto3_device.get_device(
             instance.block_device_mappings, '/dev/sdg')
         aws_svc.create_tags(
-            boto3_device.get_volume_id(
-                mv_root_device), name=NAME_METAVISOR_ROOT_VOLUME)
+            boto3_device.get_volume_id(mv_root_device),
+            name=NAME_METAVISOR_ROOT_VOLUME)
         aws_svc.create_tags(
             boto3_device.get_volume_id(encrypted_root_device),
-            name=NAME_ENCRYPTED_ROOT_VOLUME
-        )
+            name=NAME_ENCRYPTED_ROOT_VOLUME)
     except:
         cleanup_instance_ids = []
         cleanup_sg_ids = []
@@ -228,12 +211,9 @@ def _terminate_instance(aws_svc, id, name, terminated_instance_ids):
         log.warn('Could not terminate %s instance: %s', name, e)
 
 
-def _snapshot_encrypted_instance(
-        aws_svc, enc_svc_cls, encryptor_instance,
-        image_id=None, vol_type=None, iops=None,
-        legacy=False, save_encryptor_logs=True,
-        status_port=encryptor_service.ENCRYPTOR_STATUS_PORT,
-        encryption_start_timeout=600):
+def _snapshot_encrypted_instance(aws_svc, enc_svc_cls, values,
+                                 encryptor_instance, vol_type='gp2',
+                                 iops=None, encryption_start_timeout=600):
     # First wait for encryption to complete
     host_ips = []
     if encryptor_instance.public_ip_address:
@@ -248,7 +228,7 @@ def _snapshot_encrypted_instance(
         else:
             os.environ['NO_PROXY'] = encryptor_instance.private_ip_address
 
-    enc_svc = enc_svc_cls(host_ips, port=status_port)
+    enc_svc = enc_svc_cls(host_ips, port=values.status_port)
 
     try:
         log.info('Waiting for encryption service on %s (port %s on %s)',
@@ -262,7 +242,7 @@ def _snapshot_encrypted_instance(
         stop_and_wait(aws_svc, encryptor_instance.id)
 
         log_exception_console(aws_svc, e, encryptor_instance.id)
-        if save_encryptor_logs:
+        if values.save_encryptor_logs:
             log.info('Saving logs from encryptor instance in snapshot')
             log_snapshot = snapshot_log_volume(aws_svc, encryptor_instance.id)
             log.info('Encryptor logs saved in snapshot %(snapshot_id)s. '
@@ -284,54 +264,51 @@ def _snapshot_encrypted_instance(
     aws_svc.stop_instance(encryptor_instance.id)
     wait_for_instance(aws_svc, encryptor_instance.id, state='stopped')
 
-    description = DESCRIPTION_SNAPSHOT % {'image_id': image_id}
-
     # Set up new Block Device Mappings
     log.debug('Creating block device mapping')
-    if not vol_type:
-        vol_type = 'gp2'
 
-    # Snapshot volumes.
+    # The once empty disk is the one and only disk
     encrypted_dev = boto3_device.get_device(
         encryptor_instance.block_device_mappings, '/dev/sdg')
-    snap_guest = aws_svc.create_snapshot(
-        encrypted_dev['Ebs']['VolumeId'],
-        name=NAME_ENCRYPTED_ROOT_SNAPSHOT,
-        description=description
-    )
-    log.info(
-        'Creating snapshots for the new encrypted AMI: %s' % (
-                snap_guest.id)
-    )
-    wait_for_snapshots(aws_svc, snap_guest.id)
-    dev_guest_root = boto3_device.make_device(
-        device_name='/dev/sdf',
-        volume_type=vol_type,
-        snapshot_id=snap_guest.id,
-        iops=iops,
-        delete_on_termination=True
-    )
-    new_bdm = [dev_guest_root]
-    mv_root_dev = boto3_device.get_device(
-        encryptor_instance.block_device_mappings, '/dev/sda1')
-    mv_root_id = boto3_device.get_volume_id(mv_root_dev)
 
-    if not legacy:
+    if values.single_disk:
+        log.info('Detaching new encrypted root from Encryptor.')
+        new_root_id = boto3_device.get_volume_id(encrypted_dev)
+        aws_svc.detach_volume(new_root_id,
+                              instance_id=encryptor_instance.id,
+                              force=True)
+        aws_service.wait_for_volume(aws_svc, new_root_id)
+        aws_svc.create_tags(new_root_id, name=NAME_ENCRYPTED_ROOT_VOLUME)
+        new_bdm = list()
+    else:
+        log.info('Creating snapshot of the encrypted guest disk.')
+        encrypted_snap = aws_svc.create_snapshot(
+            encrypted_dev['Ebs']['VolumeId'],
+            name=NAME_ENCRYPTED_ROOT_SNAPSHOT,
+            description=DESCRIPTION_SNAPSHOT % {'image_id': values.ami})
+        wait_for_snapshots(aws_svc, encrypted_snap.id)
+        encrypted_dev = boto3_device.make_device(device_name='/dev/sdf',
+                                                 volume_type=vol_type,
+                                                 snapshot_id=encrypted_snap.id,
+                                                 iops=iops,
+                                                 delete_on_termination=True)
+        new_bdm = [encrypted_dev]
         log.info('Detaching Metavisor root from Encryptor.')
-        aws_svc.detach_volume(
-            mv_root_id,
-            instance_id=encryptor_instance.id,
-            force=True
-        )
+        mv_root_dev = boto3_device.get_device(
+            encryptor_instance.block_device_mappings, '/dev/sda1')
+        mv_root_id = boto3_device.get_volume_id(mv_root_dev)
+        aws_svc.detach_volume(mv_root_id,
+                              instance_id=encryptor_instance.id,
+                              force=True)
         aws_service.wait_for_volume(aws_svc, mv_root_id)
-        aws_svc.create_tags(
-            mv_root_id, name=NAME_METAVISOR_ROOT_VOLUME)
+        aws_svc.create_tags(mv_root_id, name=NAME_METAVISOR_ROOT_VOLUME)
+        new_root_id = mv_root_id
 
-    if image_id:
-        log.debug('Getting image %s', image_id)
-        guest_image = aws_svc.get_image(image_id)
+    if values.ami:
+        log.debug('Getting image %s', values.ami)
+        guest_image = aws_svc.get_image(values.ami)
         if guest_image is None:
-            raise BracketError("Can't find image %s" % image_id)
+            raise BracketError("Can't find image %s" % values.ami)
 
         # Propagate any ephemeral drive mappings to the soloized image
         guest_device_names = boto3_device.get_device_names(
@@ -345,83 +322,45 @@ def _snapshot_encrypted_instance(
                          vn, guest_dev_name)
                 new_bdm.append(guest_dev)
 
-    return mv_root_id, new_bdm
+    return new_root_id, new_bdm
 
 
 def _register_ami(aws_svc, encryptor_instance, name,
-                  description, mv_bdm=None, legacy=False, guest_instance=None,
-                  mv_root_id=None):
+                  description, mv_bdm=None, guest_instance=None,
+                  mv_root_id=None, vol_type='gp2'):
     # mv_bdm contains the encrypted guest volume.
     if not mv_bdm:
         mv_bdm = list()
+
     # Register the new AMI.
+    guest_id = guest_instance.id
+    root_device_name = guest_instance.root_device_name
 
-    if legacy:
-        # The encryptor instance may modify its volume attachments while
-        # running, so we update the encryptor instance's local attributes
-        # before reading them.
-        encryptor_instance = aws_svc.get_instance(encryptor_instance.id)
-        guest_id = encryptor_instance.id
-        # Explicitly detach/delete all but root drive
-        for device_name in ['/dev/sda2', '/dev/sda3', '/dev/sda4',
-                  '/dev/sda5', '/dev/sdf', '/dev/sdg']:
-            dev = boto3_device.get_device(
-                encryptor_instance.block_device_mappings, device_name)
-            if not dev:
-                continue
-            volume_id = boto3_device.get_volume_id(dev)
-            aws_svc.detach_volume(
-                volume_id,
-                instance_id=encryptor_instance.id,
-                force=True
-            )
-            aws_service.wait_for_volume(aws_svc, volume_id)
-            aws_svc.delete_volume(volume_id)
-    else:
-        guest_id = guest_instance.id
-        root_device_name = guest_instance.root_device_name
+    log.info('Attaching new Metavisor root.')
 
-        log.info('Attaching new Metavisor root.')
+    # Explicitly attach new mv root to guest instance
+    aws_svc.attach_volume(mv_root_id, guest_instance.id, root_device_name)
 
-        # Explicitly attach new mv root to guest instance
-        aws_svc.attach_volume(
-            mv_root_id,
-            guest_instance.id,
-            root_device_name,
-        )
-
-        guest_instance = wait_for_volume_attached(
-            aws_svc, guest_instance.id, root_device_name)
-        root_dev = boto3_device.get_device(
-            guest_instance.block_device_mappings, root_device_name)
-        root_dev_copy = boto3_device.make_device_for_image(root_dev)
-        root_dev_copy['Ebs']['DeleteOnTermination'] = True
-        mv_bdm.append(root_dev_copy)
+    guest_instance = wait_for_volume_attached(
+        aws_svc, guest_instance.id, root_device_name)
+    root_dev = boto3_device.get_device(
+        guest_instance.block_device_mappings, root_device_name)
+    root_dev_copy = boto3_device.make_device_for_image(root_dev)
+    root_dev_copy['Ebs']['VolumeType'] = vol_type
+    root_dev_copy['Ebs']['DeleteOnTermination'] = True
+    mv_bdm.append(root_dev_copy)
 
     guest_instance = aws_svc.get_instance(guest_id)
 
-    # Legacy:
-    #   Create AMI from (stopped) MV instance
-    # Non-legacy:
-    #   Create AMI from original (stopped) guest instance. This
-    #   preserves any billing information found in
-    #   the identity document (i.e. billingProduct)
+    # Create AMI from original (stopped) guest instance. This
+    # preserves any billing information found in
+    # the identity document (i.e. billingProduct)
     image = aws_svc.create_image(
         guest_id,
         name,
         description=description,
         no_reboot=True,
-        block_device_mappings=mv_bdm
-    )
-
-    if not legacy:
-        aws_svc.detach_volume(
-            mv_root_id,
-            instance_id=guest_instance.id,
-            force=True
-        )
-        aws_service.wait_for_volume(aws_svc, mv_root_id)
-        aws_svc.delete_volume(mv_root_id)
+        block_device_mappings=mv_bdm)
 
     log.info('Registered %s based on the snapshots.', image.id)
     image = wait_for_image(aws_svc, image.id)
@@ -441,23 +380,11 @@ def _print_bdm(context, resource):
     print context, util.pretty_print_json(resource.block_device_mappings)
 
 
-def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
-            encrypted_ami_name=None, subnet_id=None, security_group_ids=None,
-            guest_instance_type='m4.large', encryptor_instance_type='c4.xlarge',
-            instance_config=None, save_encryptor_logs=True,
-            status_port=encryptor_service.ENCRYPTOR_STATUS_PORT,
-            terminate_encryptor_on_failure=True, legacy=False,
+def encrypt(aws_svc, enc_svc_cls, values, instance_config=None,
             encryption_start_timeout=600):
-    log.info(
-        'Starting session %s to encrypt %s',
-        aws_svc.session_id,
-        image_id
-    )
-    if legacy:
-        log.warn(
-            'Using legacy encryption mode.  This mode will be removed in '
-            'the next release.'
-        )
+
+    log.info('Starting session %s to encrypt %s', aws_svc.session_id,
+             values.ami)
 
     encryptor_instance = None
     snapshot_id = None
@@ -465,114 +392,66 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
     temp_sg_id = None
 
     # Verify that the guest and encryptor images exist.
-    aws_svc.get_image(image_id)
-    aws_svc.get_image(encryptor_ami)
+    aws_svc.get_image(values.ami)
+    aws_svc.get_image(values.encryptor_ami)
     encrypted_image = None
 
-
-    """
-    # TODO: Remove this code once we get rid of legacy mode.
-
-    root_device_name = guest_image.root_device_name
-    root_dev = boto3_device.get_device(
-        guest_image.block_device_mappings, root_device_name)
-
-    if not root_dev:
-            log.warn("AMI must have root_device_name in block_device_mapping "
-                    "in order to preserve guest OS license information")
-            legacy = True
-    if guest_image.root_device_name != "/dev/sda1":
-        log.warn("Guest Operating System license information will not be "
-                 "preserved because the root disk is attached at %s "
-                 "instead of /dev/sda1", guest_image.root_device_name)
-        legacy = True
-    """
+    vol_type = 'gp2'
 
     log.info('Snapshotting the guest root disk.')
 
     try:
-        guest_instance = run_guest_instance(
-            aws_svc,
-            image_id,
-            subnet_id=subnet_id,
-            instance_type=guest_instance_type
-        )
-
+        guest_instance = run_guest_instance(aws_svc, values.ami,
+                                            values.subnet_id,
+                                            values.guest_instance_type)
         wait_for_instance(aws_svc, guest_instance.id)
-        snapshot_id, root_dev, size, vol_type, iops = snapshot_root_volume(
-            aws_svc, guest_instance, image_id
-        )
+
+        snapshot_id, root_dev, size, snap_type, iops = \
+            snapshot_root_volume(aws_svc, guest_instance, values.ami)
 
         guest_instance = aws_svc.get_instance(guest_instance.id)
-        encryptor_instance, temp_sg_id = _run_encryptor_instance(
-            aws_svc=aws_svc,
-            encryptor_image_id=encryptor_ami,
-            snapshot=snapshot_id,
-            root_size=size,
-            guest_image_id=image_id,
-            crypto_policy=crypto_policy,
-            security_group_ids=security_group_ids,
-            subnet_id=subnet_id,
-            instance_type=encryptor_instance_type,
-            placement=guest_instance.placement,
-            instance_config=instance_config,
-            status_port=status_port
-        )
+        encryptor_instance, temp_sg_id = \
+            _run_encryptor_instance(aws_svc=aws_svc, values=values,
+                                    snapshot=snapshot_id, root_size=size,
+                                    placement=guest_instance.placement,
+                                    instance_config=instance_config,
+                                    vol_type=vol_type)
 
         # Enable ENA if Metavisor supports it.
         encryptor_ena_support = aws_service.has_ena_support(encryptor_instance)
         guest_ena_support = aws_service.has_ena_support(guest_instance)
-        log.debug(
-            'ENA support: encryptor=%s, guest=%s',
-            encryptor_ena_support,
-            guest_ena_support
-        )
+        log.debug('ENA support: encryptor=%s, guest=%s', encryptor_ena_support,
+                  guest_ena_support)
         if encryptor_ena_support and not guest_ena_support:
-            aws_svc.modify_instance_attribute(
-                guest_instance.id,
-                'enaSupport',
-                'True'
-            )
+            aws_svc.modify_instance_attribute(guest_instance.id, 'enaSupport',
+                                              'True')
 
-        log.debug('Getting image %s', image_id)
-        image = aws_svc.get_image(image_id)
+        log.debug('Getting image %s', values.ami)
+        image = aws_svc.get_image(values.ami)
         if image is None:
-            raise BracketError("Can't find image %s" % image_id)
-        if encrypted_ami_name:
-            name = encrypted_ami_name
-        else:
-            name = _get_name_from_image(image)
+            raise BracketError("Can't find image %s" % values.ami)
         description = _get_description_from_image(image)
 
         mv_root_id, mv_bdm = _snapshot_encrypted_instance(
             aws_svc,
             enc_svc_cls,
+            values,
             encryptor_instance,
-            image_id=image_id,
             vol_type=vol_type,
             iops=iops,
-            legacy=legacy,
-            save_encryptor_logs=save_encryptor_logs,
-            status_port=status_port,
-            encryption_start_timeout=encryption_start_timeout
-        )
+            encryption_start_timeout=encryption_start_timeout)
 
         guest_instance = aws_svc.get_instance(guest_instance.id)
 
         enable_sriov_net_support(aws_svc, guest_instance)
 
-        encrypted_image = _register_ami(
-            aws_svc,
-            encryptor_instance,
-            name,
-            description,
-            legacy=legacy,
-            guest_instance=guest_instance,
-            mv_root_id=mv_root_id,
-            mv_bdm=mv_bdm
-        )
-        log.info('Created encrypted AMI %s based on %s',
-                 encrypted_image.id, image_id)
+        encrypted_image = _register_ami(aws_svc, encryptor_instance,
+                                        values.encrypted_ami_name, description,
+                                        guest_instance=guest_instance,
+                                        mv_root_id=mv_root_id, mv_bdm=mv_bdm,
+                                        vol_type=vol_type)
+        log.info('Created encrypted AMI %s based on %s', encrypted_image.id,
+                 values.ami)
         return encrypted_image.id
     finally:
         instance_ids = []
@@ -581,7 +460,7 @@ def encrypt(aws_svc, enc_svc_cls, image_id, encryptor_ami, crypto_policy,
 
         terminate_encryptor = (
             encryptor_instance and
-            (encrypted_image or terminate_encryptor_on_failure)
+            (encrypted_image or values.terminate_encryptor_on_failure)
         )
 
         if terminate_encryptor:

--- a/brkt_cli/aws/update_ami.py
+++ b/brkt_cli/aws/update_ami.py
@@ -25,18 +25,25 @@ import json
 import logging
 import os
 
-from brkt_cli import encryptor_service
 from brkt_cli.aws import boto3_device, aws_service
 from brkt_cli.aws.aws_constants import (
-    NAME_GUEST_CREATOR, DESCRIPTION_GUEST_CREATOR, NAME_METAVISOR_UPDATER,
+    DESCRIPTION_GUEST_CREATOR,
     DESCRIPTION_METAVISOR_UPDATER,
-    NAME_METAVISOR_ROOT_SNAPSHOT, NAME_ENCRYPTED_ROOT_SNAPSHOT)
+    NAME_ENCRYPTED_ROOT_SNAPSHOT,
+    NAME_GUEST_CREATOR,
+    NAME_METAVISOR_ROOT_SNAPSHOT,
+    NAME_METAVISOR_UPDATER)
 from brkt_cli.aws.aws_service import (
-    wait_for_instance, wait_for_image, create_encryptor_security_group,
     clean_up,
-    wait_for_volume_attached,
-    stop_and_wait, log_exception_console)
+    create_encryptor_security_group,
+    log_exception_console,
+    snapshot_root_volume,
+    stop_and_wait,
+    wait_for_image,
+    wait_for_instance,
+    wait_for_volume_attached)
 from brkt_cli.encryptor_service import (
+    encryptor_did_single_disk,
     wait_for_encryptor_up,
     wait_for_encryption
 )
@@ -44,7 +51,6 @@ from brkt_cli.instance_config import (
     InstanceConfig,
     INSTANCE_UPDATER_MODE,
 )
-from brkt_cli.user_data import gzip_user_data
 from brkt_cli.util import Deadline
 
 log = logging.getLogger(__name__)
@@ -53,87 +59,93 @@ MV_ROOT_DEVICE_NAME = '/dev/sda1'
 GUEST_ROOT_DEVICE_NAME = '/dev/sdf'
 
 
-def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
-               subnet_id=None, security_group_ids=None,
-               enc_svc_class=encryptor_service.EncryptorService,
-               guest_instance_type='m4.large',
-               updater_instance_type='m4.large',
-               instance_config=None,
-               status_port=encryptor_service.ENCRYPTOR_STATUS_PORT):
+def update_ami(aws_svc, enc_svc_class, values, instance_config=None):
     encrypted_guest = None
     updater = None
     new_mv_vol_id = None
     temp_sg_id = None
+    snap_id = None
+
     if instance_config is None:
         instance_config = InstanceConfig(mode=INSTANCE_UPDATER_MODE)
 
     try:
-        guest_image = aws_svc.get_image(encrypted_ami)
+        instance_config.brkt_config['status_port'] = values.status_port
+
+        log.info("Starting update of %s with %s", values.ami,
+                 values.encryptor_ami)
 
         # Step 1. Launch encrypted guest AMI
         # Use 'updater' mode to avoid chain loading the guest
         # automatically. We just want this AMI/instance up as the
         # base to create a new AMI and preserve license
         # information embedded in the guest AMI
-        log.info("Launching encrypted guest/updater")
 
-        instance_config.brkt_config['status_port'] = status_port
-
+        description = DESCRIPTION_GUEST_CREATOR % {'image_id': values.ami}
         encrypted_guest = aws_svc.run_instance(
-            encrypted_ami,
-            instance_type=guest_instance_type,
+            values.ami,
+            instance_type=values.guest_instance_type,
             ebs_optimized=False,
-            subnet_id=subnet_id,
+            subnet_id=values.subnet_id,
             user_data=json.dumps(instance_config.brkt_config),
             name=NAME_GUEST_CREATOR,
-            description=DESCRIPTION_GUEST_CREATOR % {'image_id': encrypted_ami}
-        )
-        # Run updater in same zone as guest so we can swap volumes
+            description=description)
+        encrypted_guest = wait_for_instance(aws_svc, encrypted_guest.id)
+        mv_root_device_name = encrypted_guest.root_device_name
 
-        user_data = instance_config.make_userdata()
-        compressed_user_data = gzip_user_data(user_data)
+        log.info("Launched encrypted guest %s", encrypted_guest.id)
+
+        # Step 2. Create a disk device of the root file system of the
+        # encrypted guest's root disk by making a snapshot of the
+        # root disk of the instance just launched. This disk will have
+        # the metavisor on it.  Use gp2 for fast burst I/O.
+
+        snap = snapshot_root_volume(aws_svc, encrypted_guest, values.ami)
+        snap_id, snap_dev, snap_size, snap_type, snap_iops = snap
+
+        log.info("Created snapshot %s of encrypted guest root", snap_id)
+
+        # Step 3. Run updater in same zone as guest so we can swap
+        # volumes.  Attach the snapshot as an additional disk.
+
+        guest_encrypted_root = boto3_device.make_device(
+            device_name='/dev/sdf',
+            volume_type='gp2',
+            snapshot_id=snap_id,
+            delete_on_termination=True)
 
         # If the user didn't specify a security group, create a temporary
         # security group that allows brkt-cli to get status from the updater.
         run_instance = aws_svc.run_instance
-        if not security_group_ids:
+        if not values.security_group_ids:
             vpc_id = None
-            if subnet_id:
-                subnet = aws_svc.get_subnet(subnet_id)
+            if values.subnet_id:
+                subnet = aws_svc.get_subnet(values.subnet_id)
                 vpc_id = subnet.vpc_id
             temp_sg_id = create_encryptor_security_group(
-                aws_svc, vpc_id=vpc_id, status_port=status_port).id
-            security_group_ids = [temp_sg_id]
+                aws_svc, vpc_id=vpc_id, status_port=values.status_port).id
+            values.security_group_ids = [temp_sg_id]
 
             # Wrap with a retry, to handle eventual consistency issues with
             # the newly-created group.
             run_instance = aws_svc.retry(
                 aws_svc.run_instance,
-                error_code_regexp='InvalidGroup\.NotFound'
-            )
+                error_code_regexp='InvalidGroup\.NotFound')
 
         updater = run_instance(
-            updater_ami,
-            instance_type=updater_instance_type,
-            user_data=compressed_user_data,
+            values.encryptor_ami,
+            instance_type=values.updater_instance_type,
+            user_data=instance_config.make_userdata(),
             ebs_optimized=False,
-            subnet_id=subnet_id,
+            subnet_id=values.subnet_id,
             placement=encrypted_guest.placement,
-            security_group_ids=security_group_ids,
+            security_group_ids=values.security_group_ids,
+            block_device_mappings=[guest_encrypted_root],
             name=NAME_METAVISOR_UPDATER,
-            description=DESCRIPTION_METAVISOR_UPDATER
-        )
+            description=DESCRIPTION_METAVISOR_UPDATER)
+        updater = wait_for_instance(aws_svc, updater.id)
 
-        log.info(
-            "Launched guest %s, updater %s", encrypted_guest.id, updater.id)
-        encrypted_guest = wait_for_instance(
-            aws_svc, encrypted_guest.id, state="running")
-        updater = wait_for_instance(aws_svc, updater.id, state="running")
-
-        encrypted_guest_mv_root_device_name = encrypted_guest.root_device_name
-        aws_svc.stop_instance(encrypted_guest.id)
-        encrypted_guest = wait_for_instance(
-            aws_svc, encrypted_guest.id, state="stopped")
+        log.info("Launched updater %s with snapshot %s", updater.id, snap_id)
 
         # Enable ENA if Metavisor supports it.
         updater_ena_support = aws_service.has_ena_support(updater)
@@ -156,16 +168,15 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
         if updater.private_ip_address:
             host_ips.append(updater.private_ip_address)
             log.info('Adding %s to NO_PROXY environment variable' %
-                 updater.private_ip_address)
+                     updater.private_ip_address)
             if os.environ.get('NO_PROXY'):
                 os.environ['NO_PROXY'] += "," + \
                     updater.private_ip_address
             else:
                 os.environ['NO_PROXY'] = updater.private_ip_address
 
-        # Step 2. Wait for the encryption service to start up, so that we know
-        # that Metavisor is done initializing.
-        enc_svc = enc_svc_class(host_ips, port=status_port)
+        # Step 4. Wait for the updater to complete.
+        enc_svc = enc_svc_class(host_ips, port=values.status_port)
         log.info('Waiting for updater service on %s (port %s on %s)',
                  updater.id, enc_svc.port, ', '.join(host_ips))
         try:
@@ -173,7 +184,6 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
         except:
             log.error('Unable to connect to encryptor instance.')
             raise
-
         try:
             wait_for_encryption(enc_svc)
         except Exception as e:
@@ -182,6 +192,8 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
             log_exception_console(aws_svc, e, updater.id)
             raise
 
+        single_disk = encryptor_did_single_disk(enc_svc)
+
         aws_svc.stop_instance(updater.id)
         updater = wait_for_instance(aws_svc, updater.id, state="stopped")
 
@@ -189,112 +201,102 @@ def update_ami(aws_svc, encrypted_ami, updater_ami, encrypted_ami_name,
         updater_bdm = updater.block_device_mappings
         new_bdm = list()
 
-        # Step 3. Create block device mappings for the new image.  Preserve
+        # Step 5. Create block device mappings for the new image.  Preserve
         # volume properties that may get reset to their defaults while
         # updating block device mappings.
         for d in guest_bdm:
-            name = d['DeviceName']
-            vol_id = d['Ebs']['VolumeId']
-            vol = aws_svc.get_volume(vol_id)
             new_dev = boto3_device.make_device_for_image(d)
-
-            # Preserve volume type (YETI-942).
-            log.debug(
-                'Preserving volume type %s for disk %s',
-                vol.volume_type,
-                name
-            )
-            new_dev['Ebs']['VolumeType'] = vol.volume_type
-
-            # Preserve IOPS for guest root volume (YETI-1334).
-            if d == GUEST_ROOT_DEVICE_NAME and vol.volume_type == 'io1':
-                log.debug(
-                    'Preserving IOPS setting %s for %s',
-                    vol.iops,
-                    d
-                )
-                new_dev['Ebs']['Iops'] = vol.iops
-
-            if name == encrypted_guest_mv_root_device_name:
+            name = d['DeviceName']
+            # Preserve volume type
+            if name == snap_dev:
+                vol_type = snap_type
+                vol_iops = snap_iops
+            else:
+                vol = aws_svc.get_volume(d['Ebs']['VolumeId'])
+                vol_type = vol.volume_type
+                vol_iops = vol.iops
+            new_dev['Ebs']['VolumeType'] = vol_type
+            # io1 volumes must have the Iops attribute set
+            if vol_type == 'io1':
+                new_dev['Ebs']['Iops'] = vol_iops
+            if name == mv_root_device_name:
                 new_dev['Ebs']['DeleteOnTermination'] = True
-                new_dev['Ebs']['VolumeType'] = 'gp2'
-
             new_bdm.append(new_dev)
 
-        # Step 4. Detach old BSD drive(s) and delete from encrypted guest
-        old_mv_dev = boto3_device.get_device(
-            guest_bdm, encrypted_guest_mv_root_device_name)
-        old_mv_vol_id = old_mv_dev['Ebs']['VolumeId']
+        if single_disk:
+            # Step 6. Detach the Metavisor root from the updater instance.
+            log.info('Detaching boot volume from %s', updater.id)
+            new_mv_dev = boto3_device.get_device(updater_bdm,
+                                                 GUEST_ROOT_DEVICE_NAME)
+            new_mv_vol_id = new_mv_dev['Ebs']['VolumeId']
+            aws_svc.detach_volume(new_mv_vol_id, instance_id=updater.id,
+                                  force=True)
 
-        log.info(
-            'Detaching old metavisor disk %s from %s',
-            old_mv_vol_id,
-            encrypted_guest.id
-        )
-        aws_svc.detach_volume(
-            old_mv_vol_id,
-            instance_id=encrypted_guest.id,
-            force=True
-        )
-        aws_svc.delete_volume(old_mv_vol_id)
+            # Step 7. Attach new boot disk to guest instance.
+            log.info('Attaching new metavisor boot disk %s to %s',
+                     new_mv_vol_id, encrypted_guest.id)
+            aws_svc.attach_volume(new_mv_vol_id, encrypted_guest.id,
+                                  mv_root_device_name)
+            encrypted_guest = wait_for_volume_attached(aws_svc,
+                                                       encrypted_guest.id,
+                                                       mv_root_device_name)
 
-        # Step 5. Detach the Metavisor root from the updater instance.
-        log.info('Detaching boot volume from %s', updater.id)
-        new_mv_dev = boto3_device.get_device(updater_bdm, MV_ROOT_DEVICE_NAME)
-        new_mv_vol_id = new_mv_dev['Ebs']['VolumeId']
-        aws_svc.detach_volume(
-            new_mv_vol_id,
-            instance_id=updater.id,
-            force=True
-        )
+            # Step 8. Create new AMI.
+            log.info("Creating new AMI")
+            guest_image = aws_svc.get_image(values.ami)
+            image = aws_svc.create_image(encrypted_guest.id,
+                                         values.encrypted_ami_name,
+                                         description=guest_image.description,
+                                         no_reboot=True,
+                                         block_device_mappings=new_bdm)
+            image = wait_for_image(aws_svc, image.id)
+        else:
+            # Step 6. Detach the Metavisor root from the updater instance.
+            log.info('Detaching boot volume from %s', updater.id)
+            new_mv_dev = boto3_device.get_device(updater_bdm,
+                                                 MV_ROOT_DEVICE_NAME)
+            new_mv_vol_id = new_mv_dev['Ebs']['VolumeId']
+            aws_svc.detach_volume(new_mv_vol_id, instance_id=updater.id,
+                                  force=True)
 
-        # Step 6. Attach new boot disk to guest instance.
-        log.info(
-            'Attaching new metavisor boot disk %s to %s',
-            new_mv_vol_id,
-            encrypted_guest.id
-        )
-        aws_svc.attach_volume(
-            new_mv_vol_id,
-            encrypted_guest.id,
-            encrypted_guest_mv_root_device_name
-        )
-        encrypted_guest = wait_for_volume_attached(
-            aws_svc, encrypted_guest.id, encrypted_guest_mv_root_device_name)
+            # Step 7. Attach new boot disk to guest instance.
+            log.info('Attaching new metavisor boot disk %s to %s',
+                     new_mv_vol_id, encrypted_guest.id)
+            aws_svc.attach_volume(new_mv_vol_id, encrypted_guest.id,
+                                  mv_root_device_name)
+            encrypted_guest = wait_for_volume_attached(aws_svc,
+                                                       encrypted_guest.id,
+                                                       mv_root_device_name)
 
-        # Step 7. Create new AMI.
-        log.info("Creating new AMI")
-        image = aws_svc.create_image(
-            encrypted_guest.id,
-            encrypted_ami_name,
-            description=guest_image.description,
-            no_reboot=True,
-            block_device_mappings=new_bdm
-        )
-        image = wait_for_image(aws_svc, image.id)
+            # Step 8. Create new AMI.
+            log.info("Creating new AMI")
+            guest_image = aws_svc.get_image(values.ami)
+            image = aws_svc.create_image(encrypted_guest.id,
+                                         values.encrypted_ami_name,
+                                         description=guest_image.description,
+                                         no_reboot=True,
+                                         block_device_mappings=new_bdm)
+            image = wait_for_image(aws_svc, image.id)
 
-        # Step 8. Tag the snapshots and image that we just created.
-        mv_root_dev = boto3_device.get_device(
-            image.block_device_mappings,
-            encrypted_guest_mv_root_device_name
-        )
-        guest_dev = boto3_device.get_device(
-            image.block_device_mappings,
-            GUEST_ROOT_DEVICE_NAME
-        )
-        aws_svc.create_tags(
-            mv_root_dev['Ebs']['SnapshotId'],
-            name=NAME_METAVISOR_ROOT_SNAPSHOT,
-        )
+            # Step 9. Tag the snapshots and image that we just created.
+            guest_dev = boto3_device.get_device(image.block_device_mappings,
+                                                GUEST_ROOT_DEVICE_NAME)
+            aws_svc.create_tags(guest_dev['Ebs']['SnapshotId'],
+                                name=NAME_ENCRYPTED_ROOT_SNAPSHOT)
 
-        aws_svc.create_tags(
-            guest_dev['Ebs']['SnapshotId'],
-            name=NAME_ENCRYPTED_ROOT_SNAPSHOT,
-        )
+        # Step 9. Tag the snapshots and image that we just created.
+        mv_root_dev = boto3_device.get_device(image.block_device_mappings,
+                                              mv_root_device_name)
+        if mv_root_dev:
+            aws_svc.create_tags(mv_root_dev['Ebs']['SnapshotId'],
+                                name=NAME_METAVISOR_ROOT_SNAPSHOT)
         aws_svc.create_tags(image.id)
-
         return image.id
+
     finally:
+        if snap_id:
+            aws_svc.delete_snapshot(snap_id)
+
         instance_ids = set()
         volume_ids = set()
         sg_ids = set()

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -211,13 +211,8 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
             why = "default"
         else:
             why = "command-line"
-        # Staggered introduction of single-disk encryption...
-        if values.subparser_name in ['gcp', 'vmware']:
-            log.info("Single-disk encryption: %s (%s)", values.single_disk,
-                     why)
-            brkt_config['single_disk'] = values.single_disk
-        elif values.single_disk:
-            log.info("Single-disk encryption not supported.")
+        log.info("Single-disk encryption: %s (%s)", values.single_disk, why)
+        brkt_config['single_disk'] = values.single_disk
 
     add_brkt_env_to_brkt_config(brkt_env, brkt_config)
 
@@ -236,7 +231,7 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
     if proxy_config:
         ic.add_brkt_file('proxy.yaml', proxy_config)
 
-    if 'ca_cert' in values and values.ca_cert:
+    if hasattr(values, 'ca_cert') and values.ca_cert:
         if not brkt_env:
             raise ValidationError(
                 'Must specify --service-domain or --brkt-env when specifying '
@@ -248,7 +243,7 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
         ca_cert_filename = 'ca_cert.pem.' + domain
         ic.add_brkt_file(ca_cert_filename, ca_cert_data)
 
-    if 'guest_fqdn' in values and values.guest_fqdn:
+    if hasattr(values, 'guest_fqdn') and values.guest_fqdn:
         ic.add_brkt_file('vpn.yaml', 'fqdn: ' + values.guest_fqdn)
 
     return ic


### PR DESCRIPTION
See also 6c2b513

Additionally: don't compress the AWS user data. We don't
base64 encode it, resulting in AWS console errors. The
user data isn't so large that it needs compressing.

Jira: YETI-3635