### PR TITLE
Change single-disk default

### DIFF
--- a/brkt_cli/aws/__init__.py
+++ b/brkt_cli/aws/__init__.py
@@ -365,6 +365,9 @@ def run_encrypt(values, config, verbose=False):
             append_suffix(guest_image.name, suffix,
                           max_length=AMI_NAME_MAX_LENGTH)
 
+    if values.single_disk is None:
+        values.single_disk = True if values.encryptor_ami else False
+
     if not values.encryptor_ami:
         values.encryptor_ami = _get_encryptor_ami(values.region,
                                                   values.metavisor_version)

--- a/brkt_cli/instance_config_args.py
+++ b/brkt_cli/instance_config_args.py
@@ -186,32 +186,9 @@ def instance_config_from_values(values=None, mode=INSTANCE_CREATOR_MODE,
         brkt_config['crypto_policy_type'] = values.crypto
 
         if values.single_disk is None:
-            # Neither single-disk flag has been given. Let's pick a
-            # reasonable default. This is a little ugly, but it's
-            # temporary.
-            encryptor = ((values.subparser_name == 'gcp' and
-                          values.encryptor_image) or
-                         (values.subparser_name == 'aws' and
-                          values.encryptor_ami) or
-                         (values.subparser_name == 'vmware' and
-                          values.image_name))
-            if encryptor:
-                # If an encryptor image has been specified, then we
-                # assume that this is an unreleased image, which
-                # supports single-disk encryption. In a sense, we're
-                # defaulting on behalf of forward progress.
-                values.single_disk = True
-            else:
-                # If no encryptor image has been specified, then we
-                # typically grab the latest from some bucket.  We
-                # don't know enough about the image at this time to
-                # assume that single-disk encryption is supported.
-                # Maybe later...
-                values.single_disk = False
-            why = "default"
-        else:
-            why = "command-line"
-        log.info("Single-disk encryption: %s (%s)", values.single_disk, why)
+            values.single_disk = True
+
+        log.info("Single-disk encryption: %s", values.single_disk)
         brkt_config['single_disk'] = values.single_disk
 
     add_brkt_env_to_brkt_config(brkt_env, brkt_config)


### PR DESCRIPTION
On AWS and when no encryptor AMI has been given, default to
no single-disk. This was always intended but ended up not
being the case (due to restruturing some code).

For all other CSPs, always default to single-disk from now
on.